### PR TITLE
Visual editing mode (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- **Visual editing mode (experimental)**: LaTeX renders as formatted text —
+  styled headings, bold/italic, real list bullets, KaTeX math, chips for
+  figures/tables/cites — while the source stays the single source of truth.
+  **Byte-stable by construction**: rendering never rewrites source you didn't
+  deliberately edit (proven by an e2e test). Cursor-reveal shows raw source
+  for the construct under any caret, including remote collaborators'.
+  Toggle via the Source|Visual control after enabling "experimental Visual
+  editor" in the command palette. Mod-B/Mod-I formatting works in both modes.
 - `ALDINE_TEXLIVE_SCHEME=full` build option: compiler image with **all of
   CTAN** preinstalled (scheme-full, ~9 GB on disk) instead of the curated medium set.
   Missing-package compile errors now name the package and point at the option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,24 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Added
-- **Visual editing mode (experimental)**: LaTeX renders as formatted text —
-  styled headings, bold/italic, real list bullets, KaTeX math, chips for
-  figures/tables/cites — while the source stays the single source of truth.
-  **Byte-stable by construction**: rendering never rewrites source you didn't
-  deliberately edit (proven by an e2e test). Cursor-reveal shows raw source
-  for the construct under any caret, including remote collaborators'.
-  Toggle via the Source|Visual control after enabling "experimental Visual
-  editor" in the command palette. Mod-B/Mod-I formatting works in both modes.
+- **Visual editing mode (experimental)** — LaTeX renders as formatted text
+  while the source stays the single source of truth. **Byte-stable by
+  construction**: rendering never rewrites source you didn't deliberately edit
+  (proven by an e2e test) — unlike Overleaf's visual editor. Includes:
+  - Styled headings, bold/italic/underline, real itemize/enumerate lists.
+  - **KaTeX math with click-to-edit** in a MathLive WYSIWYG popover; edits
+    write back precise source.
+  - **Editable tables** — `tabular` renders as a grid you edit in place
+    (cell edit, add row/column).
+  - **Inline tracked changes** — review suggestions show as strikethrough +
+    proposed text with accept/dismiss.
+  - **Paste rich text → LaTeX** — HTML from Word/Docs/web converts on paste.
+  - Figure chips render the image; cite chips show author-year from the `.bib`;
+    a Contents dropdown lists and jumps to headings.
+  - Cursor-reveal shows raw source for the construct under any caret — including
+    a remote collaborator's, so it stays collab-correct.
+  Enable via "experimental Visual editor" in the command palette (⌘K), then the
+  Source|Visual toggle. Off by default. Mod-B/Mod-I work in both modes.
 - `ALDINE_TEXLIVE_SCHEME=full` build option: compiler image with **all of
   CTAN** preinstalled (scheme-full, ~9 GB on disk) instead of the curated medium set.
   Missing-package compile errors now name the package and point at the option.
@@ -23,6 +33,20 @@ All notable changes to Aldine are documented here. The format follows
 - Relicensed from MIT to AGPL-3.0 (pre-launch, sole-author): self-hosting is
   unaffected; hosted derivatives must share their modifications. Plugins are
   separate works and may use any license.
+
+### Fixed
+- Documents no longer duplicate when a collaborator reconnects after a server
+  restart/deploy (Yjs docs now reload from a binary snapshot, preserving
+  operation identity, instead of reseeding from text).
+- Creating or renaming a file onto an existing name no longer destroys it.
+- DOI/arXiv citation import escapes `&` and other specials so the imported
+  `.bib` always compiles.
+- A stale biblatex `.aux` no longer breaks later compiles after the package set
+  changes (the compiler cleans aux and rebuilds).
+- Review-comment anchors track their text after edits above them, across reload.
+- Deleting the typeset root re-points it at another `.tex`.
+- Modals are proper dialogs (focus trap, Escape); editor is usable on small
+  screens; assorted validation, error-state, and a11y fixes.
 
 ## [0.1.0] — 2026-07-19
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ That's it. Projects live in the `aldine-data` volume.
 | Warm recompile | ~2s (persistent latexmk cache) | Comparable | Fastest (local) |
 | Templates gallery | 4 built-in | Huge community gallery — **they win** | CTAN / your own |
 | Package coverage | Curated set, or **all of CTAN** (`ALDINE_TEXLIVE_SCHEME=full`) | All of TeX Live | Whatever you install |
-| Rich-text / visual editing | ❌ — **they win** | ✅ | ❌ |
+| Rich-text / visual editing | ✅ experimental, byte-stable (never rewrites your source) | ✅ (rewrites source) | ❌ |
 | Maturity | Young (v0.x, 2026) — **they win** | A decade in production | Very mature |
 | License | AGPL-3.0 | AGPL | MIT/varies |
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,15 @@ Live collaboration, a recompile, and a SyncTeX jump — one real recording (comp
   autocomplete.
 
 <details>
-<summary><strong>Everything else</strong> — review mode, AI error fix, SyncTeX, plugins, auth, scaling…</summary>
+<summary><strong>Everything else</strong> — visual editor, review mode, AI error fix, SyncTeX, plugins, auth, scaling…</summary>
 
+- **Visual editing mode** (experimental) — LaTeX renders as formatted text
+  while the source stays authoritative and **byte-stable** (it never rewrites
+  source you didn't deliberately edit). WYSIWYG math (click an equation to edit
+  it in a MathLive popover), editable tables, inline tracked changes from review
+  suggestions, paste-rich-text-to-LaTeX, image-previewing figure chips, and an
+  outline. Cursor-reveal shows raw source under the caret — including a remote
+  collaborator's. Enable it in the command palette (⌘K), off by default.
 - **Review mode** — select text and leave an anchored, threaded comment;
   optionally attach a suggested replacement the author accepts with one click.
   Comments highlight in the editor, resolve/reopen, and track edits.
@@ -118,7 +125,7 @@ That's it. Projects live in the `aldine-data` volume.
 | Warm recompile | ~2s (persistent latexmk cache) | Comparable | Fastest (local) |
 | Templates gallery | 4 built-in | Huge community gallery — **they win** | CTAN / your own |
 | Package coverage | Curated set, or **all of CTAN** (`ALDINE_TEXLIVE_SCHEME=full`) | All of TeX Live | Whatever you install |
-| Rich-text / visual editing | ✅ experimental, byte-stable (never rewrites your source) | ✅ (rewrites source) | ❌ |
+| Rich-text / visual editing | ✅ experimental — byte-stable, WYSIWYG math, editable tables, tracked changes | ✅ (rewrites your source) | ❌ |
 | Maturity | Young (v0.x, 2026) — **they win** | A decade in production | Very mature |
 | License | AGPL-3.0 | AGPL | MIT/varies |
 

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -148,7 +148,10 @@ async function compileInner(body) {
   ];
   const base = path.basename(rootFile).replace(/\.tex$/, '');
   const rel = (f) => path.join(rootDir, OUT_SUBDIR, f); // path relative to the project dir
-  const pdfPath = path.join(absDir, rootDir, OUT_SUBDIR, `${base}.pdf`);
+  const outAbs = path.join(absDir, rootDir, OUT_SUBDIR);
+  const pdfPath = path.join(outAbs, `${base}.pdf`);
+  const logPath = path.join(outAbs, `${base}.log`);
+  const readLog = (fallback) => { try { return fs.readFileSync(logPath, 'utf8'); } catch { return fallback; } };
 
   // First pass without -g: latexmk skips work that is already up to date, so an
   // unchanged document "recompiles" in ~a second instead of a full rebuild.
@@ -160,10 +163,18 @@ async function compileInner(body) {
     // output dir / stale state) — force a real rebuild.
     ({ code, out, timedOut } = await run('latexmk', mkArgs(true), runOpts, TIMEOUT_MS));
   }
+  // Stale-aux recovery: if the package set changed (e.g. dropping biblatex),
+  // leftover .aux/.bcf artifacts make an otherwise-valid document fail with an
+  // undefined-control-sequence in the .aux (\abx@aux@…, \bibcite, …). Wipe the
+  // regenerable aux files once and rebuild — the .aux is not source of truth.
+  if (code !== 0 && !timedOut && /(\\abx@aux@|\\bibcite|\\@writefile|undefined)/i.test(readLog(out)) && /\.(aux|bcf)\b/i.test(readLog(out))) {
+    for (const ext of ['aux', 'bcf', 'bbl', 'blg', 'run.xml', 'toc', 'out', 'fls', 'fdb_latexmk']) {
+      try { fs.rmSync(path.join(outAbs, `${base}.${ext}`), { force: true }); } catch { /* best effort */ }
+    }
+    ({ code, out, timedOut } = await run('latexmk', mkArgs(true), runOpts, TIMEOUT_MS));
+  }
   const durationMs = Date.now() - t0;
-  const logPath = path.join(absDir, rootDir, OUT_SUBDIR, `${base}.log`);
-  let log = '';
-  try { log = fs.readFileSync(logPath, 'utf8'); } catch { log = out; }
+  let log = readLog(out);
   const errors = parseLog(log);
   const ok = code === 0 && fs.existsSync(pdfPath);
   return {

--- a/apps/server/src/collab.ts
+++ b/apps/server/src/collab.ts
@@ -5,6 +5,7 @@ import { Server as HocuspocusServer } from '@hocuspocus/server';
 import type { Hocuspocus } from '@hocuspocus/server';
 import * as Y from 'yjs';
 import { branchDir, readMeta } from './store.js';
+import { config } from './config.js';
 import { commitAll, ensureWorktree } from './gitops.js';
 import { safeJoin, debouncePerKey } from './util.js';
 import { AUTH_ENABLED, userFromRequest } from './auth.js';
@@ -36,6 +37,30 @@ export function parseDocName(name: string): { projectId: string; branch: string;
 }
 
 const TEXT_KEY = 'content';
+
+/**
+ * Yjs binary snapshots (one per doc), stored OUTSIDE the git worktree so they
+ * never reach git or the compiler. Reloading a doc from its snapshot preserves
+ * CRDT operation identity; reseeding from plain text instead would mint fresh
+ * operations that a reconnecting client's copy MERGES — duplicating the whole
+ * document on every server restart/deploy. The .tex file on disk stays the
+ * source of truth for git/compile; the snapshot only carries collab identity.
+ */
+const YJS_DIR = path.join(config.metaRoot, 'yjs');
+const snapPath = (name: string) => path.join(YJS_DIR, crypto.createHash('sha1').update(name).digest('hex') + '.ybin');
+
+function writeSnapshot(name: string, document: Y.Doc): void {
+  try {
+    fs.mkdirSync(YJS_DIR, { recursive: true });
+    fs.writeFileSync(snapPath(name), Buffer.from(Y.encodeStateAsUpdate(document)));
+  } catch (err) { console.error('[collab] snapshot write failed', (err as Error).message); }
+}
+function readSnapshot(name: string): Uint8Array | null {
+  try { return fs.readFileSync(snapPath(name)); } catch { return null; }
+}
+function deleteSnapshot(name: string): void {
+  try { fs.rmSync(snapPath(name), { force: true }); } catch { /* best effort */ }
+}
 
 /** Debounced auto-commit per project::branch after edits settle. */
 const scheduleAutoCommit = debouncePerKey(20_000, (key: string) => {
@@ -78,7 +103,11 @@ export function writeDocToDisk(name: string, document: Y.Doc): void {
   if (!fs.existsSync(dir)) return; // branch was deleted while doc loaded
   const abs = safeJoin(dir, filePath);
   const text = document.getText(TEXT_KEY).toString();
-  // Skip the write when the content is identical to what's on disk (keeps
+  // Keep the collab snapshot in step with the live doc on every store (small,
+  // and independent of the .tex-write skip below so reconnect identity is
+  // always current even when the rendered text didn't change).
+  writeSnapshot(name, document);
+  // Skip the .tex write when the content is identical to what's on disk (keeps
   // latexmk incremental builds effective) — compared in memory, no disk read.
   const hash = sha1(text);
   if (lastWritten.get(name) === hash) return;
@@ -153,11 +182,31 @@ export const hocuspocus: Hocuspocus = HocuspocusServer.configure({
     if (text.length > 0) return document; // already has state (e.g. synced from a peer node)
     let content = '';
     try { content = fs.readFileSync(safeJoin(branchDir(projectId, branch), filePath), 'utf8'); } catch { /* new file → empty */ }
-    if (content.length > 0) text.insert(0, content);
-    // Seed lastWritten from what's actually on disk right now, so (a) the first
-    // store of an unchanged doc skips (no mtime churn) and (b) a doc reopened
-    // after an out-of-band disk change tracks the NEW disk state, not a stale
-    // hash from a previous load — otherwise a later store could wrongly skip.
+
+    // Prefer the Yjs snapshot (preserves operation identity → reconnect-safe).
+    // Fall back to a plain-text seed only when there's no snapshot or the file
+    // changed out-of-band on disk (git pull/merge/revert), where disk wins.
+    const snap = readSnapshot(documentName);
+    let loaded = false;
+    if (snap) {
+      try {
+        Y.applyUpdate(document, snap);
+        loaded = true;
+        if (text.toString() !== content) {
+          document.transact(() => { text.delete(0, text.length); if (content.length) text.insert(0, content); });
+          writeSnapshot(documentName, document);
+        }
+      } catch {
+        try { document.transact(() => text.delete(0, text.length)); } catch { /* start clean */ }
+        loaded = false;
+      }
+    }
+    if (!loaded) {
+      if (content.length > 0) text.insert(0, content);
+      writeSnapshot(documentName, document); // establish a snapshot for future reconnects
+    }
+    // Track lastWritten against disk so the first store of an unchanged doc
+    // skips the .tex rewrite (no latexmk churn).
     lastWritten.set(documentName, sha1(content));
     return document;
   },
@@ -191,6 +240,7 @@ export function evictDoc(projectId: string, branch: string, filePath: string): v
   const name = docName(projectId, branch, filePath);
   tombstone(name);
   lastWritten.delete(name);
+  deleteSnapshot(name); // file deleted/renamed → drop its collab snapshot so a re-create starts clean
   const doc = hocuspocus.documents.get(name) as (Y.Doc & { destroy?: () => void }) | undefined;
   if (doc) {
     hocuspocus.documents.delete(name);
@@ -238,5 +288,6 @@ export function refreshBranchDocsFromDisk(projectId: string, branch: string): vo
       text.delete(0, text.length);
       text.insert(0, content!);
     });
+    writeSnapshot(name, doc); // the doc's ops changed → keep the reconnect snapshot current
   });
 }

--- a/apps/server/src/references.ts
+++ b/apps/server/src/references.ts
@@ -10,6 +10,34 @@ const DOI_BASE = process.env.DOI_API_BASE || 'https://doi.org';
 const ARXIV_BASE = process.env.ARXIV_API_BASE || 'https://export.arxiv.org';
 const OPENALEX_BASE = process.env.OPENALEX_API_BASE || 'https://api.openalex.org';
 
+/** Decode the HTML entities upstream metadata (CrossRef, arXiv, OpenAlex) ships. */
+function unescapeHtml(s: string): string {
+  return s
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#0*39;|&apos;/g, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)));
+}
+
+/** Escape LaTeX specials that would break a compile, skipping already-escaped ones. */
+function latexEscape(s: string): string {
+  return s.replace(/(\\?)([&%$#_])/g, (_, bs, ch) => (bs ? bs + ch : `\\${ch}`));
+}
+
+/** A field value built from upstream metadata: HTML-decode, then LaTeX-escape. */
+function bibField(s: string): string {
+  return latexEscape(unescapeHtml(s));
+}
+
+/**
+ * Sanitize a raw BibTeX blob (e.g. CrossRef via doi.org): decode HTML entities
+ * and escape bare & / % inside brace-delimited values so the entry compiles.
+ * A bare `&` is read by LaTeX as an alignment tab — the classic broken-.bib bug.
+ */
+function sanitizeBibtex(bib: string): string {
+  return unescapeHtml(bib).replace(/(\\?)([&%])/g, (_, bs, ch) => (bs ? bs + ch : `\\${ch}`));
+}
+
 export interface SearchHit { id: string; doi: string | null; title: string; authors: string; year: number | null; venue: string }
 
 /** Full-text search across OpenAlex (250M+ works, no key). */
@@ -52,9 +80,9 @@ async function fetchOpenAlex(id: string): Promise<string | null> {
   const first = authorships[0]?.author?.display_name?.split(' ').pop()?.toLowerCase().replace(/[^a-z]/g, '') || 'anon';
   const venue = (w.primary_location as { source?: { display_name?: string } } | undefined)?.source?.display_name || '';
   return `@article{${first}${year},
-  title   = {${title}},
-  author  = {${authorField}},
-  year    = {${year}},${venue ? `\n  journaltitle = {${venue}},` : ''}
+  title   = {${bibField(title)}},
+  author  = {${bibField(authorField)}},
+  year    = {${year}},${venue ? `\n  journaltitle = {${bibField(venue)}},` : ''}
   url     = {${w.id}},
 }`;
 }
@@ -103,7 +131,7 @@ async function fetchDoi(doi: string): Promise<string | null> {
   });
   if (!res.ok) throw new Error(`DOI lookup failed (HTTP ${res.status})`);
   const bib = (await readCapped(res)).trim();
-  return bib.startsWith('@') ? bib : null;
+  return bib.startsWith('@') ? sanitizeBibtex(bib) : null;
 }
 
 async function fetchArxiv(id: string): Promise<string | null> {
@@ -127,8 +155,8 @@ async function fetchArxiv(id: string): Promise<string | null> {
   const first = authors[0]?.split(' ').pop()?.toLowerCase().replace(/[^a-z]/g, '') || 'anon';
   const key = `${first}${year}`;
   return `@article{${key},
-  title        = {${title}},
-  author       = {${authorField}},
+  title        = {${bibField(title)}},
+  author       = {${bibField(authorField)}},
   year         = {${year}},
   eprint       = {${id}},
   archivePrefix = {arXiv},

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -333,10 +333,14 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ---------- files ----------
-  app.get<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/files', async (req) => {
+  app.get<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/files', async (req, reply) => {
     const branch = req.query.branch || 'main';
-    await gitops.ensureWorktree(req.params.id, branch);
-    return store.listFiles(req.params.id, branch);
+    try {
+      await gitops.ensureWorktree(req.params.id, branch);
+      return store.listFiles(req.params.id, branch);
+    } catch {
+      return reply.code(404).send({ error: 'Project or branch not found' });
+    }
   });
 
   app.get<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/file', async (req, reply) => {
@@ -366,13 +370,17 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     '/api/projects/:id/file', async (req, reply) => {
       const { branch = 'main', path: rel, content = '', encoding = 'utf8', createOnly = false } = req.body || {};
       if (!rel) return reply.code(400).send({ error: 'path required' });
-      if (isHiddenPath(rel)) return reply.code(403).send({ error: 'forbidden path' });
+      if (isHiddenPath(rel) || rel.includes('..')) return reply.code(403).send({ error: 'Invalid file path' });
       await gitops.ensureWorktree(req.params.id, branch);
       // createOnly (new-file flow): never clobber an existing file with empty content
       if (createOnly && store.fileExists(req.params.id, branch, rel)) {
         return reply.code(409).send({ error: 'A file with that name already exists' });
       }
-      store.writeFile(req.params.id, branch, rel, encoding === 'base64' ? Buffer.from(content, 'base64') : content);
+      try {
+        store.writeFile(req.params.id, branch, rel, encoding === 'base64' ? Buffer.from(content, 'base64') : content);
+      } catch {
+        return reply.code(400).send({ error: 'Could not write that file path' });
+      }
       refreshBranchDocsFromDisk(req.params.id, branch);
       scheduleCommit(req.params.id, branch); // non-collab write → still reach git history
       return { ok: true };
@@ -383,6 +391,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       const { branch = 'main', from, to } = req.body || {};
       if (!from || !to) return reply.code(400).send({ error: 'from/to required' });
       if (isHiddenPath(from) || isHiddenPath(to)) return reply.code(403).send({ error: 'forbidden path' });
+      if (from === to) return { ok: true };
+      // never overwrite an existing file — that would destroy both it and the source
+      if (store.fileExists(req.params.id, branch, to)) {
+        return reply.code(409).send({ error: `A file named "${to}" already exists` });
+      }
       // evict the source doc first so its final store can't recreate the old file
       evictDoc(req.params.id, branch, from);
       store.renameFile(req.params.id, branch, from, to);

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -34,6 +34,19 @@ function reqUser(req: any): auth.PublicUser | null {
   return req._user ?? null;
 }
 
+/** Validate an email/password body before it reaches auth (avoids leaking
+ *  internal TypeErrors on malformed requests, and caps lengths). Returns an
+ *  error message, or null when the shape is acceptable. */
+function badCredentials(body: { email?: unknown; password?: unknown } | undefined): string | null {
+  const email = body?.email, password = body?.password;
+  if (typeof email !== 'string' || typeof password !== 'string' || !email || !password) {
+    return 'Email and password are required';
+  }
+  if (email.length > 254) return 'Email is too long';
+  if (password.length > 1024) return 'Password is too long';
+  return null;
+}
+
 function oauthProviders(): Array<{ id: string; label: string }> {
   return oauth.configuredProviders().map((p) => ({ id: p.id, label: p.label }));
 }
@@ -87,6 +100,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     if (!auth.AUTH_ENABLED) return reply.code(400).send({ error: 'Auth is not enabled' });
     if (auth.SSO_ONLY) return passwordDisabled(reply);
     if (!(await registerLimiter.take(clientKey(req)))) return reply.code(429).send({ error: 'Too many accounts created — try again later' });
+    const bad = badCredentials(req.body);
+    if (bad) return reply.code(400).send({ error: bad });
     try {
       const user = await auth.register(req.body.email, req.body.password, req.body.name);
       reply.header('set-cookie', auth.sessionCookie(await auth.createSession(user.id)));
@@ -98,6 +113,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     if (!auth.AUTH_ENABLED) return reply.code(400).send({ error: 'Auth is not enabled' });
     if (auth.SSO_ONLY) return passwordDisabled(reply);
     if (!(await loginLimiter.take(clientKey(req)))) return reply.code(429).send({ error: 'Too many attempts — wait a moment and try again' });
+    if (badCredentials(req.body)) return reply.code(400).send({ error: 'Email and password are required' });
     try {
       const user = await auth.login(req.body.email, req.body.password);
       reply.header('set-cookie', auth.sessionCookie(await auth.createSession(user.id)));
@@ -346,12 +362,16 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     }
   });
 
-  app.put<{ Params: { id: string }; Body: { branch?: string; path: string; content?: string; encoding?: 'utf8' | 'base64' } }>(
+  app.put<{ Params: { id: string }; Body: { branch?: string; path: string; content?: string; encoding?: 'utf8' | 'base64'; createOnly?: boolean } }>(
     '/api/projects/:id/file', async (req, reply) => {
-      const { branch = 'main', path: rel, content = '', encoding = 'utf8' } = req.body || {};
+      const { branch = 'main', path: rel, content = '', encoding = 'utf8', createOnly = false } = req.body || {};
       if (!rel) return reply.code(400).send({ error: 'path required' });
       if (isHiddenPath(rel)) return reply.code(403).send({ error: 'forbidden path' });
       await gitops.ensureWorktree(req.params.id, branch);
+      // createOnly (new-file flow): never clobber an existing file with empty content
+      if (createOnly && store.fileExists(req.params.id, branch, rel)) {
+        return reply.code(409).send({ error: 'A file with that name already exists' });
+      }
       store.writeFile(req.params.id, branch, rel, encoding === 'base64' ? Buffer.from(content, 'base64') : content);
       refreshBranchDocsFromDisk(req.params.id, branch);
       scheduleCommit(req.params.id, branch); // non-collab write → still reach git history
@@ -474,17 +494,29 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     '/api/projects/:id/branches', async (req, reply) => {
       const { name, from = 'main' } = req.body || {};
       if (!name) return reply.code(400).send({ error: 'name required' });
+      if (!BRANCH_RE.test(name) || name.includes('..') || /^(refs|heads|remotes)\//.test(name) || /^-/.test(name)) {
+        return reply.code(400).send({ error: 'Invalid branch name' });
+      }
       // capture latest edits so the new branch starts from what the user sees
       flushBranchDocs(req.params.id, from);
       await gitops.commitAll(req.params.id, from, 'aldine: checkpoint before branching').catch(() => {});
-      await gitops.createBranch(req.params.id, name, from);
+      try {
+        await gitops.createBranch(req.params.id, name, from);
+      } catch (err) {
+        return reply.code(409).send({ error: `Could not create branch: ${(err as Error).message}` });
+      }
       return { ok: true };
     });
 
   app.delete<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/branches', async (req, reply) => {
     const { name } = req.query;
     if (!name) return reply.code(400).send({ error: 'name required' });
-    await gitops.deleteBranch(req.params.id, name);
+    if (name === 'main') return reply.code(400).send({ error: 'Cannot delete the main branch' });
+    try {
+      await gitops.deleteBranch(req.params.id, name);
+    } catch (err) {
+      return reply.code(409).send({ error: `Could not delete branch: ${(err as Error).message}` });
+    }
     return { ok: true };
   });
 

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -314,10 +314,15 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.patch<{ Params: { id: string }; Body: Partial<Pick<store.ProjectMeta, 'name' | 'rootFile' | 'engine'>> }>(
-    '/api/projects/:id', async (req) => {
+    '/api/projects/:id', async (req, reply) => {
       const meta = await store.readMeta(req.params.id);
       const { name, rootFile, engine } = req.body || {};
-      if (name) meta.name = name;
+      if (name !== undefined) {
+        const trimmed = String(name).trim();
+        if (!trimmed) return reply.code(400).send({ error: 'Project name cannot be empty' });
+        if (trimmed.length > 200) return reply.code(400).send({ error: 'Project name is too long (max 200 characters)' });
+        meta.name = trimmed;
+      }
       if (rootFile) meta.rootFile = rootFile;
       if (engine) meta.engine = engine;
       await store.writeMeta(meta);
@@ -410,7 +415,17 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     evictDoc(req.params.id, branch, rel); // prevent resurrection via pending store
     store.deleteFile(req.params.id, branch, rel);
     scheduleCommit(req.params.id, branch);
-    return { ok: true };
+    // If the typeset root was deleted, re-point it at another .tex so the next
+    // compile doesn't fail with "root file not found".
+    let newRoot: string | undefined;
+    try {
+      const meta = await store.readMeta(req.params.id);
+      if (meta.rootFile === rel) {
+        const tex = store.listFiles(req.params.id, branch).find((f) => f.type === 'file' && f.path.endsWith('.tex'));
+        if (tex) { meta.rootFile = tex.path; await store.writeMeta(meta); newRoot = tex.path; }
+      }
+    } catch { /* meta unreadable — leave as-is */ }
+    return { ok: true, ...(newRoot ? { newRoot } : {}) };
   });
 
   /** Serve compile artifacts (PDF, synctex) from the branch's .aldine-out. */
@@ -677,8 +692,17 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     '/api/projects/:id/comments', async (req, reply) => {
       const b = req.body || ({} as any);
       if (!b.file || !b.anchor) return reply.code(400).send({ error: 'file and anchor required' });
+      const branch = b.branch || 'main';
+      // the anchor must point at a real span in a real file
+      if (!store.fileExists(req.params.id, branch, b.file)) return reply.code(404).send({ error: 'File not found' });
+      const { from, to } = b.anchor;
+      if (typeof from !== 'number' || typeof to !== 'number' || from < 0 || to <= from) {
+        return reply.code(400).send({ error: 'Invalid comment anchor' });
+      }
+      if (typeof b.body === 'string' && b.body.length > 5000) return reply.code(400).send({ error: 'Comment is too long (max 5000 characters)' });
+      if (typeof b.suggestion === 'string' && b.suggestion.length > 20000) return reply.code(400).send({ error: 'Suggestion is too long' });
       return comments.addComment(req.params.id, {
-        branch: b.branch || 'main',
+        branch,
         file: b.file,
         anchor: b.anchor,
         author: reqUser(req)?.name || b.author || 'Anonymous',

--- a/apps/server/src/store.ts
+++ b/apps/server/src/store.ts
@@ -104,6 +104,10 @@ export function readFile(id: string, branch: string, rel: string): Buffer {
   return fs.readFileSync(safeJoin(branchDir(id, branch), rel));
 }
 
+export function fileExists(id: string, branch: string, rel: string): boolean {
+  try { return fs.existsSync(safeJoin(branchDir(id, branch), rel)); } catch { return false; }
+}
+
 export function writeFile(id: string, branch: string, rel: string, content: string | Buffer): void {
   const abs = safeJoin(branchDir(id, branch), rel);
   fs.mkdirSync(path.dirname(abs), { recursive: true });

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,6 +18,7 @@
         "@hocuspocus/provider": "^2.15.2",
         "codemirror-lang-latex": "^0.4.1",
         "katex": "^0.18.1",
+        "mathlive": "^0.110.0",
         "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -34,6 +35,12 @@
         "vite": "^6.3.5",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@arnog/colors": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@arnog/colors/-/colors-0.5.0.tgz",
+      "integrity": "sha512-NB7yqrO7qvInsqJdqz6C6mDU+2oiKmbBbk3czMS0E7KkGxLRy538tEHCsB5TKqmaxxXpi6/U120TnGl8NsDePg==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -397,6 +404,21 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@cortex-js/compute-engine": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.58.0.tgz",
+      "integrity": "sha512-N0+vXjVZfKwJS7ZIGvq41mojI55m5TrdDXveAXzNjzjZ9iNiNrdEzXL2EmrcP+9GCWCwTonrEeZWAIG78f3INg==",
+      "license": "MIT",
+      "dependencies": {
+        "@arnog/colors": "^0.5.0",
+        "complex-esm": "^2.1.1-esm1",
+        "decimal.js": "^10.6.0"
+      },
+      "engines": {
+        "node": ">=21.7.3",
+        "npm": ">=10.5.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1944,6 +1966,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/complex-esm": {
+      "version": "2.1.1-esm1",
+      "resolved": "https://registry.npmjs.org/complex-esm/-/complex-esm-2.1.1-esm1.tgz",
+      "integrity": "sha512-IShBEWHILB9s7MnfyevqNGxV0A1cfcSnewL/4uPFiSxkcQL4Mm3FxJ0pXMtCXuWLjYz3lRRyk6OfkeDZcjD6nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1981,6 +2013,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.395",
@@ -2220,6 +2258,19 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.110.0.tgz",
+      "integrity": "sha512-UOpJsQ6h1eeN0xZULGTl1MwUB/lZLCDuzKeHvKEh7Zra8U/rtgDNrssj5PZdJtBTIV48AfEhtv6rv47AeMOxJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cortex-js/compute-engine": "0.58.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/ms": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,0 +1,2873 @@
+{
+  "name": "@aldine/web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aldine/web",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.8.1",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/search": "^6.5.10",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.36.8",
+        "@hocuspocus/provider": "^2.15.2",
+        "codemirror-lang-latex": "^0.4.1",
+        "katex": "^0.18.1",
+        "pdfjs-dist": "^4.10.38",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.0",
+        "y-codemirror.next": "^0.3.5",
+        "yjs": "^13.6.27"
+      },
+      "devDependencies": {
+        "@types/katex": "^0.16.8",
+        "@types/react": "^18.3.20",
+        "@types/react-dom": "^18.3.6",
+        "@vitejs/plugin-react": "^4.4.1",
+        "typescript": "^5.8.3",
+        "vite": "^6.3.5",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hocuspocus/common": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.15.3.tgz",
+      "integrity": "sha512-Rzh1HF0a2o/tf90A3w2XNdXd9Ym3aQzMDfD3lAUONCX9B9QOdqdyiORrj6M25QEaJrEIbXFy8LtAFcL0wRdWzA==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.87"
+      }
+    },
+    "node_modules/@hocuspocus/provider": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-2.15.3.tgz",
+      "integrity": "sha512-oadN05m+KL4ylNKVo5YspNG4MXkT2Y+FUFzrgigpQeTjQibkPUwCNmUnkUxMgrGRgxb+O0lJCfirFIJMxedctA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hocuspocus/common": "^2.15.3",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.87",
+        "ws": "^8.17.1"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/generator": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.8.0.tgz",
+      "integrity": "sha512-/SF4EDWowPqV1jOgoGSGTIFsE7Ezdr7ZYxyihl5eMKVO5tlnpIhFcDavgm1hHY5GEonoOAEnJ0CU0x+tvuAuUg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.1.0",
+        "@lezer/lr": "^1.3.0"
+      },
+      "bin": {
+        "lezer-generator": "src/lezer-generator.cjs"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lifeomic/attempt": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.1.0.tgz",
+      "integrity": "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==",
+      "license": "MIT"
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
+      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/codemirror-lang-latex": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/codemirror-lang-latex/-/codemirror-lang-latex-0.4.2.tgz",
+      "integrity": "sha512-NjhekT+elGTGv49i1KA35J5239RX3hbMrO0dBRfyUbLYMIdjqmwMoOJScxJdIl7qwo9Tgd92QGrYhR4kX68yQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.20.1",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/search": "^6.6.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.0",
+        "@lezer/common": "^1.5.2",
+        "@lezer/generator": "^1.8.0",
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.395",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
+      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y-codemirror.next": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/y-codemirror.next/-/y-codemirror.next-0.3.5.tgz",
+      "integrity": "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "yjs": "^13.5.6"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@hocuspocus/provider": "^2.15.2",
     "codemirror-lang-latex": "^0.4.1",
     "katex": "^0.18.1",
+    "mathlive": "^0.110.0",
     "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.6",
@@ -17,6 +18,7 @@
     "@codemirror/view": "^6.36.8",
     "@hocuspocus/provider": "^2.15.2",
     "codemirror-lang-latex": "^0.4.1",
+    "katex": "^0.18.1",
     "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -25,11 +27,13 @@
     "yjs": "^13.6.27"
   },
   "devDependencies": {
+    "@types/katex": "^0.16.8",
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.10"
   },
   "license": "AGPL-3.0-only"
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -83,6 +83,8 @@ export const api = {
   },
   writeFile: (id: string, branch: string, path: string, content: string, encoding: 'utf8' | 'base64' = 'utf8') =>
     req<{ ok: boolean }>(`/api/projects/${id}/file`, { method: 'PUT', body: JSON.stringify({ branch, path, content, encoding }) }),
+  createFile: (id: string, branch: string, path: string) =>
+    req<{ ok: boolean }>(`/api/projects/${id}/file`, { method: 'PUT', body: JSON.stringify({ branch, path, content: '', createOnly: true }) }),
   deleteFile: (id: string, branch: string, path: string) =>
     req<{ ok: boolean }>(`/api/projects/${id}/file?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(path)}`, { method: 'DELETE' }),
   renameFile: (id: string, branch: string, from: string, to: string) =>

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -798,3 +798,29 @@
 .notfound { min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; text-align: center; padding: 24px; }
 .notfound h1 { font-size: 22px; font-weight: 600; }
 .notfound p { color: var(--text-2); }
+
+/* --- a11y & responsive polish (QA deferred batch) --- */
+/* Import-ZIP label acts as a button; expose it to AT */
+.home__bar label.btn, .empty label.btn { position: relative; }
+
+/* light-theme line numbers: lift contrast to meet WCAG */
+:root:not([data-theme="dark"]) .code-pane .cm-gutters { color: #6b6b70; }
+
+/* sidebar tabs: single scrollable row instead of an uneven wrap */
+.sidebar__tabs { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: none; }
+.sidebar__tabs::-webkit-scrollbar { display: none; }
+.sidebar__tab { flex: 0 0 auto; }
+
+/* responsive: below 900px let the editor stack usably; hide the fixed PDF pane
+   split and let panes flow, and allow the sidebar to collapse */
+@media (max-width: 900px) {
+  .editor-shell .resizer { display: none; }
+  .toolbar { flex-wrap: wrap; height: auto; row-gap: 4px; padding-top: 6px; padding-bottom: 6px; }
+  .toolbar__name { max-width: 40vw; }
+}
+@media (max-width: 640px) {
+  .home__bar { flex-direction: column; align-items: stretch; gap: 12px; }
+  .home__bar > div:last-child { flex-wrap: wrap; }
+  .split-pdf, .pdf-pane { display: none; }
+  .sidebar { position: absolute; z-index: 30; height: 100%; box-shadow: var(--shadow-pop); }
+}

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -793,3 +793,8 @@
 .vis-math-popover { z-index: 60; background: var(--bg-panel); border: 1px solid var(--hairline); border-radius: 10px; box-shadow: var(--shadow-pop); padding: 10px; display: flex; flex-direction: column; gap: 8px; min-width: 300px; }
 .vis-math-popover math-field { font-size: 18px; border: 1px solid var(--hairline); border-radius: 6px; padding: 4px 8px; background: var(--bg-inset); color: var(--text); }
 .vis-math-popover__bar { display: flex; gap: 8px; justify-content: flex-end; }
+
+/* 404 */
+.notfound { min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; text-align: center; padding: 24px; }
+.notfound h1 { font-size: 22px; font-weight: 600; }
+.notfound p { color: var(--text-2); }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -773,3 +773,9 @@
 .history__item:hover { background: var(--bg-hover); }
 .history__msg { font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .history__meta { font-size: 11px; color: var(--text-2); }
+
+/* segmented control (Source | Visual) */
+.seg { display: inline-flex; gap: 2px; padding: 2px; border: 1px solid var(--hairline); border-radius: 8px; background: var(--bg-inset); }
+.seg__btn { border: 0; background: transparent; color: var(--text-2); font: 600 12.5px var(--font-ui); padding: 4px 12px; border-radius: 6px; cursor: pointer; }
+.seg__btn:hover { color: var(--text); }
+.seg__btn--active { background: var(--bg-panel); color: var(--text); box-shadow: var(--shadow-card); }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -779,3 +779,12 @@
 .seg__btn { border: 0; background: transparent; color: var(--text-2); font: 600 12.5px var(--font-ui); padding: 4px 12px; border-radius: 6px; cursor: pointer; }
 .seg__btn:hover { color: var(--text); }
 .seg__btn--active { background: var(--bg-panel); color: var(--text); box-shadow: var(--shadow-card); }
+
+/* visual-mode formatting toolbar */
+.fmt { display: inline-flex; gap: 2px; margin-left: 10px; align-items: center; }
+.fmt__btn { border: 1px solid transparent; background: transparent; color: var(--text-2); font: 600 12.5px var(--font-ui); width: 26px; height: 22px; border-radius: 6px; cursor: pointer; }
+.fmt__btn:hover { background: var(--bg-hover); color: var(--text); }
+.fmt__btn--b { font-weight: 800; }
+.fmt__btn--i { font-style: italic; font-family: var(--font-serif); }
+.fmt__select { border: 1px solid transparent; background: transparent; color: var(--text-2); font: 600 12px var(--font-ui); border-radius: 6px; cursor: pointer; }
+.fmt__select:hover { background: var(--bg-hover); color: var(--text); }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -788,3 +788,8 @@
 .fmt__btn--i { font-style: italic; font-family: var(--font-serif); }
 .fmt__select { border: 1px solid transparent; background: transparent; color: var(--text-2); font: 600 12px var(--font-ui); border-radius: 6px; cursor: pointer; }
 .fmt__select:hover { background: var(--bg-hover); color: var(--text); }
+
+/* MathLive popover */
+.vis-math-popover { z-index: 60; background: var(--bg-panel); border: 1px solid var(--hairline); border-radius: 10px; box-shadow: var(--shadow-pop); padding: 10px; display: flex; flex-direction: column; gap: 8px; min-width: 300px; }
+.vis-math-popover math-field { font-size: 18px; border: 1px solid var(--hairline); border-radius: 6px; padding: 4px 8px; background: var(--bg-inset); color: var(--text); }
+.vis-math-popover__bar { display: flex; gap: 8px; justify-content: flex-end; }

--- a/apps/web/src/components/AccountSettings.tsx
+++ b/apps/web/src/components/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { api, AuthUser } from '../api';
 import { useToast } from './Toast';
+import Modal from './Modal';
 
 /** Account settings: identity + change password (password accounts only). */
 export default function AccountSettings({ user, onClose }: { user: AuthUser; onClose(): void }) {
@@ -25,8 +26,8 @@ export default function AccountSettings({ user, onClose }: { user: AuthUser; onC
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal" style={{ width: 420 }} onClick={(e) => e.stopPropagation()} data-testid="account-settings">
+    <Modal onClose={onClose} label="Account settings" testId="account-settings">
+      <div style={{ width: 420 }}>
         <h2 style={{ marginBottom: 2 }}>Account</h2>
         <p className="modal__sub">{user.email}</p>
 
@@ -57,6 +58,6 @@ export default function AccountSettings({ user, onClose }: { user: AuthUser; onC
           {!isSso && <button className="btn btn--primary" onClick={change} disabled={busy} data-testid="save-password">{busy ? '…' : 'Update password'}</button>}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/CodePane.tsx
+++ b/apps/web/src/components/CodePane.tsx
@@ -17,8 +17,31 @@ import { visualExtensions, type VisualDeps } from '../editor/visual';
 import { toggleStyle, setSectionLevel, toggleItemize } from '../editor/visual/commands';
 import { documentOutline, OutlineEntry } from '../editor/visual/outline';
 import type { PresenceUser } from './Presence';
+import type { Text } from '@codemirror/state';
 
 export type EditorMode = 'source' | 'visual';
+
+/**
+ * Re-anchor a comment by its stored quote when its saved offset has drifted
+ * (edits above it made while it wasn't being live-tracked — reload, another
+ * user's edits). Uses the occurrence of the quote nearest the saved offset;
+ * falls back to the clamped saved offset when the quote can't be found.
+ */
+function reanchor(doc: Text, r: CommentRange): CommentRange {
+  const len = doc.length;
+  const from = Math.min(Math.max(0, r.from), len);
+  const to = Math.min(Math.max(from, r.to), len);
+  if (!r.quote) return { ...r, from, to };
+  if (doc.sliceString(from, to) === r.quote) return { ...r, from, to }; // still exact
+  const text = doc.toString();
+  let best = -1, bestDist = Infinity;
+  for (let i = text.indexOf(r.quote); i !== -1; i = text.indexOf(r.quote, i + 1)) {
+    const d = Math.abs(i - r.from);
+    if (d < bestDist) { best = i; bestDist = d; }
+  }
+  if (best === -1) return { ...r, from, to }; // quote gone — keep clamped offset
+  return { ...r, from: best, to: best + r.quote.length };
+}
 
 export interface CodePaneHandle {
   gotoLine(line: number): void;
@@ -134,6 +157,7 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
   cbRef.current = { onDocChanged, onStats, onSave, onJumpToPdf };
   // Per-mount reconfiguration handles: compartments + the deps visualExtensions needs.
   const reconfRef = useRef<{ modeComp: Compartment; spellComp: Compartment; deps: VisualDeps } | null>(null);
+  const lastCommentRanges = useRef<CommentRange[]>([]);
 
   useImperativeHandle(ref, () => ({
     gotoLine(line: number) {
@@ -163,9 +187,10 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
       return { from: sel.from, to: sel.to, quote: view.state.sliceDoc(sel.from, sel.to) };
     },
     setCommentRanges(ranges) {
+      lastCommentRanges.current = ranges; // remember for a re-apply once the doc syncs
       const view = viewRef.current;
       if (!view) return;
-      view.dispatch({ effects: setComments.of(ranges) });
+      view.dispatch({ effects: setComments.of(ranges.map((r) => reanchor(view.state.doc, r))) });
     },
     revealPos(pos) {
       const view = viewRef.current;
@@ -297,6 +322,11 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
 
     const initialStats = () => {
       cbRef.current.onStats?.({ words: latexWordCount(view.state.doc.toString()), selWords: null });
+      // Re-anchor comments against the now-populated doc: a push that arrived
+      // before the Yjs sync ran against an empty document.
+      if (lastCommentRanges.current.length) {
+        view.dispatch({ effects: setComments.of(lastCommentRanges.current.map((r) => reanchor(view.state.doc, r))) });
+      }
     };
     provider.on('synced', initialStats);
 

--- a/apps/web/src/components/CodePane.tsx
+++ b/apps/web/src/components/CodePane.tsx
@@ -13,6 +13,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import { localUser } from '../api';
 import { citeCompletionSource, refCompletionSource, citeHoverTooltip, warmBib } from '../editor/latexExtras';
 import { visualExtensions, type VisualDeps } from '../editor/visual';
+import { toggleStyle, setSectionLevel, toggleItemize } from '../editor/visual/commands';
 import type { PresenceUser } from './Presence';
 
 export type EditorMode = 'source' | 'visual';
@@ -24,6 +25,7 @@ export interface CodePaneHandle {
   getSelection(): { from: number; to: number; quote: string } | null;
   setCommentRanges(ranges: Array<{ id: string; from: number; to: number; resolved: boolean }>): void;
   revealPos(pos: number): void;
+  format(action: 'bold' | 'italic' | 'list' | { section: 1 | 2 | 3 | 4 }): void;
 }
 
 /** Comment highlight decorations, updatable via an effect and tracking edits. */
@@ -170,6 +172,15 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
       view.dispatch({ selection: { anchor: p }, effects: EditorView.scrollIntoView(p, { y: 'center' }) });
       view.focus();
     },
+    format(action) {
+      const view = viewRef.current;
+      if (!view) return;
+      if (action === 'bold') toggleStyle('bold')(view);
+      else if (action === 'italic') toggleStyle('italic')(view);
+      else if (action === 'list') toggleItemize(view);
+      else setSectionLevel(action.section)(view);
+      view.focus();
+    },
   }), []);
 
   useEffect(() => {
@@ -247,6 +258,8 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
             indentWithTab,
             { key: 'Mod-s', run: () => { cbRef.current.onSave(); return true; } },
             { key: 'Mod-j', run: () => { cbRef.current.onJumpToPdf?.(); return true; } },
+            { key: 'Mod-b', run: toggleStyle('bold') },
+            { key: 'Mod-i', run: toggleStyle('italic') },
           ]),
           EditorView.updateListener.of((u) => {
             if (u.docChanged) cbRef.current.onDocChanged?.();

--- a/apps/web/src/components/CodePane.tsx
+++ b/apps/web/src/components/CodePane.tsx
@@ -12,8 +12,10 @@ import { yCollab, yUndoManagerKeymap } from 'y-codemirror.next';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { localUser } from '../api';
 import { citeCompletionSource, refCompletionSource, citeHoverTooltip, warmBib } from '../editor/latexExtras';
+import { setComments, CommentRange } from '../editor/commentsEffect';
 import { visualExtensions, type VisualDeps } from '../editor/visual';
 import { toggleStyle, setSectionLevel, toggleItemize } from '../editor/visual/commands';
+import { documentOutline, OutlineEntry } from '../editor/visual/outline';
 import type { PresenceUser } from './Presence';
 
 export type EditorMode = 'source' | 'visual';
@@ -23,13 +25,13 @@ export interface CodePaneHandle {
   insertAtCursor(text: string): void;
   currentLine(): number | null;
   getSelection(): { from: number; to: number; quote: string } | null;
-  setCommentRanges(ranges: Array<{ id: string; from: number; to: number; resolved: boolean }>): void;
+  setCommentRanges(ranges: CommentRange[]): void;
   revealPos(pos: number): void;
   format(action: 'bold' | 'italic' | 'list' | { section: 1 | 2 | 3 | 4 }): void;
+  getOutline(): OutlineEntry[];
 }
 
 /** Comment highlight decorations, updatable via an effect and tracking edits. */
-const setComments = StateEffect.define<Array<{ from: number; to: number; resolved: boolean }>>();
 const commentMark = Decoration.mark({ class: 'cm-comment-range' });
 const commentResolvedMark = Decoration.mark({ class: 'cm-comment-range cm-comment-resolved' });
 const commentField = StateField.define<DecorationSet>({
@@ -163,7 +165,7 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
     setCommentRanges(ranges) {
       const view = viewRef.current;
       if (!view) return;
-      view.dispatch({ effects: setComments.of(ranges.map((r) => ({ from: r.from, to: r.to, resolved: r.resolved }))) });
+      view.dispatch({ effects: setComments.of(ranges) });
     },
     revealPos(pos) {
       const view = viewRef.current;
@@ -180,6 +182,10 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
       else if (action === 'list') toggleItemize(view);
       else setSectionLevel(action.section)(view);
       view.focus();
+    },
+    getOutline() {
+      const view = viewRef.current;
+      return view ? documentOutline(view.state) : [];
     },
   }), []);
 

--- a/apps/web/src/components/CodePane.tsx
+++ b/apps/web/src/components/CodePane.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection, rectangularSelection, highlightSpecialChars, Decoration, DecorationSet } from '@codemirror/view';
-import { EditorState, StateField, StateEffect } from '@codemirror/state';
+import { EditorState, StateField, StateEffect, Compartment } from '@codemirror/state';
 import { indentOnInput, bracketMatching, foldGutter, syntaxHighlighting, defaultHighlightStyle, HighlightStyle } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { defaultKeymap, indentWithTab } from '@codemirror/commands';
@@ -12,7 +12,10 @@ import { yCollab, yUndoManagerKeymap } from 'y-codemirror.next';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { localUser } from '../api';
 import { citeCompletionSource, refCompletionSource, citeHoverTooltip, warmBib } from '../editor/latexExtras';
+import { visualExtensions, type VisualDeps } from '../editor/visual';
 import type { PresenceUser } from './Presence';
+
+export type EditorMode = 'source' | 'visual';
 
 export interface CodePaneHandle {
   gotoLine(line: number): void;
@@ -58,6 +61,7 @@ interface Props {
   onStats?(stats: { words: number; selWords: number | null }): void;
   onJumpToPdf?(): void;
   spellcheck?: boolean;
+  mode?: EditorMode;
 }
 
 /** Approximate word count for LaTeX prose: strips comments, commands, math. */
@@ -110,11 +114,22 @@ const aldineTheme = EditorView.theme({
   '.cm-panels': { backgroundColor: 'var(--bg-inset)', color: 'var(--text)', borderColor: 'var(--hairline)' },
 });
 
-const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId, branch, filePath, onUsers, onSave, onDocChanged, onStats, onJumpToPdf, spellcheck = false }, ref) {
+/** Spellcheck is presentation config, swapped at runtime via a Compartment. */
+function spellcheckAttrs(spellcheck: boolean, filePath: string) {
+  return EditorView.contentAttributes.of({
+    spellcheck: spellcheck && /\.(tex|md|txt)$/i.test(filePath) ? 'true' : 'false',
+    autocorrect: 'off',
+    autocapitalize: 'off',
+  });
+}
+
+const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId, branch, filePath, onUsers, onSave, onDocChanged, onStats, onJumpToPdf, spellcheck = false, mode = 'source' }, ref) {
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const cbRef = useRef({ onDocChanged, onStats, onSave, onJumpToPdf });
   cbRef.current = { onDocChanged, onStats, onSave, onJumpToPdf };
+  // Per-mount reconfiguration handles: compartments + the deps visualExtensions needs.
+  const reconfRef = useRef<{ modeComp: Compartment; spellComp: Compartment; deps: VisualDeps } | null>(null);
 
   useImperativeHandle(ref, () => ({
     gotoLine(line: number) {
@@ -180,6 +195,9 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
     provider.setAwarenessField('user', { name: user.name, color: user.color, colorLight: user.color + '55' });
 
     const awareness = provider.awareness!;
+    const modeComp = new Compartment();
+    const spellComp = new Compartment();
+    const deps: VisualDeps = { projectId, branch, ydoc, awareness };
     const reportUsers = () => {
       // key by Yjs clientID so two collaborators with the same display name stay distinct
       const byClient = new Map<number, PresenceUser>();
@@ -249,16 +267,14 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
           aldineTheme,
           EditorView.lineWrapping,
           // browser-native spellcheck on prose (only meaningful for .tex/.md)
-          EditorView.contentAttributes.of({
-            spellcheck: spellcheck && /\.(tex|md|txt)$/i.test(filePath) ? 'true' : 'false',
-            autocorrect: 'off',
-            autocapitalize: 'off',
-          }),
+          spellComp.of(spellcheckAttrs(spellcheck, filePath)),
+          modeComp.of(mode === 'visual' ? visualExtensions(deps) : []),
           yCollab(ytext, provider.awareness),
         ],
       }),
     });
     viewRef.current = view;
+    reconfRef.current = { modeComp, spellComp, deps };
 
     const initialStats = () => {
       cbRef.current.onStats?.({ words: latexWordCount(view.state.doc.toString()), selWords: null });
@@ -273,8 +289,22 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
       provider.destroy();
       ydoc.destroy();
       viewRef.current = null;
+      reconfRef.current = null;
     };
   }, [projectId, branch, filePath]);
+
+  // Mode and spellcheck are presentation-only: swap them at runtime through
+  // compartments so the Yjs doc, collab socket, scroll, and cursor survive.
+  useEffect(() => {
+    const view = viewRef.current, rc = reconfRef.current;
+    if (!view || !rc) return;
+    view.dispatch({ effects: rc.modeComp.reconfigure(mode === 'visual' ? visualExtensions(rc.deps) : []) });
+  }, [mode]);
+  useEffect(() => {
+    const view = viewRef.current, rc = reconfRef.current;
+    if (!view || !rc) return;
+    view.dispatch({ effects: rc.spellComp.reconfigure(spellcheckAttrs(spellcheck, filePath)) });
+  }, [spellcheck, filePath]);
 
   return <div ref={hostRef} className="code-pane" data-testid="code-pane" />;
 });

--- a/apps/web/src/components/CommentComposer.tsx
+++ b/apps/web/src/components/CommentComposer.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Modal from './Modal';
 
 /** Inline composer for a new review comment (replaces the old window.prompt flow). */
 export default function CommentComposer({ quote, onSubmit, onClose }: {
@@ -18,8 +19,8 @@ export default function CommentComposer({ quote, onSubmit, onClose }: {
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal" style={{ width: 460 }} onClick={(e) => e.stopPropagation()} data-testid="comment-composer">
+    <Modal onClose={onClose} label="Add a comment" testId="comment-composer">
+      <div style={{ width: 460 }}>
         <h2 style={{ marginBottom: 8 }}>Add a comment</h2>
         <blockquote className="composer__quote" title={quote}>{quote}</blockquote>
         <textarea
@@ -53,6 +54,6 @@ export default function CommentComposer({ quote, onSubmit, onClose }: {
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/FormatToolbar.tsx
+++ b/apps/web/src/components/FormatToolbar.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import type { CodePaneHandle } from './CodePane';
+import type { OutlineEntry } from '../editor/visual/outline';
 
 interface Props {
   target: React.RefObject<CodePaneHandle | null>;
@@ -29,6 +31,31 @@ export default function FormatToolbar({ target }: Props) {
         <option value="3">Subsubsection</option>
         <option value="4">Paragraph</option>
       </select>
+      <ContentsDropdown target={target} />
     </span>
+  );
+}
+
+function ContentsDropdown({ target }: Props) {
+  const [outline, setOutline] = useState<OutlineEntry[] | null>(null);
+  return (
+    <select
+      className="fmt__select"
+      title="Contents"
+      aria-label="Contents"
+      data-testid="outline-dropdown"
+      value=""
+      onFocus={() => setOutline(target.current?.getOutline() ?? [])}
+      onChange={(e) => {
+        const line = Number(e.target.value);
+        if (line) target.current?.gotoLine(line);
+        e.target.value = '';
+      }}
+    >
+      <option value="" disabled>Contents…</option>
+      {(outline ?? []).map((h, i) => (
+        <option key={i} value={h.line}>{'\u2007'.repeat((h.level - 1) * 2) + h.title}</option>
+      ))}
+    </select>
   );
 }

--- a/apps/web/src/components/FormatToolbar.tsx
+++ b/apps/web/src/components/FormatToolbar.tsx
@@ -1,0 +1,34 @@
+import type { CodePaneHandle } from './CodePane';
+
+interface Props {
+  target: React.RefObject<CodePaneHandle | null>;
+}
+
+/** Formatting affordances for Visual mode; every action is a plain text edit. */
+export default function FormatToolbar({ target }: Props) {
+  const fmt = (action: Parameters<CodePaneHandle['format']>[0]) => () => target.current?.format(action);
+  return (
+    <span className="fmt" data-testid="format-toolbar">
+      <button className="fmt__btn fmt__btn--b" title="Bold (⌘B)" aria-label="Bold" onClick={fmt('bold')}>B</button>
+      <button className="fmt__btn fmt__btn--i" title="Italic (⌘I)" aria-label="Italic" onClick={fmt('italic')}>I</button>
+      <button className="fmt__btn" title="Bullet list" aria-label="Bullet list" onClick={fmt('list')}>•≡</button>
+      <select
+        className="fmt__select"
+        title="Heading level"
+        aria-label="Heading level"
+        value=""
+        onChange={(e) => {
+          const v = Number(e.target.value);
+          if (v >= 1 && v <= 4) target.current?.format({ section: v as 1 | 2 | 3 | 4 });
+          e.target.value = '';
+        }}
+      >
+        <option value="" disabled>Heading…</option>
+        <option value="1">Section</option>
+        <option value="2">Subsection</option>
+        <option value="3">Subsubsection</option>
+        <option value="4">Paragraph</option>
+      </select>
+    </span>
+  );
+}

--- a/apps/web/src/components/GithubImport.tsx
+++ b/apps/web/src/components/GithubImport.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { api, GithubRepo, GithubStatus } from '../api';
 import { useToast } from './Toast';
 import { friendlyDate } from '../util/dates';
+import Modal from './Modal';
 
 const GH_ICON = (
   <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" style={{ flexShrink: 0 }}><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
@@ -44,8 +45,8 @@ export default function GithubImport({ onClose, onImported }: { onClose(): void;
   const shown = (repos || []).filter((r) => r.fullName.toLowerCase().includes(filter.toLowerCase()));
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal modal--wide" onClick={(e) => e.stopPropagation()} data-testid="github-import">
+    <Modal onClose={onClose} label="Import from GitHub" wide testId="github-import">
+      <div>
         <h2 style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>{GH_ICON} Import from GitHub</h2>
 
         {!status && <p className="modal__sub">Checking connection…</p>}
@@ -98,6 +99,6 @@ export default function GithubImport({ onClose, onImported }: { onClose(): void;
 
         <div className="modal__row" style={{ marginTop: 14 }}><button className="btn" onClick={onClose}>Close</button></div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, ReactNode } from 'react';
+
+interface Props {
+  onClose: () => void;
+  children: ReactNode;
+  label: string;
+  wide?: boolean;
+  testId?: string;
+}
+
+/**
+ * Accessible modal dialog: role/aria-modal for screen readers, focus moved in
+ * on open and restored on close, focus trapped within, Escape and
+ * backdrop-click to dismiss.
+ */
+export default function Modal({ onClose, children, label, wide, testId }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const returnFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    returnFocus.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    // focus the first focusable control, else the panel itself
+    const focusables = () => Array.from(
+      panel?.querySelectorAll<HTMLElement>('a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])') ?? [],
+    );
+    (focusables()[0] ?? panel)?.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.stopPropagation(); onClose(); return; }
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (!items.length) { e.preventDefault(); return; }
+      const first = items[0], last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.removeEventListener('keydown', onKey, true);
+      returnFocus.current?.focus?.();
+    };
+  }, [onClose]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        ref={panelRef}
+        className={`modal${wide ? ' modal--wide' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        data-testid={testId}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Onboarding.tsx
+++ b/apps/web/src/components/Onboarding.tsx
@@ -1,3 +1,4 @@
+import Modal from './Modal';
 /** First-run welcome shown once (localStorage-gated by the parent). */
 export default function Onboarding({ onNew, onGithub, onImportZip, onClose }: {
   onNew(): void; onGithub(): void; onImportZip(file: File): void; onClose(): void;
@@ -5,8 +6,8 @@ export default function Onboarding({ onNew, onGithub, onImportZip, onClose }: {
   const start = (fn: () => void) => { onClose(); fn(); };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal onboard" onClick={(e) => e.stopPropagation()} data-testid="onboarding">
+    <Modal onClose={onClose} label="Welcome to Aldine" testId="onboarding">
+      <div className="onboard">
         <h1 className="home__brand" style={{ fontSize: 30, marginBottom: 2 }}>aldine<em>.</em></h1>
         <p className="home__tag" style={{ marginBottom: 20 }}>Write LaTeX together — fast, versioned, yours.</p>
 
@@ -36,6 +37,6 @@ export default function Onboarding({ onNew, onGithub, onImportZip, onClose }: {
           <button className="btn btn--primary" onClick={onClose} data-testid="onboard-dismiss">Get started</button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/apps/web/src/components/PdfPane.tsx
+++ b/apps/web/src/components/PdfPane.tsx
@@ -94,7 +94,8 @@ const PdfPane = forwardRef<PdfPaneHandle, Props>(function PdfPane({ pdfUrl, stat
         setRendered(true);
         scroller.scrollTop = prevScroll;
       } catch (err) {
-        console.error('[pdf] render failed', err);
+        // a superseded render (fast retyping) cancels itself — that's expected, not an error
+        if ((err as { name?: string })?.name !== 'RenderingCancelledException') console.error('[pdf] render failed', err);
       }
     })();
     // Invalidate any in-flight render (so its guarded loop bails before touching

--- a/apps/web/src/components/Presence.tsx
+++ b/apps/web/src/components/Presence.tsx
@@ -5,7 +5,7 @@ export default function Presence({ users }: { users: PresenceUser[] }) {
   return (
     <div className="presence" title={users.map((u) => u.name).join(', ')} data-testid="presence">
       {users.slice(0, 5).map((u, i) => (
-        <span key={i} className="presence__avatar" style={{ background: u.color }}>
+        <span key={i} className="presence__avatar" title={u.name} aria-label={u.name} style={{ background: u.color }}>
           {u.name.trim().slice(0, 1).toUpperCase()}
         </span>
       ))}

--- a/apps/web/src/editor/commentsEffect.ts
+++ b/apps/web/src/editor/commentsEffect.ts
@@ -1,0 +1,12 @@
+import { StateEffect } from '@codemirror/state';
+
+/** Review-comment ranges pushed into the editor (shared by source + visual layers). */
+export interface CommentRange {
+  id: string;
+  from: number;
+  to: number;
+  resolved: boolean;
+  suggestion?: string;
+}
+
+export const setComments = StateEffect.define<CommentRange[]>();

--- a/apps/web/src/editor/commentsEffect.ts
+++ b/apps/web/src/editor/commentsEffect.ts
@@ -7,6 +7,7 @@ export interface CommentRange {
   to: number;
   resolved: boolean;
   suggestion?: string;
+  quote?: string;
 }
 
 export const setComments = StateEffect.define<CommentRange[]>();

--- a/apps/web/src/editor/visual/__tests__/decorations.test.ts
+++ b/apps/web/src/editor/visual/__tests__/decorations.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState, EditorSelection } from '@codemirror/state';
+import { ensureSyntaxTree } from '@codemirror/language';
+import { latex } from 'codemirror-lang-latex';
+import { buildAtomic, buildMarks } from '../decorations';
+import { computeRevealRanges, revealField } from '../reveal';
+
+function state(doc: string, selection?: { anchor: number; head?: number }) {
+  const s = EditorState.create({
+    doc,
+    selection: selection ? EditorSelection.single(selection.anchor, selection.head ?? selection.anchor) : undefined,
+    extensions: [latex(), revealField],
+  });
+  ensureSyntaxTree(s, s.doc.length, 5_000);
+  return s;
+}
+
+function atomicRanges(s: EditorState) {
+  const out: Array<[number, number]> = [];
+  buildAtomic(s, s.field(revealField).ranges).between(0, s.doc.length, (from, to) => { out.push([from, to]); });
+  return out;
+}
+
+function markRanges(s: EditorState) {
+  const out: Array<[number, number, string]> = [];
+  buildMarks(s, s.field(revealField).ranges, [{ from: 0, to: s.doc.length }]).between(0, s.doc.length, (from, to, deco) => {
+    out.push([from, to, (deco.spec.class as string) ?? '']);
+  });
+  return out;
+}
+
+describe('visual decorations', () => {
+  it('hides section markup and marks the heading line', () => {
+    const s = state('\\section{Intro}\nBody text', { anchor: 20 }); // cursor in body prose
+    // hide "\section{" [0,9) and "}" [14,15)
+    expect(atomicRanges(s)).toEqual([[0, 9], [14, 15]]);
+    const lines = markRanges(s).filter(([, , cls]) => cls.includes('cm-vis-h'));
+    expect(lines).toEqual([[0, 0, 'cm-vis-h cm-vis-h1']]);
+  });
+
+  it('ranks subsection and subsubsection headings', () => {
+    const s = state('\\subsection{A}\n\\subsubsection{B}\nx', { anchor: 33 });
+    const classes = markRanges(s).map(([, , cls]) => cls);
+    expect(classes).toContain('cm-vis-h cm-vis-h2');
+    expect(classes).toContain('cm-vis-h cm-vis-h3');
+  });
+
+  it('hides bold markup and marks the interior', () => {
+    const s = state('a \\textbf{bold} b');
+    expect(atomicRanges(s)).toEqual([[2, 10], [14, 15]]);
+    expect(markRanges(s)).toEqual([[10, 14, 'cm-vis-b']]);
+  });
+
+  it('styles emph as italic', () => {
+    const s = state('\\emph{x} y', { anchor: 10 });
+    expect(markRanges(s)).toEqual([[6, 7, 'cm-vis-i']]);
+  });
+
+  it('renders nested bold inside a heading', () => {
+    const s = state('\\section{A \\textbf{big} deal}\nx', { anchor: 31 });
+    const marks = markRanges(s);
+    expect(marks.some(([, , cls]) => cls === 'cm-vis-b')).toBe(true);
+    // both the heading braces and the nested bold braces are hidden
+    expect(atomicRanges(s).length).toBe(4);
+  });
+
+  it('leaves unclosed constructs as raw source', () => {
+    const s = state('x \\textbf{never closed', { anchor: 0 });
+    expect(atomicRanges(s)).toEqual([]);
+    expect(markRanges(s)).toEqual([]);
+  });
+
+  it('never decorates inside verbatim', () => {
+    const s = state('\\begin{verbatim}\n\\textbf{not bold}\n\\end{verbatim}\nx', { anchor: 49 });
+    expect(atomicRanges(s)).toEqual([]);
+  });
+
+  it('leaves unknown commands untouched', () => {
+    const s = state('\\weirdmacro{x}{y} z', { anchor: 19 });
+    expect(atomicRanges(s)).toEqual([]);
+    expect(markRanges(s)).toEqual([]);
+  });
+
+  it('reveals a construct containing the cursor', () => {
+    const doc = 'a \\textbf{bold} b';
+    const s = state(doc, { anchor: 12 }); // cursor inside "bold"
+    expect(s.field(revealField).ranges).toEqual([{ from: 2, to: 15 }]);
+    expect(atomicRanges(s)).toEqual([]); // markup shown
+    expect(markRanges(s)).toEqual([]);
+  });
+
+  it('cursor outside the construct keeps it rendered', () => {
+    const s = state('a \\textbf{bold} b', { anchor: 0 });
+    expect(atomicRanges(s).length).toBe(2);
+  });
+
+  it('a selection spanning constructs reveals every one it touches', () => {
+    const doc = 'x \\textbf{a} y \\emph{b} z';
+    const s = state(doc, { anchor: 0, head: doc.length });
+    const reveals = computeRevealRanges(s, []);
+    expect(reveals.length).toBeGreaterThanOrEqual(2);
+    expect(atomicRanges(s)).toEqual([]);
+  });
+
+  it('remote carets force-reveal their construct', () => {
+    const doc = 'a \\textbf{bold} b';
+    const s = state(doc, { anchor: 0 });
+    const reveals = computeRevealRanges(s, [12]);
+    expect(reveals).toContainEqual({ from: 2, to: 15 });
+  });
+
+  it('tolerates syntax errors elsewhere in the document', () => {
+    const s = state('\\section{Ok}\nplain\n\\begin{itemize} unclosed\n\\textbf{b}', { anchor: 15 });
+    // the section still renders even though the doc has an error node
+    expect(atomicRanges(s).some(([f]) => f === 0)).toBe(true);
+  });
+});

--- a/apps/web/src/editor/visual/atomicField.ts
+++ b/apps/web/src/editor/visual/atomicField.ts
@@ -1,0 +1,29 @@
+import { StateField } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type { DecorationSet } from '@codemirror/view';
+import { revealField, RevealState } from './reveal';
+import { buildAtomic } from './decorations';
+
+interface AtomicValue { deco: DecorationSet; forReveal: RevealState }
+
+/**
+ * Full-document replace decorations (hidden markup, widgets) plus the matching
+ * atomic ranges so the caret skips over hidden spans. Rebuilds only when the
+ * document or the reveal set actually changed; widget DOM stays lazy (CM calls
+ * toDOM only for the viewport), so full-doc building stays cheap.
+ */
+export const atomicField = StateField.define<AtomicValue>({
+  create(state) {
+    const rv = state.field(revealField);
+    return { deco: buildAtomic(state, rv.ranges), forReveal: rv };
+  },
+  update(value, tr) {
+    const rv = tr.state.field(revealField);
+    if (!tr.docChanged && rv === value.forReveal) return value;
+    return { deco: buildAtomic(tr.state, rv.ranges), forReveal: rv };
+  },
+  provide: (f) => [
+    EditorView.decorations.from(f, (v) => v.deco),
+    EditorView.atomicRanges.of((view) => view.state.field(f).deco),
+  ],
+});

--- a/apps/web/src/editor/visual/bridge.ts
+++ b/apps/web/src/editor/visual/bridge.ts
@@ -1,0 +1,27 @@
+import { ViewPlugin } from '@codemirror/view';
+
+/**
+ * Widgets are plain DOM with no EditorView reference; this bridge turns their
+ * window events into precise CM dispatches (which flow through yCollab/undo).
+ */
+export const docEditBridge = ViewPlugin.define((view) => {
+  const onEdit = (e: Event) => {
+    const { from, to, insert } = (e as CustomEvent<{ from: number; to: number; insert: string }>).detail;
+    const len = view.state.doc.length;
+    if (from < 0 || to > len || from > to) return;
+    view.dispatch({ changes: { from, to, insert }, userEvent: 'input.visual' });
+  };
+  const onGoto = (e: Event) => {
+    const { pos } = (e as CustomEvent<{ pos: number }>).detail;
+    view.dispatch({ selection: { anchor: Math.min(Math.max(0, pos), view.state.doc.length) }, scrollIntoView: true });
+    view.focus();
+  };
+  window.addEventListener('aldine:doc-edit', onEdit);
+  window.addEventListener('aldine:goto', onGoto);
+  return {
+    destroy() {
+      window.removeEventListener('aldine:doc-edit', onEdit);
+      window.removeEventListener('aldine:goto', onGoto);
+    },
+  };
+});

--- a/apps/web/src/editor/visual/commands.ts
+++ b/apps/web/src/editor/visual/commands.ts
@@ -1,0 +1,144 @@
+import { EditorView } from '@codemirror/view';
+import { EditorSelection } from '@codemirror/state';
+import type { EditorState } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+
+/**
+ * All formatting is expressed as ordinary CodeMirror text dispatches, so it
+ * flows through yCollab (collaborative) and the Yjs undo manager. These are
+ * the only code paths in the visual editor that change document bytes.
+ */
+
+const STYLE = {
+  bold: { cmd: '\\textbf', node: 'TextBoldCommand' },
+  italic: { cmd: '\\textit', node: 'TextItalicCommand' },
+} as const;
+export type StyleKind = keyof typeof STYLE;
+
+const SECTION_CMDS = ['\\section', '\\subsection', '\\subsubsection', '\\paragraph'] as const;
+const SECTION_TOKENS = new Set([
+  'BookCtrlSeq', 'PartCtrlSeq', 'ChapterCtrlSeq', 'SectionCtrlSeq',
+  'SubSectionCtrlSeq', 'SubSubSectionCtrlSeq', 'ParagraphCtrlSeq', 'SubParagraphCtrlSeq',
+]);
+
+function ancestor(state: EditorState, pos: number, name: string): SyntaxNode | null {
+  for (const side of [-1, 1] as const) {
+    let n: SyntaxNode | null = syntaxTree(state).resolveInner(pos, side);
+    while (n) {
+      if (n.name === name) return n;
+      n = n.parent;
+    }
+  }
+  return null;
+}
+
+/** Wrap the selection in \textbf{}/\textit{} — or unwrap when already inside one. */
+export function toggleStyle(kind: StyleKind) {
+  return (view: EditorView): boolean => {
+    const { state } = view;
+    const { cmd, node } = STYLE[kind];
+    const sel = state.selection.main;
+    const wrapper = ancestor(state, sel.head, node);
+    if (wrapper) {
+      const arg = wrapper.getChild('TextArgument');
+      const open = arg?.getChild('OpenBrace');
+      const close = arg?.getChild('CloseBrace');
+      if (arg && open && close) {
+        view.dispatch({
+          changes: [
+            { from: wrapper.from, to: open.to },
+            { from: close.from, to: close.to },
+          ],
+          scrollIntoView: true,
+        });
+        return true;
+      }
+      return false;
+    }
+    view.dispatch(state.changeByRange((range) => ({
+      changes: [
+        { from: range.from, insert: `${cmd}{` },
+        { from: range.to, insert: '}' },
+      ],
+      range: EditorSelection.range(range.from + cmd.length + 1, range.to + cmd.length + 1),
+    })));
+    return true;
+  };
+}
+
+/**
+ * Set the sectioning level of the enclosing heading by replacing only its
+ * command token (a `*` stays untouched). With no enclosing heading, the
+ * current line's text becomes a new heading.
+ */
+export function setSectionLevel(level: 1 | 2 | 3 | 4) {
+  return (view: EditorView): boolean => {
+    const { state } = view;
+    const cmd = SECTION_CMDS[level - 1];
+    const pos = state.selection.main.head;
+    const sect = ancestor(state, pos, 'SectioningCommand');
+    if (sect) {
+      let tok: SyntaxNode | null = sect.firstChild;
+      while (tok && !SECTION_TOKENS.has(tok.name)) tok = tok.nextSibling;
+      if (!tok) return false;
+      view.dispatch({ changes: { from: tok.from, to: tok.to, insert: cmd } });
+      return true;
+    }
+    const line = state.doc.lineAt(pos);
+    const text = line.text.trim();
+    view.dispatch({
+      changes: { from: line.from, to: line.to, insert: `${cmd}{${text}}` },
+      selection: { anchor: line.from + cmd.length + 1 + text.length },
+    });
+    return true;
+  };
+}
+
+/** Wrap the selected lines in an itemize (or unwrap the enclosing list). */
+export function toggleItemize(view: EditorView): boolean {
+  const { state } = view;
+  const sel = state.selection.main;
+  const env = ancestor(state, sel.head, 'ListEnvironment');
+  if (env) {
+    const begin = env.getChild('BeginEnv');
+    const end = env.getChild('EndEnv');
+    if (!begin || !end) return false;
+    const changes: Array<{ from: number; to: number; insert?: string }> = [];
+    // drop the \begin/\end lines (with their newlines) …
+    const beginTo = state.doc.sliceString(begin.to, begin.to + 1) === '\n' ? begin.to + 1 : begin.to;
+    const endFrom = state.doc.sliceString(end.from - 1, end.from) === '\n' ? end.from - 1 : end.from;
+    changes.push({ from: begin.from, to: beginTo }, { from: endFrom, to: end.to });
+    // …and every \item prefix inside
+    const re = /\\item\s?/g;
+    const body = state.doc.sliceString(beginTo, endFrom);
+    for (let m = re.exec(body); m; m = re.exec(body)) {
+      changes.push({ from: beginTo + m.index, to: beginTo + m.index + m[0].length });
+    }
+    view.dispatch({ changes });
+    return true;
+  }
+  const fromLine = state.doc.lineAt(sel.from);
+  const toLine = state.doc.lineAt(sel.to);
+  const changes: Array<{ from: number; insert: string }> = [];
+  for (let ln = fromLine.number; ln <= toLine.number; ln++) {
+    const line = state.doc.line(ln);
+    if (line.text.trim()) changes.push({ from: line.from, insert: '\\item ' });
+  }
+  changes.push({ from: fromLine.from, insert: '\\begin{itemize}\n' });
+  changes.push({ from: toLine.to, insert: '\n\\end{itemize}' });
+  view.dispatch({ changes });
+  return true;
+}
+
+/** Current heading level at the cursor (for the toolbar dropdown), or null. */
+export function sectionLevelAt(state: EditorState, pos: number): number | null {
+  const sect = ancestor(state, pos, 'SectioningCommand');
+  if (!sect) return null;
+  let tok: SyntaxNode | null = sect.firstChild;
+  while (tok && !SECTION_TOKENS.has(tok.name)) tok = tok.nextSibling;
+  if (!tok) return null;
+  const text = state.doc.sliceString(tok.from, tok.to);
+  const idx = SECTION_CMDS.indexOf(text as (typeof SECTION_CMDS)[number]);
+  return idx === -1 ? 1 : idx + 1;
+}

--- a/apps/web/src/editor/visual/context.ts
+++ b/apps/web/src/editor/visual/context.ts
@@ -1,0 +1,41 @@
+import { api, BibEntry } from '../../api';
+import { pokeViews } from './refresh';
+
+/**
+ * Project context for widgets that need more than the document text (cite
+ * labels from the bibliography, image URLs). Set by visualExtensions() when a
+ * pane mounts; decoration building itself stays pure.
+ */
+let ctx: { projectId: string; branch: string } | null = null;
+let bib: BibEntry[] | null = null;
+let bibKey = '';
+
+export function setVisualContext(projectId: string, branch: string): void {
+  ctx = { projectId, branch };
+  const key = `${projectId}::${branch}`;
+  if (key !== bibKey) {
+    bibKey = key;
+    bib = null;
+    api.bib(projectId, branch)
+      .then((entries) => { bib = entries; pokeViews(); })
+      .catch(() => { bib = []; });
+  }
+}
+
+/** "(Knuth 1984; Lamport 1994)" for a comma-separated key list, best effort. */
+export function citeLabel(keys: string): string | null {
+  if (!bib) return null;
+  const parts = keys.split(',').map((k) => k.trim()).filter(Boolean).map((key) => {
+    const e = bib!.find((b) => b.key === key);
+    if (!e) return key;
+    const surname = (e.author || '').split(/\s+and\s+|,/)[0].trim().split(/\s+/).pop() || key;
+    return e.year ? `${surname} ${e.year}` : surname;
+  });
+  return parts.length ? parts.join('; ') : null;
+}
+
+/** Raw file URL inside the current project (for figure image previews). */
+export function fileUrl(path: string): string | null {
+  if (!ctx) return null;
+  return `/api/projects/${ctx.projectId}/file?branch=${encodeURIComponent(ctx.branch)}&path=${encodeURIComponent(path)}`;
+}

--- a/apps/web/src/editor/visual/decorations.ts
+++ b/apps/web/src/editor/visual/decorations.ts
@@ -4,6 +4,8 @@ import { syntaxTree } from '@codemirror/language';
 import type { SyntaxNode } from '@lezer/common';
 import { RevealRange, intersectsReveal } from './reveal';
 import { MathWidget } from './widgets/math';
+import { figureChip, tableChip, citeChip, refChip } from './widgets/chips';
+import { ItemMarkerWidget } from './widgets/listMarker';
 
 /** Copied from codemirror-lang-latex (internal SECTION_RANK, not exported). */
 export const SECTION_RANK: Record<string, number> = {
@@ -84,14 +86,91 @@ function wrapperParts(node: SyntaxNode, argName: string) {
  * constructs) stays raw source. Verbatim subtrees are never entered. Nodes
  * intersecting a reveal range are skipped (their source shows).
  */
+/** First braced-argument interior text of a node (e.g. a caption), trimmed. */
+function argText(node: SyntaxNode, doc: { sliceString(from: number, to: number): string }): string {
+  const arg = node.getChild('TextArgument') ?? node.getChild('ShortTextArgument');
+  const open = arg?.getChild('OpenBrace');
+  const close = arg?.getChild('CloseBrace');
+  if (!arg || !open || !close) return '';
+  return doc.sliceString(open.to, close.from).trim().slice(0, 60);
+}
+
+function findDescendant(node: SyntaxNode, name: string): SyntaxNode | null {
+  const c = node.cursor();
+  do {
+    if (c.name === name) return c.node;
+  } while (c.next() && c.from < node.to);
+  return null;
+}
+
+const itemLine = Decoration.line({ class: 'cm-vis-li' });
+
 export function walk(state: EditorState, reveals: readonly RevealRange[], from: number, to: number, emit: WalkEmit): void {
   const doc = state.doc;
+  // enumerate counters per list nesting depth
+  const listStack: Array<{ name: string; counter: number }> = [];
   syntaxTree(state).iterate({
     from,
     to,
+    leave(n) {
+      if (n.name === 'ListEnvironment') listStack.pop();
+    },
     enter(n) {
       if (n.name === 'VerbatimEnvironment') return false;
       if (n.name === 'Comment') return false;
+
+      if (n.name === 'ListEnvironment') {
+        const envName = findDescendant(n.node, 'ListEnvName');
+        listStack.push({ name: envName ? doc.sliceString(envName.from, envName.to) : 'itemize', counter: 0 });
+        return; // walk into items and nested content
+      }
+      if (n.name === 'BeginEnv' || n.name === 'EndEnv') {
+        const inList = listStack.length > 0;
+        if (!inList || intersectsReveal(reveals, n.from, n.to)) return;
+        // hide the \begin{...}/\end{...} line including one adjacent newline so
+        // the list reads as a block; bail out near doc edges or odd layouts.
+        let hideFrom = n.from;
+        let hideTo = n.to;
+        if (n.name === 'BeginEnv' && hideTo < doc.length && doc.sliceString(hideTo, hideTo + 1) === '\n') hideTo += 1;
+        else if (n.name === 'EndEnv' && hideFrom > 0 && doc.sliceString(hideFrom - 1, hideFrom) === '\n') hideFrom -= 1;
+        emit.atomic(hideFrom, hideTo, hide);
+        return;
+      }
+      if (n.name === 'Item') {
+        const top = listStack[listStack.length - 1];
+        const tok = n.node.getChild('ItemCtrlSeq');
+        if (!top || !tok || intersectsReveal(reveals, tok.from, tok.to)) return;
+        let markerTo = tok.to;
+        if (doc.sliceString(markerTo, markerTo + 1) === ' ') markerTo += 1;
+        const marker = top.name === 'enumerate' ? `${++top.counter}. ` : top.name === 'description' ? '– ' : '•  ';
+        emit.atomic(tok.from, markerTo, Decoration.replace({ widget: new ItemMarkerWidget(marker) }));
+        emit.mark(doc.lineAt(tok.from).from, doc.lineAt(tok.from).from, itemLine);
+        return;
+      }
+
+      if (n.name === 'FigureEnvironment' || n.name === 'TableEnvironment' || n.name === 'TabularEnvironment') {
+        if (intersectsReveal(reveals, n.from, n.to)) return; // revealed: show raw source
+        const end = n.node.getChild('EndEnv');
+        if (!end || end.to !== n.to) return; // incomplete env stays raw
+        const caption = findDescendant(n.node, 'Caption');
+        const label = caption ? argText(caption, doc) : '';
+        const chip = n.name === 'FigureEnvironment' ? figureChip(label, n.from) : tableChip(label, n.from);
+        emit.atomic(n.from, n.to, Decoration.replace({ widget: chip }));
+        return false;
+      }
+
+      if (n.name === 'Cite' || n.name === 'Ref') {
+        if (intersectsReveal(reveals, n.from, n.to)) return;
+        const argName = n.name === 'Cite' ? 'BibKeyArgument' : 'RefArgument';
+        const arg = n.node.getChild(argName);
+        const inner = arg?.getChild('ShortTextArgument') ?? arg;
+        const open = inner?.getChild('OpenBrace');
+        const close = inner?.getChild('CloseBrace');
+        if (!inner || !open || !close || close.to !== n.to) return;
+        const keys = doc.sliceString(open.to, close.from).trim();
+        emit.atomic(n.from, n.to, Decoration.replace({ widget: n.name === 'Cite' ? citeChip(keys, n.from) : refChip(keys, n.from) }));
+        return false;
+      }
 
       const rank = SECTION_RANK[n.name];
       if (rank) {

--- a/apps/web/src/editor/visual/decorations.ts
+++ b/apps/web/src/editor/visual/decorations.ts
@@ -1,0 +1,163 @@
+import { EditorState, RangeSetBuilder } from '@codemirror/state';
+import { Decoration, DecorationSet, WidgetType } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import { RevealRange, intersectsReveal } from './reveal';
+import { MathWidget } from './widgets/math';
+
+/** Copied from codemirror-lang-latex (internal SECTION_RANK, not exported). */
+export const SECTION_RANK: Record<string, number> = {
+  Book: 1, Part: 1, Chapter: 1,
+  Section: 1, SubSection: 2, SubSubSection: 3,
+  Paragraph: 4, SubParagraph: 4,
+};
+
+const STYLE_CLASS: Record<string, string> = {
+  TextBoldCommand: 'cm-vis-b',
+  TextItalicCommand: 'cm-vis-i',
+  EmphasisCommand: 'cm-vis-i',
+  UnderlineCommand: 'cm-vis-u',
+  TextSmallCapsCommand: 'cm-vis-sc',
+};
+
+const hide = Decoration.replace({});
+const styleMarks = Object.fromEntries(
+  Object.entries(STYLE_CLASS).map(([k, cls]) => [k, Decoration.mark({ class: cls })]),
+) as Record<string, Decoration>;
+const headingLines = [1, 2, 3, 4].map((n) => Decoration.line({ class: `cm-vis-h cm-vis-h${n}` }));
+
+export interface WalkEmit {
+  /** Decoration.replace/widget material + atomic ranges (full-doc StateField). */
+  atomic(from: number, to: number, deco: Decoration): void;
+  /** Styling marks / line classes (viewport ViewPlugin). */
+  mark(from: number, to: number, deco: Decoration): void;
+}
+
+/**
+ * Extract renderable math from a math node, or null if `name` isn't math or
+ * the construct is incomplete. Equation-array content is wrapped in `aligned`
+ * so KaTeX can typeset the `&`/`\\` alignment.
+ */
+function mathParts(name: string, node: SyntaxNode, doc: { sliceString(from: number, to: number): string }): { source: string; display: boolean } | null {
+  const slice = (a: number, b: number) => doc.sliceString(a, b).trim();
+  if (name === 'DollarMath') {
+    const inner = node.getChild('InlineMath') ?? node.getChild('DisplayMath');
+    const dollars = node.getChildren('Dollar');
+    if (!inner || dollars.length < 2) return null;
+    return { source: slice(inner.from, inner.to), display: inner.name === 'DisplayMath' };
+  }
+  if (name === 'BracketMath' || name === 'ParenMath') {
+    const open = node.getChild(name === 'BracketMath' ? 'OpenBracketMath' : 'OpenParenMath');
+    const close = node.getChild(name === 'BracketMath' ? 'CloseBracketMath' : 'CloseParenMath');
+    if (!open || !close) return null;
+    return { source: slice(open.to, close.from), display: name === 'BracketMath' };
+  }
+  if (name === 'EquationEnvironment' || name === 'EquationArrayEnvironment') {
+    const begin = node.getChild('BeginEnv');
+    const end = node.getChild('EndEnv');
+    if (!begin || !end || end.to !== node.to) return null;
+    const body = slice(begin.to, end.from);
+    return {
+      source: name === 'EquationArrayEnvironment' ? `\\begin{aligned}${body}\\end{aligned}` : body,
+      display: true,
+    };
+  }
+  return null;
+}
+
+/**
+ * The argument interior of a `\cmd{...}` wrapper: returns the hide ranges for
+ * `\cmd{` and `}` plus the interior span — or null when the construct is
+ * incomplete (unclosed brace ⇒ leave as raw source).
+ */
+function wrapperParts(node: SyntaxNode, argName: string) {
+  const arg = node.getChild(argName);
+  const open = arg?.getChild('OpenBrace');
+  const close = arg?.getChild('CloseBrace');
+  if (!arg || !open || !close || close.to !== node.to) return null;
+  return { openEnd: open.to, closeFrom: close.from, closeTo: close.to };
+}
+
+/**
+ * Single tree walk over [from,to] emitting visual decorations. Whitelist-only:
+ * anything not positively matched (unknown commands, ⚠ errors, unclosed
+ * constructs) stays raw source. Verbatim subtrees are never entered. Nodes
+ * intersecting a reveal range are skipped (their source shows).
+ */
+export function walk(state: EditorState, reveals: readonly RevealRange[], from: number, to: number, emit: WalkEmit): void {
+  const doc = state.doc;
+  syntaxTree(state).iterate({
+    from,
+    to,
+    enter(n) {
+      if (n.name === 'VerbatimEnvironment') return false;
+      if (n.name === 'Comment') return false;
+
+      const rank = SECTION_RANK[n.name];
+      if (rank) {
+        const cmd = n.node.getChild('SectioningCommand');
+        if (!cmd || intersectsReveal(reveals, cmd.from, cmd.to)) return;
+        const parts = wrapperParts(cmd, 'SectioningArgument');
+        if (!parts || parts.closeTo !== cmd.to) return;
+        emit.atomic(cmd.from, parts.openEnd, hide);
+        emit.atomic(parts.closeFrom, parts.closeTo, hide);
+        emit.mark(doc.lineAt(cmd.from).from, doc.lineAt(cmd.from).from, headingLines[rank - 1]);
+        return; // children of the heading argument render as plain heading text
+      }
+
+      const math = mathParts(n.name, n.node, doc);
+      if (math) {
+        if (intersectsReveal(reveals, n.from, n.to)) return false;
+        emit.atomic(n.from, n.to, Decoration.replace({ widget: new MathWidget(math.source, math.display, n.from) }));
+        return false; // math interior is the widget's business
+      }
+
+      const styleMark = styleMarks[n.name];
+      if (styleMark) {
+        if (intersectsReveal(reveals, n.from, n.to)) return;
+        const parts = wrapperParts(n.node, 'TextArgument');
+        if (!parts) return;
+        emit.atomic(n.from, parts.openEnd, hide);
+        emit.atomic(parts.closeFrom, parts.closeTo, hide);
+        if (parts.openEnd < parts.closeFrom) emit.mark(parts.openEnd, parts.closeFrom, styleMark);
+        return; // interior may nest further styles; walk continues into it
+      }
+    },
+  });
+}
+
+/** Full-document atomic set (replace decorations). */
+export function buildAtomic(state: EditorState, reveals: readonly RevealRange[]): DecorationSet {
+  const ranges: Array<{ from: number; to: number; deco: Decoration }> = [];
+  walk(state, reveals, 0, state.doc.length, {
+    atomic: (from, to, deco) => { if (from < to) ranges.push({ from, to, deco }); },
+    mark: () => {},
+  });
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+  const b = new RangeSetBuilder<Decoration>();
+  for (const r of ranges) b.add(r.from, r.to, r.deco);
+  return b.finish();
+}
+
+/** Viewport mark/line set for the given visible ranges. */
+export function buildMarks(state: EditorState, reveals: readonly RevealRange[], visible: readonly { from: number; to: number }[]): DecorationSet {
+  const ranges: Array<{ from: number; to: number; deco: Decoration }> = [];
+  for (const v of visible) {
+    walk(state, reveals, v.from, v.to, {
+      atomic: () => {},
+      mark: (from, to, deco) => ranges.push({ from, to, deco }),
+    });
+  }
+  // line decorations are zero-length at line start and must precede marks there
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+  const b = new RangeSetBuilder<Decoration>();
+  let prev: { from: number; to: number } | null = null;
+  for (const r of ranges) {
+    if (prev && prev.from === r.from && prev.to === r.to) continue; // dedupe overlapping viewport chunks
+    b.add(r.from, r.to, r.deco);
+    prev = r;
+  }
+  return b.finish();
+}
+
+export { WidgetType };

--- a/apps/web/src/editor/visual/decorations.ts
+++ b/apps/web/src/editor/visual/decorations.ts
@@ -5,6 +5,7 @@ import type { SyntaxNode } from '@lezer/common';
 import { RevealRange, intersectsReveal } from './reveal';
 import { MathWidget } from './widgets/math';
 import { figureChip, tableChip, citeChip, refChip } from './widgets/chips';
+import { TableWidget, parseTabular } from './widgets/table';
 import { ItemMarkerWidget } from './widgets/listMarker';
 
 /** Copied from codemirror-lang-latex (internal SECTION_RANK, not exported). */
@@ -40,19 +41,19 @@ export interface WalkEmit {
  * the construct is incomplete. Equation-array content is wrapped in `aligned`
  * so KaTeX can typeset the `&`/`\\` alignment.
  */
-function mathParts(name: string, node: SyntaxNode, doc: { sliceString(from: number, to: number): string }): { source: string; display: boolean } | null {
+function mathParts(name: string, node: SyntaxNode, doc: { sliceString(from: number, to: number): string }): { source: string; display: boolean; innerFrom: number; innerTo: number } | null {
   const slice = (a: number, b: number) => doc.sliceString(a, b).trim();
   if (name === 'DollarMath') {
     const inner = node.getChild('InlineMath') ?? node.getChild('DisplayMath');
     const dollars = node.getChildren('Dollar');
     if (!inner || dollars.length < 2) return null;
-    return { source: slice(inner.from, inner.to), display: inner.name === 'DisplayMath' };
+    return { source: slice(inner.from, inner.to), display: inner.name === 'DisplayMath', innerFrom: inner.from, innerTo: inner.to };
   }
   if (name === 'BracketMath' || name === 'ParenMath') {
     const open = node.getChild(name === 'BracketMath' ? 'OpenBracketMath' : 'OpenParenMath');
     const close = node.getChild(name === 'BracketMath' ? 'CloseBracketMath' : 'CloseParenMath');
     if (!open || !close) return null;
-    return { source: slice(open.to, close.from), display: name === 'BracketMath' };
+    return { source: slice(open.to, close.from), display: name === 'BracketMath', innerFrom: open.to, innerTo: close.from };
   }
   if (name === 'EquationEnvironment' || name === 'EquationArrayEnvironment') {
     const begin = node.getChild('BeginEnv');
@@ -62,6 +63,8 @@ function mathParts(name: string, node: SyntaxNode, doc: { sliceString(from: numb
     return {
       source: name === 'EquationArrayEnvironment' ? `\\begin{aligned}${body}\\end{aligned}` : body,
       display: true,
+      innerFrom: begin.to,
+      innerTo: end.from,
     };
   }
   return null;
@@ -104,6 +107,7 @@ function findDescendant(node: SyntaxNode, name: string): SyntaxNode | null {
 }
 
 const itemLine = Decoration.line({ class: 'cm-vis-li' });
+const captionMark = Decoration.mark({ class: 'cm-vis-cap' });
 
 export function walk(state: EditorState, reveals: readonly RevealRange[], from: number, to: number, emit: WalkEmit): void {
   const doc = state.doc;
@@ -113,16 +117,16 @@ export function walk(state: EditorState, reveals: readonly RevealRange[], from: 
     from,
     to,
     leave(n) {
-      if (n.name === 'ListEnvironment') listStack.pop();
+      if (n.name === 'ListEnvironment' || n.name === 'TableEnvironment') listStack.pop();
     },
     enter(n) {
       if (n.name === 'VerbatimEnvironment') return false;
       if (n.name === 'Comment') return false;
 
-      if (n.name === 'ListEnvironment') {
-        const envName = findDescendant(n.node, 'ListEnvName');
+      if (n.name === 'ListEnvironment' || n.name === 'TableEnvironment') {
+        const envName = findDescendant(n.node, n.name === 'ListEnvironment' ? 'ListEnvName' : 'TableEnvName');
         listStack.push({ name: envName ? doc.sliceString(envName.from, envName.to) : 'itemize', counter: 0 });
-        return; // walk into items and nested content
+        return; // walk into items / tabular / caption
       }
       if (n.name === 'BeginEnv' || n.name === 'EndEnv') {
         const inList = listStack.length > 0;
@@ -139,7 +143,8 @@ export function walk(state: EditorState, reveals: readonly RevealRange[], from: 
       if (n.name === 'Item') {
         const top = listStack[listStack.length - 1];
         const tok = n.node.getChild('ItemCtrlSeq');
-        if (!top || !tok || intersectsReveal(reveals, tok.from, tok.to)) return;
+        if (!top || !tok || !['itemize', 'enumerate', 'description'].includes(top.name)) return;
+        if (intersectsReveal(reveals, tok.from, tok.to)) return;
         let markerTo = tok.to;
         if (doc.sliceString(markerTo, markerTo + 1) === ' ') markerTo += 1;
         const marker = top.name === 'enumerate' ? `${++top.counter}. ` : top.name === 'description' ? '– ' : '•  ';
@@ -148,14 +153,59 @@ export function walk(state: EditorState, reveals: readonly RevealRange[], from: 
         return;
       }
 
-      if (n.name === 'FigureEnvironment' || n.name === 'TableEnvironment' || n.name === 'TabularEnvironment') {
+      if (n.name === 'Caption') {
+        if (intersectsReveal(reveals, n.from, n.to)) return;
+        const parts = wrapperParts(n.node, 'TextArgument');
+        if (!parts) return;
+        emit.atomic(n.from, parts.openEnd, hide);
+        emit.atomic(parts.closeFrom, parts.closeTo, hide);
+        if (parts.openEnd < parts.closeFrom) emit.mark(parts.openEnd, parts.closeFrom, captionMark);
+        return;
+      }
+
+      if (n.name === 'FigureEnvironment') {
         if (intersectsReveal(reveals, n.from, n.to)) return; // revealed: show raw source
         const end = n.node.getChild('EndEnv');
         if (!end || end.to !== n.to) return; // incomplete env stays raw
         const caption = findDescendant(n.node, 'Caption');
         const label = caption ? argText(caption, doc) : '';
-        const chip = n.name === 'FigureEnvironment' ? figureChip(label, n.from) : tableChip(label, n.from);
-        emit.atomic(n.from, n.to, Decoration.replace({ widget: chip }));
+        let image: string | null = null;
+        const ig = findDescendant(n.node, 'IncludeGraphics');
+        const igArg = ig && (findDescendant(ig, 'FilePathArgument') ?? findDescendant(ig, 'BareFilePathArgument'));
+        if (igArg) {
+          const open = igArg.getChild('OpenBrace');
+          const close = igArg.getChild('CloseBrace');
+          image = open && close ? doc.sliceString(open.to, close.from).trim() : doc.sliceString(igArg.from, igArg.to).trim();
+        }
+        emit.atomic(n.from, n.to, Decoration.replace({ widget: figureChip(label, n.from, image) }));
+        return false;
+      }
+
+      if (n.name === 'TabularEnvironment') {
+        if (intersectsReveal(reveals, n.from, n.to)) return; // revealed: show raw source
+        const begin = n.node.getChild('BeginEnv');
+        const end = n.node.getChild('EndEnv');
+        if (!begin || !end || end.to !== n.to) return;
+        // column spec is the tabular's argument group right after \begin{tabular}
+        const argNode = n.node.getChild('TabularArgument') ?? n.node.getChild('TextArgument') ?? n.node.getChild('NonEmptyGroup');
+        const argOpen = argNode ? (argNode.getChild('OpenBrace') ?? findDescendant(argNode, 'OpenBrace')) : null;
+        const argClose = argNode ? (argNode.getChild('CloseBrace') ?? findDescendant(argNode, 'CloseBrace')) : null;
+        const bodyFrom = argNode ? argNode.to : begin.to;
+        const parsed = parseTabular(doc.sliceString(bodyFrom, end.from), bodyFrom);
+        if (!parsed) {
+          emit.atomic(n.from, n.to, Decoration.replace({ widget: tableChip('', n.from) }));
+          return false;
+        }
+        const cols = Math.max(...parsed.rows.map((r) => r.length));
+        emit.atomic(n.from, n.to, Decoration.replace({
+          widget: new TableWidget({
+            rows: parsed.rows,
+            rowEnds: parsed.rowEnds,
+            cols,
+            rowInsertAt: doc.lineAt(end.from).from,
+            colSpec: argOpen && argClose ? { from: argOpen.to, to: argClose.from } : null,
+          }, doc.sliceString(n.from, n.to), n.from),
+        }));
         return false;
       }
 
@@ -187,7 +237,7 @@ export function walk(state: EditorState, reveals: readonly RevealRange[], from: 
       const math = mathParts(n.name, n.node, doc);
       if (math) {
         if (intersectsReveal(reveals, n.from, n.to)) return false;
-        emit.atomic(n.from, n.to, Decoration.replace({ widget: new MathWidget(math.source, math.display, n.from) }));
+        emit.atomic(n.from, n.to, Decoration.replace({ widget: new MathWidget(math.source, math.display, n.from, math.innerFrom, math.innerTo) }));
         return false; // math interior is the widget's business
       }
 

--- a/apps/web/src/editor/visual/html2latex.ts
+++ b/apps/web/src/editor/visual/html2latex.ts
@@ -1,0 +1,101 @@
+/**
+ * Convert pasted rich text (HTML from Word, Google Docs, web pages) into
+ * clean LaTeX. Deliberately conservative: unknown markup degrades to its
+ * plain text; nothing invents structure that wasn't in the clipboard.
+ */
+
+const SPECIALS: Record<string, string> = {
+  '\\': '\\textbackslash{}',
+  '&': '\\&', '%': '\\%', '$': '\\$', '#': '\\#', '_': '\\_',
+  '{': '\\{', '}': '\\}', '~': '\\textasciitilde{}', '^': '\\textasciicircum{}',
+};
+
+export function escapeLatex(text: string): string {
+  return text.replace(/[\\&%$#_{}~^]/g, (c) => SPECIALS[c]);
+}
+
+function isBlock(el: Element): boolean {
+  return /^(p|div|h[1-6]|ul|ol|li|table|tr|blockquote|br|section|article)$/i.test(el.tagName);
+}
+
+function convertChildren(node: Node): string {
+  let out = '';
+  node.childNodes.forEach((child) => { out += convertNode(child); });
+  return out;
+}
+
+function convertTable(el: Element): string {
+  const rows = Array.from(el.querySelectorAll('tr')).map((tr) =>
+    Array.from(tr.querySelectorAll('td,th')).map((td) => convertChildren(td).trim().replace(/\n+/g, ' ')),
+  ).filter((r) => r.length);
+  if (!rows.length) return '';
+  const cols = Math.max(...rows.map((r) => r.length));
+  const body = rows.map((r) => {
+    while (r.length < cols) r.push('');
+    return `${r.join(' & ')} \\\\`;
+  }).join('\n');
+  return `\n\\begin{tabular}{${'l'.repeat(cols)}}\n${body}\n\\end{tabular}\n`;
+}
+
+function convertList(el: Element, ordered: boolean): string {
+  const items = Array.from(el.children)
+    .filter((c) => c.tagName.toLowerCase() === 'li')
+    .map((li) => `\\item ${convertChildren(li).trim()}`);
+  if (!items.length) return '';
+  const env = ordered ? 'enumerate' : 'itemize';
+  return `\n\\begin{${env}}\n${items.join('\n')}\n\\end{${env}}\n`;
+}
+
+function convertNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return escapeLatex((node.textContent || '').replace(/\s+/g, ' '));
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return '';
+  const el = node as Element;
+  const tag = el.tagName.toLowerCase();
+  switch (tag) {
+    case 'b': case 'strong': {
+      const inner = convertChildren(el).trim();
+      return inner ? `\\textbf{${inner}}` : '';
+    }
+    case 'i': case 'em': {
+      const inner = convertChildren(el).trim();
+      return inner ? `\\textit{${inner}}` : '';
+    }
+    case 'u': {
+      const inner = convertChildren(el).trim();
+      return inner ? `\\underline{${inner}}` : '';
+    }
+    case 'code': case 'tt': {
+      const inner = convertChildren(el).trim();
+      return inner ? `\\texttt{${inner}}` : '';
+    }
+    case 'h1': return `\n\\section{${convertChildren(el).trim()}}\n`;
+    case 'h2': return `\n\\subsection{${convertChildren(el).trim()}}\n`;
+    case 'h3': case 'h4': case 'h5': case 'h6':
+      return `\n\\subsubsection{${convertChildren(el).trim()}}\n`;
+    case 'a': {
+      const href = el.getAttribute('href');
+      const inner = convertChildren(el).trim();
+      if (!href || href.startsWith('#') || href === inner) return inner ? `\\url{${href ?? inner}}` : '';
+      return `\\href{${href}}{${inner}}`;
+    }
+    case 'ul': return convertList(el, false);
+    case 'ol': return convertList(el, true);
+    case 'table': return convertTable(el);
+    case 'br': return '\n';
+    case 'style': case 'script': case 'head': case 'meta': case 'title': return '';
+    default: {
+      const inner = convertChildren(el);
+      return isBlock(el) ? `${inner.replace(/\s+$/, '')}\n\n` : inner;
+    }
+  }
+}
+
+export function htmlToLatex(html: string): string {
+  const dom = new DOMParser().parseFromString(html, 'text/html');
+  return convertNode(dom.body)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/apps/web/src/editor/visual/index.ts
+++ b/apps/web/src/editor/visual/index.ts
@@ -6,17 +6,55 @@ import { revealField } from './reveal';
 import { atomicField } from './atomicField';
 import { markPlugin } from './markPlugin';
 import { visualTheme } from './theme';
-import { ensureKatex, registerView, unregisterView } from './katex';
+import { ensureKatex } from './katex';
+import { registerView, unregisterView } from './refresh';
+import { setVisualContext } from './context';
+import { suggestField } from './suggestions';
+import { docEditBridge } from './bridge';
+import { htmlToLatex } from './html2latex';
+import { openMathEditor, closeMathPopover } from './mathPopover';
 import { remoteCaretReveal } from './remoteCarets';
 
-/** Clicking a rendered widget puts the caret inside its construct → reveal. */
+/**
+ * Clicking a rendered widget: math opens the MathLive editor; chips put the
+ * caret inside their construct → cursor-reveal shows the source.
+ */
 const widgetClick = EditorView.domEventHandlers({
   mousedown(e, view) {
     const t = (e.target as HTMLElement).closest?.('[data-pos].cm-vis-math, [data-pos].cm-vis-chip') as HTMLElement | null;
     if (!t?.dataset.pos) return false;
+    if (t.classList.contains('cm-vis-math') && t.dataset.innerFrom) {
+      const innerFrom = Number(t.dataset.innerFrom);
+      const innerTo = Number(t.dataset.innerTo);
+      e.preventDefault();
+      openMathEditor(view, {
+        innerFrom,
+        innerTo,
+        source: view.state.doc.sliceString(innerFrom, innerTo),
+        rect: t.getBoundingClientRect(),
+      });
+      return true;
+    }
+    closeMathPopover();
     const pos = Math.min(Number(t.dataset.pos) + 1, view.state.doc.length);
     view.dispatch({ selection: { anchor: pos }, scrollIntoView: true });
     view.focus();
+    return true;
+  },
+});
+
+/** Rich-text paste converts to clean LaTeX instead of dumping plain text. */
+const pasteLatex = EditorView.domEventHandlers({
+  paste(e, view) {
+    const html = e.clipboardData?.getData('text/html');
+    if (!html) return false;
+    // skip clipboard that is already LaTeX-ish plain text (own-editor copies)
+    const text = e.clipboardData?.getData('text/plain') ?? '';
+    if (/\\(section|textbf|begin|item|cite)\b/.test(text)) return false;
+    const latex = htmlToLatex(html);
+    if (!latex || latex === text.trim()) return false;
+    e.preventDefault();
+    view.dispatch(view.state.replaceSelection(latex));
     return true;
   },
 });
@@ -42,5 +80,6 @@ export interface VisualDeps {
  * by explicit user edits and the formatting commands in ./commands.ts.
  */
 export function visualExtensions(deps: VisualDeps): Extension {
-  return [revealField, atomicField, markPlugin, visualTheme, widgetClick, katexLifecycle, remoteCaretReveal(deps.awareness)];
+  setVisualContext(deps.projectId, deps.branch);
+  return [revealField, atomicField, markPlugin, visualTheme, widgetClick, pasteLatex, katexLifecycle, suggestField, docEditBridge, remoteCaretReveal(deps.awareness)];
 }

--- a/apps/web/src/editor/visual/index.ts
+++ b/apps/web/src/editor/visual/index.ts
@@ -1,0 +1,20 @@
+import type { Extension } from '@codemirror/state';
+import type * as Y from 'yjs';
+import type { Awareness } from 'y-protocols/awareness';
+
+/** Everything the visual mode needs from the hosting CodePane. */
+export interface VisualDeps {
+  projectId: string;
+  branch: string;
+  ydoc: Y.Doc;
+  awareness: Awareness;
+}
+
+/**
+ * The Visual editing mode: a pure decoration layer over the shared Y.Text.
+ * It never dispatches document changes — source bytes are only ever modified
+ * by explicit user edits and the formatting commands in ./commands.ts.
+ */
+export function visualExtensions(_deps: VisualDeps): Extension {
+  return []; // Phase 0 scaffolding — populated in later phases.
+}

--- a/apps/web/src/editor/visual/index.ts
+++ b/apps/web/src/editor/visual/index.ts
@@ -1,6 +1,31 @@
 import type { Extension } from '@codemirror/state';
+import { EditorView, ViewPlugin } from '@codemirror/view';
 import type * as Y from 'yjs';
 import type { Awareness } from 'y-protocols/awareness';
+import { revealField } from './reveal';
+import { atomicField } from './atomicField';
+import { markPlugin } from './markPlugin';
+import { visualTheme } from './theme';
+import { ensureKatex, registerView, unregisterView } from './katex';
+
+/** Clicking a rendered widget puts the caret inside its construct → reveal. */
+const widgetClick = EditorView.domEventHandlers({
+  mousedown(e, view) {
+    const t = (e.target as HTMLElement).closest?.('[data-pos].cm-vis-math, [data-pos].cm-vis-chip') as HTMLElement | null;
+    if (!t?.dataset.pos) return false;
+    const pos = Math.min(Number(t.dataset.pos) + 1, view.state.doc.length);
+    view.dispatch({ selection: { anchor: pos }, scrollIntoView: true });
+    view.focus();
+    return true;
+  },
+});
+
+/** Kick the lazy KaTeX chunk and keep the view re-measurable when it lands. */
+const katexLifecycle = ViewPlugin.define((view) => {
+  registerView(view);
+  ensureKatex();
+  return { destroy: () => unregisterView(view) };
+});
 
 /** Everything the visual mode needs from the hosting CodePane. */
 export interface VisualDeps {
@@ -16,5 +41,5 @@ export interface VisualDeps {
  * by explicit user edits and the formatting commands in ./commands.ts.
  */
 export function visualExtensions(_deps: VisualDeps): Extension {
-  return []; // Phase 0 scaffolding — populated in later phases.
+  return [revealField, atomicField, markPlugin, visualTheme, widgetClick, katexLifecycle];
 }

--- a/apps/web/src/editor/visual/index.ts
+++ b/apps/web/src/editor/visual/index.ts
@@ -7,6 +7,7 @@ import { atomicField } from './atomicField';
 import { markPlugin } from './markPlugin';
 import { visualTheme } from './theme';
 import { ensureKatex, registerView, unregisterView } from './katex';
+import { remoteCaretReveal } from './remoteCarets';
 
 /** Clicking a rendered widget puts the caret inside its construct → reveal. */
 const widgetClick = EditorView.domEventHandlers({
@@ -40,6 +41,6 @@ export interface VisualDeps {
  * It never dispatches document changes — source bytes are only ever modified
  * by explicit user edits and the formatting commands in ./commands.ts.
  */
-export function visualExtensions(_deps: VisualDeps): Extension {
-  return [revealField, atomicField, markPlugin, visualTheme, widgetClick, katexLifecycle];
+export function visualExtensions(deps: VisualDeps): Extension {
+  return [revealField, atomicField, markPlugin, visualTheme, widgetClick, katexLifecycle, remoteCaretReveal(deps.awareness)];
 }

--- a/apps/web/src/editor/visual/katex.ts
+++ b/apps/web/src/editor/visual/katex.ts
@@ -1,0 +1,56 @@
+import type { EditorView } from '@codemirror/view';
+
+/**
+ * Lazy KaTeX: loaded (with its CSS) only when visual mode first renders math,
+ * as its own Vite chunk — the source-mode bundle is untouched. Until the
+ * module arrives, math widgets show styled raw source; registered views get a
+ * re-measure poke when rendering becomes available.
+ */
+type Katex = typeof import('katex').default;
+
+let katex: Katex | null = null;
+let loading: Promise<void> | null = null;
+const views = new Set<EditorView>();
+
+export function registerView(view: EditorView): void {
+  views.add(view);
+}
+export function unregisterView(view: EditorView): void {
+  views.delete(view);
+}
+
+export function ensureKatex(): void {
+  if (katex || loading) return;
+  // @ts-expect-error -- CSS import is handled by Vite, not TS
+  loading = Promise.all([import('katex'), import('katex/dist/katex.min.css')])
+    .then(([mod]) => {
+      katex = mod.default;
+      for (const v of views) v.requestMeasure();
+      // widgets compare by source string; force a redraw so toDOM reruns
+      for (const v of views) v.dispatch({});
+    })
+    .catch(() => { loading = null; });
+}
+
+const cache = new Map<string, string>();
+const CACHE_MAX = 500;
+
+/** Rendered HTML for a math source, or null while KaTeX is still loading. */
+export function renderMath(source: string, displayMode: boolean): string | null {
+  if (!katex) { ensureKatex(); return null; }
+  const key = `${displayMode ? 'D' : 'I'}:${source}`;
+  const hit = cache.get(key);
+  if (hit !== undefined) return hit;
+  let html: string;
+  try {
+    html = katex.renderToString(source, { displayMode, throwOnError: false, output: 'html' });
+  } catch {
+    return ''; // signals render failure → widget falls back to raw source
+  }
+  if (cache.size >= CACHE_MAX) {
+    const first = cache.keys().next().value;
+    if (first !== undefined) cache.delete(first);
+  }
+  cache.set(key, html);
+  return html;
+}

--- a/apps/web/src/editor/visual/katex.ts
+++ b/apps/web/src/editor/visual/katex.ts
@@ -1,4 +1,4 @@
-import type { EditorView } from '@codemirror/view';
+import { pokeViews } from './refresh';
 
 /**
  * Lazy KaTeX: loaded (with its CSS) only when visual mode first renders math,
@@ -10,14 +10,6 @@ type Katex = typeof import('katex').default;
 
 let katex: Katex | null = null;
 let loading: Promise<void> | null = null;
-const views = new Set<EditorView>();
-
-export function registerView(view: EditorView): void {
-  views.add(view);
-}
-export function unregisterView(view: EditorView): void {
-  views.delete(view);
-}
 
 export function ensureKatex(): void {
   if (katex || loading) return;
@@ -25,9 +17,7 @@ export function ensureKatex(): void {
   loading = Promise.all([import('katex'), import('katex/dist/katex.min.css')])
     .then(([mod]) => {
       katex = mod.default;
-      for (const v of views) v.requestMeasure();
-      // widgets compare by source string; force a redraw so toDOM reruns
-      for (const v of views) v.dispatch({});
+      pokeViews(); // widgets compare by source; a redraw makes toDOM rerun
     })
     .catch(() => { loading = null; });
 }

--- a/apps/web/src/editor/visual/markPlugin.ts
+++ b/apps/web/src/editor/visual/markPlugin.ts
@@ -1,0 +1,26 @@
+import { ViewPlugin, ViewUpdate, EditorView } from '@codemirror/view';
+import type { DecorationSet } from '@codemirror/view';
+import { revealField, RevealState } from './reveal';
+import { buildMarks } from './decorations';
+
+/** Viewport-only styling marks (headings, bold, italic, …). */
+export const markPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    private forReveal: RevealState;
+
+    constructor(view: EditorView) {
+      this.forReveal = view.state.field(revealField);
+      this.decorations = buildMarks(view.state, this.forReveal.ranges, view.visibleRanges);
+    }
+
+    update(u: ViewUpdate) {
+      const rv = u.state.field(revealField);
+      if (u.docChanged || u.viewportChanged || rv !== this.forReveal) {
+        this.forReveal = rv;
+        this.decorations = buildMarks(u.state, rv.ranges, u.view.visibleRanges);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations },
+);

--- a/apps/web/src/editor/visual/mathPopover.ts
+++ b/apps/web/src/editor/visual/mathPopover.ts
@@ -1,0 +1,96 @@
+import type { EditorView } from '@codemirror/view';
+
+/**
+ * WYSIWYG math editing: clicking a rendered equation opens a floating
+ * MathLive field. "Done" writes the edited LaTeX back as one precise source
+ * edit (collaborative + undoable); "TeX" drops into raw source instead.
+ * MathLive loads lazily — first open on a cold cache falls back to source
+ * editing rather than blocking.
+ */
+
+interface MathTarget { innerFrom: number; innerTo: number; source: string; rect: DOMRect }
+
+let mathfieldReady: Promise<boolean> | null = null;
+function ensureMathlive(): Promise<boolean> {
+  if (!mathfieldReady) {
+    mathfieldReady = import('mathlive')
+      .then((m) => {
+        // registers <math-field>; keep MathLive's sounds/telemetry off
+        (m as { MathfieldElement?: { soundsDirectory?: string | null } }).MathfieldElement &&
+          ((m as unknown as { MathfieldElement: { soundsDirectory: string | null } }).MathfieldElement.soundsDirectory = null);
+        return true;
+      })
+      .catch(() => false);
+  }
+  return mathfieldReady;
+}
+
+let openPopover: HTMLElement | null = null;
+
+export function closeMathPopover(): void {
+  openPopover?.remove();
+  openPopover = null;
+}
+
+export async function openMathEditor(view: EditorView, target: MathTarget): Promise<void> {
+  closeMathPopover();
+  const ok = await ensureMathlive();
+  const revealSource = () => {
+    closeMathPopover();
+    view.dispatch({ selection: { anchor: Math.min(target.innerFrom, view.state.doc.length) }, scrollIntoView: true });
+    view.focus();
+  };
+  if (!ok) return revealSource();
+
+  const pop = document.createElement('div');
+  pop.className = 'vis-math-popover';
+  pop.setAttribute('data-testid', 'math-popover');
+  pop.style.position = 'fixed';
+  pop.style.left = `${Math.max(8, Math.min(target.rect.left, window.innerWidth - 340))}px`;
+  pop.style.top = `${Math.min(target.rect.bottom + 6, window.innerHeight - 120)}px`;
+
+  const mf = document.createElement('math-field') as HTMLElement & { value: string };
+  mf.setAttribute('data-testid', 'math-field');
+  mf.value = target.source;
+  pop.appendChild(mf);
+
+  const bar = document.createElement('div');
+  bar.className = 'vis-math-popover__bar';
+  const done = document.createElement('button');
+  done.textContent = 'Done';
+  done.className = 'btn btn--primary vis-math-popover__btn';
+  done.setAttribute('data-testid', 'math-popover-done');
+  done.onclick = () => {
+    const next = mf.value;
+    // refuse to write through a stale range (e.g. a concurrent remote edit)
+    const current = view.state.doc.sliceString(target.innerFrom, target.innerTo);
+    closeMathPopover();
+    if (current !== target.source || next === target.source) return;
+    view.dispatch({ changes: { from: target.innerFrom, to: target.innerTo, insert: next }, userEvent: 'input.visual' });
+    view.focus();
+  };
+  const tex = document.createElement('button');
+  tex.textContent = 'TeX';
+  tex.className = 'btn vis-math-popover__btn';
+  tex.setAttribute('data-testid', 'math-popover-source');
+  tex.onclick = revealSource;
+  bar.append(done, tex);
+  pop.appendChild(bar);
+
+  pop.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeMathPopover();
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) done.click();
+    e.stopPropagation();
+  });
+  const onOutside = (e: MouseEvent) => {
+    if (!pop.contains(e.target as Node)) {
+      closeMathPopover();
+      window.removeEventListener('mousedown', onOutside, true);
+    }
+  };
+  window.addEventListener('mousedown', onOutside, true);
+
+  document.body.appendChild(pop);
+  openPopover = pop;
+  (mf as unknown as { focus(): void }).focus?.();
+}

--- a/apps/web/src/editor/visual/outline.ts
+++ b/apps/web/src/editor/visual/outline.ts
@@ -1,0 +1,28 @@
+import type { EditorState } from '@codemirror/state';
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
+import { SECTION_RANK } from './decorations';
+
+export interface OutlineEntry { level: number; title: string; line: number }
+
+/** Headings of the document, in order, for the Contents dropdown. */
+export function documentOutline(state: EditorState): OutlineEntry[] {
+  ensureSyntaxTree(state, state.doc.length, 300);
+  const out: OutlineEntry[] = [];
+  syntaxTree(state).iterate({
+    enter(n) {
+      const rank = SECTION_RANK[n.name];
+      if (!rank) return;
+      const cmd = n.node.getChild('SectioningCommand');
+      const arg = cmd?.getChild('SectioningArgument');
+      const open = arg?.getChild('OpenBrace');
+      const close = arg?.getChild('CloseBrace');
+      if (!cmd || !open || !close) return;
+      out.push({
+        level: rank,
+        title: state.doc.sliceString(open.to, close.from).trim().slice(0, 80) || '(untitled)',
+        line: state.doc.lineAt(cmd.from).number,
+      });
+    },
+  });
+  return out;
+}

--- a/apps/web/src/editor/visual/refresh.ts
+++ b/apps/web/src/editor/visual/refresh.ts
@@ -1,0 +1,17 @@
+import type { EditorView } from '@codemirror/view';
+
+/**
+ * Registry of live visual-mode views, so async resources (KaTeX, bibliography,
+ * MathLive) can poke a redraw when they arrive.
+ */
+const views = new Set<EditorView>();
+
+export function registerView(view: EditorView): void {
+  views.add(view);
+}
+export function unregisterView(view: EditorView): void {
+  views.delete(view);
+}
+export function pokeViews(): void {
+  for (const v of views) v.dispatch({});
+}

--- a/apps/web/src/editor/visual/remoteCarets.ts
+++ b/apps/web/src/editor/visual/remoteCarets.ts
@@ -1,0 +1,51 @@
+import { ViewPlugin } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import { ySyncFacet } from 'y-codemirror.next';
+import type { Awareness } from 'y-protocols/awareness';
+import { setRemoteCarets } from './reveal';
+
+/**
+ * Remote-caret force-reveal: a construct containing a collaborator's caret
+ * shows raw source locally, exactly like a local-cursor reveal. This keeps
+ * yCollab's remote caret decorations inside visible text — a remote caret can
+ * never end up inside a replaced (hidden) range.
+ */
+export function remoteCaretReveal(awareness: Awareness): Extension {
+  return ViewPlugin.define((view) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let last = '';
+    const push = () => {
+      timer = null;
+      const conf = view.state.facet(ySyncFacet);
+      if (!conf) return;
+      const positions: number[] = [];
+      awareness.getStates().forEach((state, clientId) => {
+        if (clientId === awareness.clientID) return;
+        const cursor = (state as { cursor?: { head?: unknown } }).cursor;
+        if (!cursor?.head) return;
+        try {
+          positions.push(conf.fromYPos(cursor.head).pos);
+        } catch {
+          /* stale position from another doc epoch — ignore */
+        }
+      });
+      positions.sort((a, b) => a - b);
+      const key = positions.join(',');
+      if (key === last) return;
+      last = key;
+      view.dispatch({ effects: setRemoteCarets.of(positions) });
+    };
+    const onChange = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(push, 60);
+    };
+    awareness.on('change', onChange);
+    onChange();
+    return {
+      destroy() {
+        awareness.off('change', onChange);
+        if (timer) clearTimeout(timer);
+      },
+    };
+  });
+}

--- a/apps/web/src/editor/visual/reveal.ts
+++ b/apps/web/src/editor/visual/reveal.ts
@@ -14,7 +14,7 @@ const UNIT_NAMES = new Set([
   'TextBoldCommand', 'TextItalicCommand', 'EmphasisCommand', 'UnderlineCommand', 'TextSmallCapsCommand',
   'DollarMath', 'BracketMath', 'ParenMath', 'EquationEnvironment', 'EquationArrayEnvironment',
   'FigureEnvironment', 'TableEnvironment', 'TabularEnvironment',
-  'Cite', 'Ref', 'BeginEnv', 'EndEnv',
+  'Cite', 'Ref', 'BeginEnv', 'EndEnv', 'Caption',
 ]);
 // \item reveals only its marker token, not the item's whole content.
 const ITEM = 'Item';

--- a/apps/web/src/editor/visual/reveal.ts
+++ b/apps/web/src/editor/visual/reveal.ts
@@ -1,0 +1,110 @@
+import { EditorState, StateEffect, StateField } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+
+export interface RevealRange { from: number; to: number }
+
+/**
+ * Node names that form "reveal units": when any caret (local or remote) sits
+ * inside one, that construct shows raw source instead of its rendering.
+ * Innermost unit wins so e.g. bold inside a heading reveals only the bold.
+ */
+const UNIT_NAMES = new Set([
+  'SectioningCommand',
+  'TextBoldCommand', 'TextItalicCommand', 'EmphasisCommand', 'UnderlineCommand', 'TextSmallCapsCommand',
+  'DollarMath', 'BracketMath', 'ParenMath', 'EquationEnvironment', 'EquationArrayEnvironment',
+  'FigureEnvironment', 'TableEnvironment', 'TabularEnvironment',
+  'Cite', 'Ref', 'BeginEnv', 'EndEnv',
+]);
+// \item reveals only its marker token, not the item's whole content.
+const ITEM = 'Item';
+
+/** Remote collaborators' caret offsets (already mapped to this doc). */
+export const setRemoteCarets = StateEffect.define<number[]>();
+
+function unitFor(node: SyntaxNode): RevealRange | null {
+  let n: SyntaxNode | null = node;
+  while (n) {
+    if (n.name === ITEM) {
+      const tok = n.getChild('ItemCtrlSeq');
+      if (tok) return { from: tok.from, to: tok.to };
+    }
+    if (UNIT_NAMES.has(n.name)) return { from: n.from, to: n.to };
+    n = n.parent;
+  }
+  return null;
+}
+
+function pushUnique(out: RevealRange[], r: RevealRange | null) {
+  if (r && !out.some((o) => o.from === r.from && o.to === r.to)) out.push(r);
+}
+
+export function computeRevealRanges(state: EditorState, remote: readonly number[]): RevealRange[] {
+  const tree = syntaxTree(state);
+  const out: RevealRange[] = [];
+  const atPos = (pos: number) => {
+    for (const side of [-1, 1] as const) pushUnique(out, unitFor(tree.resolveInner(pos, side)));
+  };
+  for (const r of state.selection.ranges) {
+    atPos(r.head);
+    if (!r.empty) {
+      atPos(r.anchor);
+      // A selection must never contain invisible bytes: reveal every unit it touches.
+      tree.iterate({
+        from: r.from,
+        to: r.to,
+        enter(n) {
+          if (UNIT_NAMES.has(n.name)) pushUnique(out, { from: n.from, to: n.to });
+          if (n.name === 'VerbatimEnvironment') return false;
+        },
+      });
+    }
+  }
+  for (const pos of remote) {
+    if (pos >= 0 && pos <= state.doc.length) atPos(pos);
+  }
+  out.sort((a, b) => a.from - b.from || a.to - b.to);
+  // merge overlaps so downstream intersection checks are cheap
+  const merged: RevealRange[] = [];
+  for (const r of out) {
+    const last = merged[merged.length - 1];
+    if (last && r.from <= last.to) last.to = Math.max(last.to, r.to);
+    else merged.push({ ...r });
+  }
+  return merged;
+}
+
+function sameRanges(a: RevealRange[], b: RevealRange[]): boolean {
+  return a.length === b.length && a.every((r, i) => r.from === b[i].from && r.to === b[i].to);
+}
+
+export interface RevealState { ranges: RevealRange[]; remote: number[] }
+
+/**
+ * Reveal ranges, recomputed on selection/doc changes and remote-caret updates.
+ * Returns the previous object when nothing changed, so consumers can gate
+ * expensive rebuilds on object identity.
+ */
+export const revealField = StateField.define<RevealState>({
+  create(state) {
+    return { ranges: computeRevealRanges(state, []), remote: [] };
+  },
+  update(value, tr) {
+    let remote = value.remote;
+    for (const e of tr.effects) if (e.is(setRemoteCarets)) remote = e.value;
+    const remoteChanged = remote !== value.remote;
+    if (!tr.docChanged && !tr.selection && !remoteChanged) return value;
+    if (tr.docChanged && !remoteChanged) remote = remote.map((p) => tr.changes.mapPos(p));
+    const ranges = computeRevealRanges(tr.state, remote);
+    if (!remoteChanged && !tr.docChanged && sameRanges(ranges, value.ranges)) return value;
+    return { ranges, remote };
+  },
+});
+
+export function intersectsReveal(reveals: readonly RevealRange[], from: number, to: number): boolean {
+  for (const r of reveals) {
+    if (r.from >= to) break;
+    if (r.to > from) return true;
+  }
+  return false;
+}

--- a/apps/web/src/editor/visual/suggestions.ts
+++ b/apps/web/src/editor/visual/suggestions.ts
@@ -1,0 +1,98 @@
+import { StateField } from '@codemirror/state';
+import { Decoration, EditorView, WidgetType } from '@codemirror/view';
+import type { DecorationSet } from '@codemirror/view';
+import { setComments, CommentRange } from '../commentsEffect';
+
+/**
+ * Inline tracked changes: an unresolved review comment carrying a suggestion
+ * renders as strikethrough over the original text plus the proposed
+ * replacement with accept/dismiss controls — Word-style track changes over
+ * LaTeX. Accepting routes through the exact same API as the Review panel.
+ */
+class SuggestionWidget extends WidgetType {
+  constructor(readonly id: string, readonly text: string) {
+    super();
+  }
+
+  eq(other: SuggestionWidget): boolean {
+    return other.id === this.id && other.text === this.text;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-vis-suggest';
+    el.setAttribute('data-testid', 'vis-suggest');
+    const ins = document.createElement('span');
+    ins.className = 'cm-vis-suggest__ins';
+    ins.textContent = this.text;
+    el.appendChild(ins);
+    const mk = (label: string, title: string, action: 'accept' | 'resolve') => {
+      const b = document.createElement('button');
+      b.className = 'cm-vis-suggest__btn';
+      b.textContent = label;
+      b.title = title;
+      b.setAttribute('data-testid', `vis-suggest-${action}`);
+      b.onmousedown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent('aldine:suggestion', { detail: { id: this.id, action } }));
+      };
+      el.appendChild(b);
+    };
+    mk('✓', 'Accept suggestion', 'accept');
+    mk('✕', 'Dismiss', 'resolve');
+    return el;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+const strike = Decoration.mark({ class: 'cm-vis-strike' });
+
+interface SuggestState { ranges: CommentRange[]; deco: DecorationSet }
+
+function build(ranges: CommentRange[], docLen: number): DecorationSet {
+  const active = ranges
+    .filter((r) => !r.resolved && r.suggestion != null && r.from < r.to && r.to <= docLen)
+    .sort((a, b) => a.from - b.from);
+  const decos = [];
+  for (const r of active) {
+    decos.push(strike.range(r.from, r.to));
+    decos.push(Decoration.widget({ widget: new SuggestionWidget(r.id, r.suggestion!), side: 1 }).range(r.to));
+  }
+  return Decoration.set(decos, true);
+}
+
+export const suggestField = StateField.define<SuggestState>({
+  create() {
+    return { ranges: [], deco: Decoration.none };
+  },
+  update(value, tr) {
+    let ranges = value.ranges;
+    let changed = false;
+    for (const e of tr.effects) {
+      if (e.is(setComments)) {
+        ranges = e.value;
+        changed = true;
+      }
+    }
+    if (tr.docChanged) {
+      // Ranges can arrive before the Yjs doc has synced (doc still empty);
+      // leave anything that doesn't fit the pre-change doc unmapped — build()
+      // only renders ranges valid for the current doc, so they light up once
+      // the content lands instead of crashing the changeset mapping.
+      const startLen = tr.startState.doc.length;
+      ranges = ranges.map((r) =>
+        r.from <= startLen && r.to <= startLen
+          ? { ...r, from: tr.changes.mapPos(r.from), to: tr.changes.mapPos(r.to, 1) }
+          : r,
+      );
+      changed = true;
+    }
+    if (!changed) return value;
+    return { ranges, deco: build(ranges, tr.state.doc.length) };
+  },
+  provide: (f) => EditorView.decorations.from(f, (v) => v.deco),
+});

--- a/apps/web/src/editor/visual/theme.ts
+++ b/apps/web/src/editor/visual/theme.ts
@@ -6,8 +6,9 @@ import { EditorView } from '@codemirror/view';
  * light/dark just work.
  */
 export const visualTheme = EditorView.theme({
-  '&': { fontFamily: 'var(--font-serif)', fontSize: '16px' },
-  '.cm-content': { maxWidth: '46em', margin: '0 auto', padding: '24px 32px', lineHeight: '1.65' },
+  // &.cm-editor beats app.css's .code-pane .cm-scroller mono rule on specificity
+  '&.cm-editor .cm-scroller': { fontFamily: 'var(--font-serif)', fontSize: '16px', lineHeight: '1.65' },
+  '.cm-content': { maxWidth: '46em', margin: '0 auto', padding: '24px 32px' },
   '.cm-gutters': { display: 'none' },
   '.cm-activeLine': { backgroundColor: 'transparent' },
 

--- a/apps/web/src/editor/visual/theme.ts
+++ b/apps/web/src/editor/visual/theme.ts
@@ -26,4 +26,16 @@ export const visualTheme = EditorView.theme({
   '.cm-vis-math:hover': { background: 'var(--accent-soft)' },
   '.cm-vis-math--display': { display: 'block', textAlign: 'center', padding: '8px 0' },
   '.cm-vis-math--raw': { fontFamily: 'var(--font-mono)', fontSize: '0.85em', color: 'var(--syn-command)' },
+
+  '.cm-vis-chip': {
+    display: 'inline-flex', alignItems: 'baseline', gap: '5px', cursor: 'pointer',
+    border: '1px solid var(--hairline)', borderRadius: '6px', padding: '1px 8px',
+    background: 'var(--bg-inset)', fontFamily: 'var(--font-ui)', fontSize: '0.8em',
+  },
+  '.cm-vis-chip:hover': { borderColor: 'var(--hairline-strong)', background: 'var(--bg-hover)' },
+  '.cm-vis-chip__kind': { textTransform: 'uppercase', fontSize: '0.75em', fontWeight: '700', color: 'var(--text-3)', letterSpacing: '0.06em' },
+  '.cm-vis-chip--cite': { color: 'var(--accent)' },
+  '.cm-vis-chip--ref': { color: 'var(--accent)' },
+  '.cm-vis-item': { color: 'var(--text-2)', paddingRight: '2px' },
+  '.cm-vis-li': { paddingLeft: '1.4em' },
 });

--- a/apps/web/src/editor/visual/theme.ts
+++ b/apps/web/src/editor/visual/theme.ts
@@ -1,0 +1,29 @@
+import { EditorView } from '@codemirror/view';
+
+/**
+ * Visual-mode presentation: prose in the serif stack, rendered headings and
+ * styles, editor chrome (gutters) tucked away. Colors ride the app CSS vars so
+ * light/dark just work.
+ */
+export const visualTheme = EditorView.theme({
+  '&': { fontFamily: 'var(--font-serif)', fontSize: '16px' },
+  '.cm-content': { maxWidth: '46em', margin: '0 auto', padding: '24px 32px', lineHeight: '1.65' },
+  '.cm-gutters': { display: 'none' },
+  '.cm-activeLine': { backgroundColor: 'transparent' },
+
+  '.cm-vis-h': { fontFamily: 'var(--font-ui)', fontWeight: '650', lineHeight: '1.3' },
+  '.cm-vis-h1': { fontSize: '1.6em', paddingTop: '0.6em' },
+  '.cm-vis-h2': { fontSize: '1.35em', paddingTop: '0.5em' },
+  '.cm-vis-h3': { fontSize: '1.15em', paddingTop: '0.4em' },
+  '.cm-vis-h4': { fontSize: '1em', paddingTop: '0.3em' },
+
+  '.cm-vis-b': { fontWeight: '700' },
+  '.cm-vis-i': { fontStyle: 'italic' },
+  '.cm-vis-u': { textDecoration: 'underline' },
+  '.cm-vis-sc': { fontVariant: 'small-caps' },
+
+  '.cm-vis-math': { cursor: 'pointer', borderRadius: '4px', padding: '0 1px' },
+  '.cm-vis-math:hover': { background: 'var(--accent-soft)' },
+  '.cm-vis-math--display': { display: 'block', textAlign: 'center', padding: '8px 0' },
+  '.cm-vis-math--raw': { fontFamily: 'var(--font-mono)', fontSize: '0.85em', color: 'var(--syn-command)' },
+});

--- a/apps/web/src/editor/visual/theme.ts
+++ b/apps/web/src/editor/visual/theme.ts
@@ -38,4 +38,34 @@ export const visualTheme = EditorView.theme({
   '.cm-vis-chip--ref': { color: 'var(--accent)' },
   '.cm-vis-item': { color: 'var(--text-2)', paddingRight: '2px' },
   '.cm-vis-li': { paddingLeft: '1.4em' },
+
+  '.cm-vis-strike': { textDecoration: 'line-through', textDecorationColor: 'var(--error)', opacity: '0.75' },
+  '.cm-vis-suggest': { display: 'inline-flex', alignItems: 'center', gap: '3px', margin: '0 3px' },
+  '.cm-vis-suggest__ins': { color: 'var(--ok)', textDecoration: 'underline', textDecorationStyle: 'dotted' },
+  '.cm-vis-suggest__btn': {
+    border: '1px solid var(--hairline)', background: 'var(--bg-inset)', color: 'var(--text-2)',
+    borderRadius: '5px', fontSize: '10px', width: '18px', height: '18px', lineHeight: '1',
+    cursor: 'pointer', padding: '0',
+  },
+  '.cm-vis-suggest__btn:hover': { color: 'var(--text)', borderColor: 'var(--hairline-strong)' },
+
+  '.cm-vis-figure__img': { display: 'block', maxHeight: '140px', maxWidth: '100%', borderRadius: '4px', margin: '2px 0' },
+  '.cm-vis-figure__cap': { display: 'block', fontSize: '0.85em', fontStyle: 'italic', color: 'var(--text-2)' },
+  '.cm-vis-figure': { display: 'inline-block', padding: '6px 10px' },
+  '.cm-vis-cap': { fontStyle: 'italic', color: 'var(--text-2)' },
+
+  '.cm-vis-table': { display: 'inline-block', margin: '4px 0' },
+  '.cm-vis-table__grid': { borderCollapse: 'collapse', fontFamily: 'var(--font-serif)', fontSize: '0.95em' },
+  '.cm-vis-table__grid td': { border: '1px solid var(--hairline)', padding: '3px 10px', cursor: 'text', minWidth: '40px' },
+  '.cm-vis-table__grid td:hover': { background: 'var(--bg-hover)' },
+  '.cm-vis-table__bar': { display: 'flex', gap: '4px', marginTop: '3px' },
+  '.cm-vis-table__btn': {
+    border: '1px solid var(--hairline)', background: 'var(--bg-inset)', color: 'var(--text-2)',
+    borderRadius: '5px', fontSize: '10.5px', fontFamily: 'var(--font-ui)', padding: '1px 7px', cursor: 'pointer',
+  },
+  '.cm-vis-table__btn:hover': { color: 'var(--text)', borderColor: 'var(--hairline-strong)' },
+  '.cm-vis-table__input': {
+    font: 'inherit', color: 'inherit', background: 'var(--bg-panel)', border: '1px solid var(--accent)',
+    borderRadius: '3px', padding: '1px 4px', width: '100%', boxSizing: 'border-box',
+  },
 });

--- a/apps/web/src/editor/visual/widgets/chips.ts
+++ b/apps/web/src/editor/visual/widgets/chips.ts
@@ -1,4 +1,5 @@
 import { WidgetType } from '@codemirror/view';
+import { citeLabel, fileUrl } from '../context';
 
 /** A compact pill standing in for a construct; click puts the caret inside. */
 class Chip extends WidgetType {
@@ -28,14 +29,52 @@ class Chip extends WidgetType {
   }
 }
 
-export function figureChip(caption: string, pos: number): Chip {
-  return new Chip('figure', caption, pos);
+/** Figure with an inline image preview when the included graphic resolves. */
+class FigureWidget extends WidgetType {
+  constructor(readonly caption: string, readonly image: string | null, readonly pos: number) {
+    super();
+  }
+
+  eq(other: FigureWidget): boolean {
+    return other.caption === this.caption && other.image === this.image;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-vis-chip cm-vis-figure';
+    el.dataset.pos = String(this.pos);
+    el.setAttribute('data-testid', 'vis-chip-figure');
+    if (this.image) {
+      const url = fileUrl(this.image);
+      if (url) {
+        const img = document.createElement('img');
+        img.src = url;
+        img.alt = this.caption || this.image;
+        img.className = 'cm-vis-figure__img';
+        img.onerror = () => img.remove();
+        el.appendChild(img);
+      }
+    }
+    const cap = document.createElement('span');
+    cap.className = 'cm-vis-figure__cap';
+    cap.textContent = this.caption ? `Figure: ${this.caption}` : 'Figure';
+    el.appendChild(cap);
+    return el;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    return event.type !== 'mousedown';
+  }
+}
+
+export function figureChip(caption: string, pos: number, image: string | null = null): FigureWidget {
+  return new FigureWidget(caption, image, pos);
 }
 export function tableChip(caption: string, pos: number): Chip {
   return new Chip('table', caption, pos);
 }
 export function citeChip(keys: string, pos: number): Chip {
-  return new Chip('cite', keys, pos);
+  return new Chip('cite', citeLabel(keys) ?? keys, pos);
 }
 export function refChip(target: string, pos: number): Chip {
   return new Chip('ref', target, pos);

--- a/apps/web/src/editor/visual/widgets/chips.ts
+++ b/apps/web/src/editor/visual/widgets/chips.ts
@@ -1,0 +1,42 @@
+import { WidgetType } from '@codemirror/view';
+
+/** A compact pill standing in for a construct; click puts the caret inside. */
+class Chip extends WidgetType {
+  constructor(readonly kind: string, readonly label: string, readonly pos: number) {
+    super();
+  }
+
+  eq(other: Chip): boolean {
+    return other.kind === this.kind && other.label === this.label;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = `cm-vis-chip cm-vis-chip--${this.kind}`;
+    el.dataset.pos = String(this.pos);
+    el.setAttribute('data-testid', `vis-chip-${this.kind}`);
+    const tag = document.createElement('span');
+    tag.className = 'cm-vis-chip__kind';
+    tag.textContent = this.kind;
+    el.appendChild(tag);
+    if (this.label) el.appendChild(document.createTextNode(this.label));
+    return el;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    return event.type !== 'mousedown';
+  }
+}
+
+export function figureChip(caption: string, pos: number): Chip {
+  return new Chip('figure', caption, pos);
+}
+export function tableChip(caption: string, pos: number): Chip {
+  return new Chip('table', caption, pos);
+}
+export function citeChip(keys: string, pos: number): Chip {
+  return new Chip('cite', keys, pos);
+}
+export function refChip(target: string, pos: number): Chip {
+  return new Chip('ref', target, pos);
+}

--- a/apps/web/src/editor/visual/widgets/listMarker.ts
+++ b/apps/web/src/editor/visual/widgets/listMarker.ts
@@ -1,0 +1,20 @@
+import { WidgetType } from '@codemirror/view';
+
+/** Bullet or number replacing an `\item` token. */
+export class ItemMarkerWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+
+  eq(other: ItemMarkerWidget): boolean {
+    return other.text === this.text;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-vis-item';
+    el.setAttribute('data-testid', 'vis-item');
+    el.textContent = this.text;
+    return el;
+  }
+}

--- a/apps/web/src/editor/visual/widgets/math.ts
+++ b/apps/web/src/editor/visual/widgets/math.ts
@@ -6,7 +6,7 @@ import { renderMath } from '../katex';
  * host extension handles the mousedown), which reveals the raw source.
  */
 export class MathWidget extends WidgetType {
-  constructor(readonly source: string, readonly display: boolean, readonly pos: number) {
+  constructor(readonly source: string, readonly display: boolean, readonly pos: number, readonly innerFrom: number, readonly innerTo: number) {
     super();
   }
 
@@ -18,6 +18,8 @@ export class MathWidget extends WidgetType {
     const el = document.createElement(this.display ? 'div' : 'span');
     el.className = `cm-vis-math ${this.display ? 'cm-vis-math--display' : ''}`;
     el.dataset.pos = String(this.pos);
+    el.dataset.innerFrom = String(this.innerFrom);
+    el.dataset.innerTo = String(this.innerTo);
     el.setAttribute('data-testid', 'vis-math');
     const html = renderMath(this.source, this.display);
     if (html) {

--- a/apps/web/src/editor/visual/widgets/math.ts
+++ b/apps/web/src/editor/visual/widgets/math.ts
@@ -1,0 +1,36 @@
+import { WidgetType } from '@codemirror/view';
+import { renderMath } from '../katex';
+
+/**
+ * Rendered math. Clicking places the caret inside the construct (the widget's
+ * host extension handles the mousedown), which reveals the raw source.
+ */
+export class MathWidget extends WidgetType {
+  constructor(readonly source: string, readonly display: boolean, readonly pos: number) {
+    super();
+  }
+
+  eq(other: MathWidget): boolean {
+    return other.source === this.source && other.display === this.display;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement(this.display ? 'div' : 'span');
+    el.className = `cm-vis-math ${this.display ? 'cm-vis-math--display' : ''}`;
+    el.dataset.pos = String(this.pos);
+    el.setAttribute('data-testid', 'vis-math');
+    const html = renderMath(this.source, this.display);
+    if (html) {
+      el.innerHTML = html;
+    } else {
+      // loading or render failure: show the raw source, honestly
+      el.classList.add('cm-vis-math--raw');
+      el.textContent = this.source;
+    }
+    return el;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    return event.type !== 'mousedown';
+  }
+}

--- a/apps/web/src/editor/visual/widgets/table.ts
+++ b/apps/web/src/editor/visual/widgets/table.ts
@@ -1,0 +1,165 @@
+import { WidgetType } from '@codemirror/view';
+
+export interface CellSpan { from: number; to: number; text: string }
+export interface TableModel {
+  rows: CellSpan[][];
+  /** insertion point for a new row (before \end) and the row template */
+  rowInsertAt: number;
+  cols: number;
+  /** column-spec interior range, for add-column */
+  colSpec: { from: number; to: number } | null;
+  /** end offset of each row's last cell — where ` & ` lands for add-column */
+  rowEnds: number[];
+}
+
+const RULE_RE = /^\s*\\(hline|toprule|midrule|bottomrule|cline\{[^}]*\})\s*/;
+
+/**
+ * Scan a tabular body into cells with exact source offsets. Braces guard
+ * nested `&`/`\\`; rule commands are display-stripped. Anything the scanner
+ * can't confidently map keeps the construct raw (caller falls back to a chip).
+ */
+export function parseTabular(body: string, base: number): { rows: CellSpan[][]; rowEnds: number[] } | null {
+  const rows: CellSpan[][] = [];
+  const rowEnds: number[] = [];
+  let cells: CellSpan[] = [];
+  let cellStart = 0;
+  let depth = 0;
+  let i = 0;
+  const pushCell = (end: number) => {
+    let s = cellStart;
+    let e = end;
+    while (s < e && /\s/.test(body[s])) s++;
+    while (e > s && /\s/.test(body[e - 1])) e--;
+    // strip leading rule commands from the display cell (keep offsets honest)
+    const m = RULE_RE.exec(body.slice(s, e));
+    if (m) s += m[0].length;
+    cells.push({ from: base + s, to: base + e, text: body.slice(s, e) });
+  };
+  const pushRow = (end: number) => {
+    pushCell(end);
+    if (cells.length && !(cells.length === 1 && cells[0].text === '')) {
+      rows.push(cells);
+      rowEnds.push(cells[cells.length - 1].to);
+    }
+    cells = [];
+  };
+  while (i < body.length) {
+    const ch = body[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth = Math.max(0, depth - 1);
+    else if (ch === '\\' && body[i + 1] === '\\' && depth === 0) {
+      pushRow(i);
+      i += 2;
+      cellStart = i;
+      continue;
+    } else if (ch === '&' && depth === 0) {
+      pushCell(i);
+      i += 1;
+      cellStart = i;
+      continue;
+    } else if (ch === '\\') {
+      i += 2; // skip escaped char / command intro conservatively
+      continue;
+    }
+    i += 1;
+  }
+  pushRow(body.length);
+  if (!rows.length) return null;
+  return { rows, rowEnds };
+}
+
+/**
+ * Editable grid replacing a tabular environment. Cell commits, add-row and
+ * add-column are dispatched as precise source edits through the doc-edit
+ * bridge; nothing else about the source is touched.
+ */
+export class TableWidget extends WidgetType {
+  constructor(readonly model: TableModel, readonly sourceKey: string, readonly pos: number) {
+    super();
+  }
+
+  eq(other: TableWidget): boolean {
+    return other.sourceKey === this.sourceKey;
+  }
+
+  private edit(from: number, to: number, insert: string) {
+    window.dispatchEvent(new CustomEvent('aldine:doc-edit', { detail: { from, to, insert } }));
+  }
+
+  toDOM(): HTMLElement {
+    const wrap = document.createElement('span');
+    wrap.className = 'cm-vis-table';
+    wrap.setAttribute('data-testid', 'vis-table');
+    const table = document.createElement('table');
+    table.className = 'cm-vis-table__grid';
+    for (const row of this.model.rows) {
+      const tr = document.createElement('tr');
+      for (const cell of row) {
+        const td = document.createElement('td');
+        td.textContent = cell.text;
+        td.title = 'Click to edit';
+        td.onmousedown = (e) => { e.preventDefault(); e.stopPropagation(); this.editCell(td, cell); };
+        tr.appendChild(td);
+      }
+      table.appendChild(tr);
+    }
+    wrap.appendChild(table);
+
+    const bar = document.createElement('span');
+    bar.className = 'cm-vis-table__bar';
+    const btn = (label: string, title: string, onClick: () => void, testid: string) => {
+      const b = document.createElement('button');
+      b.className = 'cm-vis-table__btn';
+      b.textContent = label;
+      b.title = title;
+      b.setAttribute('data-testid', testid);
+      b.onmousedown = (e) => { e.preventDefault(); e.stopPropagation(); onClick(); };
+      bar.appendChild(b);
+    };
+    btn('+ row', 'Add a row', () => {
+      const cols = this.model.cols;
+      this.edit(this.model.rowInsertAt, this.model.rowInsertAt, `${' &'.repeat(cols - 1).replace(/&/g, ' & ').trimStart()} \\\\\n`);
+    }, 'vis-table-addrow');
+    btn('+ col', 'Add a column', () => {
+      // append a column: extend the colspec, then ` & ` at each row end (last first
+      // so earlier offsets stay valid)
+      const edits: Array<[number, string]> = [];
+      for (const end of [...this.model.rowEnds].sort((a, b) => b - a)) edits.push([end, ' & ']);
+      for (const [at, text] of edits) this.edit(at, at, text);
+      if (this.model.colSpec) this.edit(this.model.colSpec.to, this.model.colSpec.to, 'l');
+    }, 'vis-table-addcol');
+    btn('TeX', 'Edit LaTeX source', () => {
+      window.dispatchEvent(new CustomEvent('aldine:goto', { detail: { pos: this.pos + 1 } }));
+    }, 'vis-table-source');
+    wrap.appendChild(bar);
+    return wrap;
+  }
+
+  private editCell(td: HTMLElement, cell: CellSpan) {
+    if (td.querySelector('input')) return;
+    const input = document.createElement('input');
+    input.className = 'cm-vis-table__input';
+    input.value = cell.text;
+    input.setAttribute('data-testid', 'vis-table-cell-input');
+    td.textContent = '';
+    td.appendChild(input);
+    input.focus();
+    input.select();
+    const commit = () => {
+      if (input.value !== cell.text) this.edit(cell.from, cell.to, input.value);
+      else td.textContent = cell.text;
+    };
+    input.onkeydown = (e) => {
+      e.stopPropagation();
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); td.textContent = cell.text; }
+    };
+    input.onblur = () => commit();
+    input.onmousedown = (e) => e.stopPropagation();
+  }
+
+  ignoreEvent(): boolean {
+    return true; // the grid handles its own events; CM never sees them
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -22,7 +22,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ToastProvider>
       <AuthProvider>
-        <BrowserRouter>
+        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/p/:id" element={<Editor />} />

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Home from './pages/Home';
 import Editor from './pages/Editor';
+
+function NotFound() {
+  return (
+    <div className="notfound">
+      <h1>Page not found</h1>
+      <p>That page doesn’t exist.</p>
+      <Link className="btn btn--primary" to="/">Back to your projects</Link>
+    </div>
+  );
+}
 import { ToastProvider } from './components/Toast';
 import { AuthProvider } from './components/Auth';
 import './theme.css';
@@ -16,6 +26,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/p/:id" element={<Editor />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { api, CompileResult, ProjectDetail, TreeEntry, Comment, localUser } from '../api';
 import { useToast } from '../components/Toast';
 import FileTree from '../components/FileTree';
-import CodePane, { CodePaneHandle } from '../components/CodePane';
+import CodePane, { CodePaneHandle, EditorMode } from '../components/CodePane';
 import PdfPane, { PdfPaneHandle } from '../components/PdfPane';
 import BranchMenu from '../components/BranchMenu';
 import HistoryPanel from '../components/HistoryPanel';
@@ -42,6 +42,11 @@ export default function Editor() {
   const [showLog, setShowLog] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [spellcheck, setSpellcheck] = useState(() => localStorage.getItem('aldine.spellcheck') === '1');
+  // Visual mode is gated by an experimental flag until it graduates.
+  const visualEnabled = localStorage.getItem('aldine.experimental.visualEditor') === '1';
+  const [mode, setMode] = useState<EditorMode>(() =>
+    visualEnabled && localStorage.getItem('aldine.editorMode') === 'visual' ? 'visual' : 'source');
+  const switchMode = (m: EditorMode) => { localStorage.setItem('aldine.editorMode', m); setMode(m); };
   const [comments, setComments] = useState<Comment[]>([]);
   const [composing, setComposing] = useState<{ from: number; to: number; quote: string } | null>(null);
   const codeRef = useRef<CodePaneHandle>(null);
@@ -280,6 +285,9 @@ export default function Editor() {
       { id: 'jump-pdf', group: 'Action', title: 'Jump PDF to cursor', hint: '⌘J', run: () => jumpToPdf() },
       { id: 'spell', group: 'Action', title: spellcheck ? 'Turn spellcheck off' : 'Turn spellcheck on', run: () => setSpellcheck((s) => { localStorage.setItem('aldine.spellcheck', s ? '0' : '1'); return !s; }) },
       { id: 'theme', group: 'View', title: 'Toggle light/dark theme', run: () => { toggleTheme(); } },
+      ...(visualEnabled
+        ? [{ id: 'mode', group: 'View', title: mode === 'visual' ? 'Switch to Source editing' : 'Switch to Visual editing', run: () => switchMode(mode === 'visual' ? 'source' : 'visual') }]
+        : [{ id: 'experimental-visual', group: 'View', title: 'Enable experimental Visual editor', run: () => { localStorage.setItem('aldine.experimental.visualEditor', '1'); location.reload(); } }]),
       { id: 'commit', group: 'Git', title: 'Save a checkpoint…', run: () => { setTab('history'); } },
       { id: 'newbranch', group: 'Git', title: 'New branch…', run: () => { setTab('files'); document.querySelector<HTMLElement>('[data-testid="branch-menu"]')?.click(); } },
     ];
@@ -346,6 +354,12 @@ export default function Editor() {
           onSwitch={switchBranch}
           onChanged={() => { loadProject(); loadFiles(); }}
         />
+        {visualEnabled && (
+          <div className="seg" role="tablist" aria-label="Editing mode" data-testid="mode-toggle">
+            <button role="tab" aria-selected={mode === 'source'} className={`seg__btn ${mode === 'source' ? 'seg__btn--active' : ''}`} onClick={() => switchMode('source')}>Source</button>
+            <button role="tab" aria-selected={mode === 'visual'} className={`seg__btn ${mode === 'visual' ? 'seg__btn--active' : ''}`} onClick={() => switchMode('visual')}>Visual</button>
+          </div>
+        )}
         <div className="toolbar__spacer" />
         {project.github && (
           <GithubSync projectId={id} fullName={project.github.fullName} onPulled={() => { loadFiles(); loadProject(); }} />
@@ -442,7 +456,7 @@ export default function Editor() {
                 </span>
               </div>
               <CodePane
-                key={`${id}::${branch}::${activeFile}::${spellcheck}`}
+                key={`${id}::${branch}::${activeFile}`}
                 ref={codeRef}
                 projectId={id}
                 branch={branch}
@@ -453,6 +467,7 @@ export default function Editor() {
                 onStats={setStats}
                 onJumpToPdf={jumpToPdf}
                 spellcheck={spellcheck}
+                mode={mode}
               />
             </>
           ) : (

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -17,6 +17,7 @@ import { invalidateBibCache, invalidateLabelCache } from '../editor/latexExtras'
 import { useCommentSignal } from '../editor/commentSignal';
 import GithubSync from '../components/GithubSync';
 import CommentComposer from '../components/CommentComposer';
+import FormatToolbar from '../components/FormatToolbar';
 import { toggleTheme } from '../theme';
 
 type CompileStatus = 'idle' | 'compiling' | 'ok' | 'error';
@@ -448,6 +449,7 @@ export default function Editor() {
             <>
               <div className="pane__header">
                 <span className="statusbar__file">{activeFile}</span>
+                {visualEnabled && mode === 'visual' && <FormatToolbar target={codeRef} />}
                 <span className="toolbar__spacer" />
                 <span className="pdf-status" data-testid="word-count">
                   {stats.selWords != null

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -418,7 +418,16 @@ export default function Editor() {
                 projectId={id}
                 branch={branch}
                 onOpen={setActiveFile}
-                onCreate={async (path) => { await api.writeFile(id, branch, path, ''); await loadFiles(); setActiveFile(path); }}
+                onCreate={async (path) => {
+                  try {
+                    await api.createFile(id, branch, path);
+                    await loadFiles();
+                    setActiveFile(path);
+                  } catch (err: any) {
+                    if (/already exists/i.test(err?.message)) { toast(`"${path}" already exists`, 'error'); setActiveFile(path); }
+                    else toast(`Could not create file: ${err.message}`, 'error');
+                  }
+                }}
                 onUploaded={async (paths) => {
                   await loadFiles();
                   toast(paths.length === 1 ? `Uploaded ${paths[0]}` : `Uploaded ${paths.length} files`, 'ok');

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -178,7 +178,7 @@ export default function Editor() {
     if (!activeFile) return;
     const ranges = comments
       .filter((c) => c.file === activeFile)
-      .map((c) => ({ id: c.id, from: c.anchor.from, to: c.anchor.to, resolved: c.resolved }));
+      .map((c) => ({ id: c.id, from: c.anchor.from, to: c.anchor.to, resolved: c.resolved, suggestion: c.suggestion }));
     requestAnimationFrame(() => codeRef.current?.setCommentRanges(ranges));
   }, [comments, activeFile]);
 
@@ -237,6 +237,20 @@ export default function Editor() {
       toast(`Could not accept: ${err.message}`, 'error');
     }
   }, [id, branch, loadComments, toast]);
+
+  // visual-mode suggestion widgets dispatch accept/dismiss as window events
+  useEffect(() => {
+    const onAction = (e: Event) => {
+      const { id: cid, action } = (e as CustomEvent<{ id: string; action: 'accept' | 'resolve' }>).detail;
+      const c = comments.find((x) => x.id === cid);
+      if (!c) return;
+      if (action === 'accept') acceptSuggestion(c);
+      else api.resolveComment(id, c.id, true).then(() => { loadComments(); bumpComments(); });
+    };
+    window.addEventListener('aldine:suggestion', onAction);
+    return () => window.removeEventListener('aldine:suggestion', onAction);
+  }, [comments, id, acceptSuggestion, loadComments, bumpComments]);
+
 
   // Inverse SyncTeX: double-click in the PDF → open the source file at that line.
   const onPdfInverse = useCallback(async (page: number, x: number, y: number) => {

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -17,6 +17,7 @@ import { invalidateBibCache, invalidateLabelCache } from '../editor/latexExtras'
 import { useCommentSignal } from '../editor/commentSignal';
 import GithubSync from '../components/GithubSync';
 import CommentComposer from '../components/CommentComposer';
+import Modal from '../components/Modal';
 import FormatToolbar from '../components/FormatToolbar';
 import { toggleTheme } from '../theme';
 
@@ -39,7 +40,17 @@ export default function Editor() {
   const [pluginPanels, setPluginPanels] = useState<PluginPanel[]>([]);
   const [auto, setAuto] = useState(() => localStorage.getItem('aldine.autoTypeset') !== '0');
   const [stats, setStats] = useState<{ words: number; selWords: number | null }>({ words: 0, selWords: null });
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoomState] = useState(() => {
+    const z = Number(localStorage.getItem('aldine.pdfZoom'));
+    return z >= 0.5 && z <= 3 ? z : 1;
+  });
+  const setZoom = useCallback((v: number | ((z: number) => number)) => {
+    setZoomState((prev) => {
+      const next = typeof v === 'function' ? v(prev) : v;
+      localStorage.setItem('aldine.pdfZoom', String(next));
+      return next;
+    });
+  }, []);
   const [showLog, setShowLog] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [spellcheck, setSpellcheck] = useState(() => localStorage.getItem('aldine.spellcheck') === '1');
@@ -178,7 +189,7 @@ export default function Editor() {
     if (!activeFile) return;
     const ranges = comments
       .filter((c) => c.file === activeFile)
-      .map((c) => ({ id: c.id, from: c.anchor.from, to: c.anchor.to, resolved: c.resolved, suggestion: c.suggestion }));
+      .map((c) => ({ id: c.id, from: c.anchor.from, to: c.anchor.to, resolved: c.resolved, suggestion: c.suggestion, quote: c.anchor.quote }));
     requestAnimationFrame(() => codeRef.current?.setCommentRanges(ranges));
   }, [comments, activeFile]);
 
@@ -460,7 +471,7 @@ export default function Editor() {
                 activeFile={activeFile}
                 onReveal={revealComment}
                 onResolve={async (c, resolved) => { await api.resolveComment(id, c.id, resolved); await loadComments(); bumpComments(); }}
-                onDelete={async (c) => { await api.deleteComment(id, c.id); await loadComments(); bumpComments(); }}
+                onDelete={async (c) => { if (!window.confirm('Delete this comment thread?')) return; await api.deleteComment(id, c.id); await loadComments(); bumpComments(); }}
                 onReply={async (c, body) => { await api.replyComment(id, c.id, body, localUser().name); await loadComments(); bumpComments(); }}
                 onAccept={acceptSuggestion}
               />
@@ -523,7 +534,11 @@ export default function Editor() {
               })}
               {errors.length === 0 && (
                 <div className="errors__row" style={{ cursor: 'default' }}>
-                  <span className="errors__msg">Typesetting failed — open the log for details.</span>
+                  <span className="errors__msg">
+                    {compile.result?.timedOut
+                      ? 'Typesetting timed out — the document took too long (a possible infinite loop, or it needs a bigger compile budget). Open the log for details.'
+                      : 'Typesetting failed — open the log for details.'}
+                  </span>
                 </div>
               )}
             </div>
@@ -558,7 +573,7 @@ export default function Editor() {
             <span className="toolbar__spacer" />
             <div className="zoom" data-testid="zoom-controls">
               <button className="btn btn--ghost btn--small" onClick={() => setZoom((z) => Math.max(0.5, +(z - 0.1).toFixed(2)))} title="Zoom out" aria-label="Zoom out">−</button>
-              <button className="zoom__label" onClick={() => setZoom(1)} title="Reset to fit width">{Math.round(zoom * 100)}%</button>
+              <button className="zoom__label" onClick={() => setZoom(1)} title="Reset to fit width" aria-label={`PDF zoom ${Math.round(zoom * 100)}%, click to reset`}>{Math.round(zoom * 100)}%</button>
               <button className="btn btn--ghost btn--small" onClick={() => setZoom((z) => Math.min(3, +(z + 0.1).toFixed(2)))} title="Zoom in" aria-label="Zoom in">+</button>
             </div>
             <button
@@ -582,15 +597,15 @@ export default function Editor() {
       )}
 
       {showLog && compile.result && (
-        <div className="modal-backdrop" onClick={() => setShowLog(false)}>
-          <div className="modal modal--wide" onClick={(e) => e.stopPropagation()}>
+        <Modal onClose={() => setShowLog(false)} label="Typesetting log" wide>
+          <div>
             <h2>Typesetting log</h2>
             <pre className="logview" data-testid="log-view">{compile.result.log || '(no log)'}</pre>
             <div className="modal__row">
               <button className="btn" onClick={() => setShowLog(false)}>Close</button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -438,9 +438,13 @@ export default function Editor() {
                   if (activeFile === path) setActiveFile(null);
                 }}
                 onRename={async (from, to) => {
-                  await api.renameFile(id, branch, from, to);
-                  await loadFiles();
-                  if (activeFile === from) setActiveFile(to);
+                  try {
+                    await api.renameFile(id, branch, from, to);
+                    await loadFiles();
+                    if (activeFile === from) setActiveFile(to);
+                  } catch (err: any) {
+                    toast(/already exists/i.test(err?.message) ? `"${to}" already exists` : `Could not rename: ${err.message}`, 'error');
+                  }
                 }}
                 onSetRoot={async (path) => {
                   await api.patchProject(id, { rootFile: path });

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { api, ProjectSummary, TemplateInfo } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
+import Modal from '../components/Modal';
 import { IconDoc, IconLink, IconX } from '../components/Icons';
 import AccountSettings from '../components/AccountSettings';
 import { getTheme, toggleTheme } from '../theme';
@@ -12,6 +13,7 @@ import { friendlyDate } from '../util/dates';
 
 export default function Home() {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [creating, setCreating] = useState(false);
   const [themeChoice, setThemeChoice] = useState(getTheme());
   const [newName, setNewName] = useState('');
@@ -26,7 +28,9 @@ export default function Home() {
   const toast = useToast();
   const { authEnabled, user, setUser } = useAuth();
 
-  const load = () => api.listProjects().then(setProjects).catch(() => setProjects([]));
+  const load = () => api.listProjects()
+    .then((p) => { setProjects(p); setLoadFailed(false); })
+    .catch(() => { setLoadFailed(true); setProjects((cur) => cur ?? []); });
   useEffect(() => { load(); }, []);
   // returning from GitHub OAuth connect → reopen the import flow (now connected)
   useEffect(() => {
@@ -108,7 +112,7 @@ export default function Home() {
             )}
             <label className="btn" data-testid="import-zip">
               Import ZIP
-              <input type="file" accept=".zip" hidden data-testid="import-input"
+              <input type="file" accept=".zip" hidden data-testid="import-input" aria-label="Import a project from a ZIP file"
                 onChange={async (e) => { if (e.target.files?.[0]) await importZip(e.target.files[0]); e.target.value = ''; }} />
             </label>
             <button className="btn" onClick={() => setShowGithub(true)} data-testid="new-from-github">
@@ -122,6 +126,11 @@ export default function Home() {
 
         {projects === null ? (
           <div className="empty"><div className="spinner" style={{ margin: '0 auto' }} /></div>
+        ) : loadFailed ? (
+          <div className="empty">
+            <p style={{ margin: '0 0 16px' }}>Couldn’t reach the server to load your projects.</p>
+            <button className="btn btn--primary" onClick={load}>Try again</button>
+          </div>
         ) : projects.length === 0 ? (
           <div className="empty">
             <p style={{ margin: '0 0 16px' }}>No projects yet — start a paper however you like.</p>
@@ -177,8 +186,8 @@ export default function Home() {
       )}
 
       {creating && (
-        <div className="modal-backdrop" onClick={() => setCreating(false)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <Modal onClose={() => setCreating(false)} label="New project">
+          <div>
             <h2>New project</h2>
             <p className="modal__sub">Name it, pick a starting point, start writing.</p>
             <input
@@ -212,7 +221,7 @@ export default function Home() {
               <button className="btn btn--primary" onClick={create} data-testid="create-project">Create</button>
             </div>
           </div>
-        </div>
+        </Modal>
       )}
     </div>
   );
@@ -242,8 +251,8 @@ function ShareModal({ project, onClose, onSaved, toast }: {
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()} data-testid="share-modal">
+    <Modal onClose={onClose} label={`Share ${project.name}`} testId="share-modal">
+      <div>
         <h2>Share “{project.name}”</h2>
         <p className="modal__sub">Choose who can open and edit this project.</p>
         <label style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
@@ -267,6 +276,6 @@ function ShareModal({ project, onClose, onSaved, toast }: {
           <button className="btn btn--primary" onClick={save} disabled={busy} data-testid="share-save">Save</button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -1,0 +1,168 @@
+# Aldine — User Story Inventory
+
+The behaviors Aldine promises, written as user stories with acceptance
+criteria. This is the QA contract: every story should be demonstrably true in
+a running instance. Stories are grouped by domain; IDs are stable
+(`DOMAIN-n`) so test reports can cite them.
+
+Legend: **[auth]** needs `AUTH_ENABLED=1`; **[flag]** behind an experimental
+flag; everything else works in the default single-tenant deploy.
+
+---
+
+## Onboarding & projects (PROJ)
+
+- **PROJ-1** — As a new visitor, I land on the home screen and see a first-run
+  onboarding overlay that I can dismiss, and it stays dismissed on return.
+- **PROJ-2** — I create a project from a template (article, IAC paper, beamer,
+  report) and land in the editor with the template's files seeded.
+- **PROJ-3** — I create a blank project and get a minimal `main.tex` +
+  `references.bib`.
+- **PROJ-4** — I rename a project inline from the toolbar; the name persists.
+- **PROJ-5** — I delete a project from the home screen; it disappears and its
+  data is gone.
+- **PROJ-6** — I import an existing project from an Overleaf/generic ZIP; its
+  files and folder structure arrive intact.
+- **PROJ-7** — My project list shows all my projects with names and opens the
+  right one on click.
+
+## Editing & files (EDIT)
+
+- **EDIT-1** — I edit `.tex` source in a CodeMirror editor with LaTeX syntax
+  highlighting; changes persist without an explicit save.
+- **EDIT-2** — I create, rename, and delete files and folders from the file
+  tree; the tree reflects each change.
+- **EDIT-3** — I open a subdirectory file (`chapters/intro.tex`) and the tree
+  shows nested structure correctly.
+- **EDIT-4** — I upload a figure by drag-drop or the upload button; it lands in
+  the project and can be `\includegraphics`'d.
+- **EDIT-5** — Live word count updates as I type and reflects a selection.
+- **EDIT-6** — The command palette (⌘K) opens, filters commands, and runs the
+  chosen one.
+- **EDIT-7** — `\cite{` and `\ref{` autocomplete from the project's
+  bibliography and labels.
+- **EDIT-8** — Hovering a `\cite` key shows a reference preview tooltip.
+- **EDIT-9** — Spellcheck can be toggled and underlines prose in `.tex`/`.md`.
+
+## Compile & preview (COMP)
+
+- **COMP-1** — I press ⌘S (or Typeset) and get a rendered PDF in the preview
+  pane within a few seconds.
+- **COMP-2** — Auto-typeset recompiles a couple of seconds after edits settle,
+  and can be turned off.
+- **COMP-3** — A compile error surfaces in the Problems panel with a line
+  number and a plain-English hint; clicking it jumps to the source line.
+- **COMP-4** — I can view the raw compile log.
+- **COMP-5** — I zoom the PDF and the setting holds.
+- **COMP-6** — SyncTeX: double-clicking the PDF jumps the editor to the source
+  line; ⌘J jumps the PDF to my cursor with a flash.
+- **COMP-7** — A missing-package error names the package and points at
+  `ALDINE_TEXLIVE_SCHEME=full`.
+
+## Collaboration (COLLAB)
+
+- **COLLAB-1** — Two people editing the same file see each other's changes live,
+  conflict-free (CRDT), with multiple cursors.
+- **COLLAB-2** — Each collaborator shows a presence indicator with name/color.
+- **COLLAB-3** — Concurrent edits at different positions both survive (no lost
+  updates).
+- **COLLAB-4** — A collaborator joining mid-session receives the current
+  document state.
+
+## Versioning & branches (GIT)
+
+- **GIT-1** — Every project is a git repo; auto-checkpoints happen while I write.
+- **GIT-2** — I create a named checkpoint (commit) from the UI.
+- **GIT-3** — I view history with diffs and can inspect a past commit.
+- **GIT-4** — I create a branch, edit it independently, and switch between
+  branches from the UI.
+- **GIT-5** — I merge one branch into another; conflicts are reported, not
+  silently lost.
+- **GIT-6** — I delete a branch.
+
+## GitHub sync (GH)
+
+- **GH-1** — I import a GitHub repo as a project (OAuth or PAT).
+- **GH-2** — I push commits to GitHub with a message; ahead/behind indicators
+  update.
+- **GH-3** — I pull remote changes; conflicts are surfaced.
+- **GH-4** — I open a pull request from the editor.
+- **GH-5** — I switch the synced remote branch.
+- **GH-6** — Opt-in auto-sync pushes on a schedule; manual push always pushes.
+- **GH-7** — Auth tokens never land in the compiler-visible project dir.
+
+## References & Zotero (REF)
+
+- **REF-1** — I cite by DOI or arXiv id; BibTeX is appended and `\cite`
+  inserted, no account needed.
+- **REF-2** — I link a Zotero library or a single collection and validate the
+  connection.
+- **REF-3** — My `.bib` refreshes from Zotero with version-aware sync.
+- **REF-4** — I search my Zotero library and insert a citation from a panel.
+
+## Review mode (REV)
+
+- **REV-1** — I select text and leave an anchored, threaded comment.
+- **REV-2** — I attach a suggested replacement; the author accepts it with one
+  click and the text changes.
+- **REV-3** — Comments highlight in the editor; I resolve and reopen them.
+- **REV-4** — Comments sync live between collaborators.
+
+## AI error fix (AI)
+
+- **AI-1** — With a key configured, a failed compile offers a plain-English
+  diagnosis and one-click fixes; without a key the feature is absent.
+- **AI-2** — The API key stays server-side and never reaches the browser.
+
+## Plugins (PLUG)
+
+- **PLUG-1** — Built-in plugins (Zotero, references, AI-fix) load and register
+  sidebar panels / commands.
+- **PLUG-2** — A plugin can insert text at the cursor, compile, toast, and
+  fetch.
+
+## Auth & sharing (AUTH) [auth]
+
+- **AUTH-1** — With auth on, I register, log in, log out, and my session
+  persists; my projects are mine.
+- **AUTH-2** — Google & GitHub SSO sign-in works; SSO-only mode hides
+  passwords.
+- **AUTH-3** — I request a password reset and receive a link (email transport)
+  scoped to the configured public URL.
+- **AUTH-4** — Registering a password for an email that has SSO is blocked
+  (anti-hijack).
+- **AUTH-5** — Project sharing (invite-only or link) grants the right access;
+  the collab socket is access-checked.
+- **AUTH-6** — Per-user compile quota returns HTTP 402 past the limit.
+
+## Visual editor (VIS) [flag]
+
+- **VIS-1** — I enable the experimental visual editor and toggle Source|Visual;
+  the switch is instant with no flicker or lost cursor.
+- **VIS-2** — Headings, bold/italic/underline, and lists render as formatted
+  text; markup hides.
+- **VIS-3** — The construct under my caret (and a remote caret) reveals its raw
+  source; leaving re-renders.
+- **VIS-4** — Math renders via KaTeX; clicking opens a MathLive editor that
+  writes back precise source.
+- **VIS-5** — Tables render as an editable grid (cell edit, add row/column);
+  figures show the image; cites show author-year.
+- **VIS-6** — A review suggestion renders as an inline tracked change I can
+  accept or dismiss.
+- **VIS-7** — Pasting rich HTML converts to clean LaTeX.
+- **VIS-8** — The Contents dropdown lists headings and jumps to them.
+- **VIS-9** — **The invariant**: nothing I do in visual mode rewrites source I
+  didn't deliberately edit (byte-stable).
+
+## Cross-cutting (X)
+
+- **X-1** — Light/dark theme: dark is the default; the toggle flips instantly
+  and the choice persists.
+- **X-2** — The UI is responsive and has no horizontal overflow at common
+  widths.
+- **X-3** — Keyboard access: visible focus, palette-first operation, no traps.
+- **X-4** — Errors and empty states are informative, not dead ends.
+- **X-5** — Rate limits guard login, AI, and reference lookups without locking
+  out normal use.
+- **X-6** — The compiler is sandboxed (no egress, dropped caps, restricted
+  shell-escape).

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,0 +1,94 @@
+# Aldine — user story inventory
+
+The behavioral contract of the application, organized by epic. Each story
+lists its acceptance criteria (AC) and where it is automated (`e2e/tests/*`,
+`apps/server/test/*`, or *manual* for flows only covered by hand/QA passes).
+This file is the reference for QA campaigns and for scoping regressions.
+
+Personas: **Solo** (single-tenant self-hoster), **Author** (writing, possibly
+non-technical), **Collaborator** (co-author, may live in git/VS Code),
+**Reviewer** (comments, suggests, doesn't typeset), **Operator** (hosts an
+instance for a group).
+
+---
+
+## 1. First run & projects
+
+- **US-101** — As a Solo user, opening a fresh instance shows onboarding once
+  and never again after dismissal.
+  AC: onboarding visible on first visit; dismissed state survives reload.
+  Covered: `01-home.spec.ts`.
+- **US-102** — As an Author, I create a project from a template and land in a
+  working editor.
+  AC: all four templates create; root `.tex` opens; project appears on Home.
+  Covered: `01-home.spec.ts` (article), *manual* (other templates).
+- **US-103** — As an Author, I can rename a project inline and delete a
+  project with confirmation.
+  AC: rename persists; delete removes card and data.
+  Covered: `01-home.spec.ts` (delete), *manual* (rename).
+- **US-104** — As an Author, I can import an Overleaf ZIP as a new project.
+  AC: files land, root file detected, project compiles if the ZIP did.
+  Covered: *manual*.
+- **US-105** — As a Collaborator, I can import a GitHub repo as a project
+  (OAuth or PAT).
+  AC: clone succeeds, default branch mapped to `main`, files visible.
+  Covered: `apps/server/test/github-sync.integration.mjs` (API level).
+
+## 2. Files & tree
+
+- **US-201** — As an Author, I manage files: create, rename, delete,
+  including in subdirectories.
+  AC: tree updates live; open editors follow renames; subdir paths compile
+  (`\input{chapters/…}`).
+  Covered: `12-subdir-tree.spec.ts`, *manual* (rename edge cases).
+- **US-202** — As an Author, I upload files (figures) by picker or drag-drop,
+  including binary.
+  AC: binary upload intact; image usable via `\includegraphics`.
+  Covered: `07-features.spec.ts` (upload), *manual* (drag-drop).
+- **US-203** — As a Solo user, internal files (`.papyr-out`/`.aldine-out`,
+  `.git`) never appear in the tree and can't be fetched via the file API.
+  AC: hidden paths 403; tree excludes them.
+  Covered: *manual* / API probing.
+
+## 3. Editing & compiling
+
+- **US-301** — As an Author, I typeset with ⌘S or the button and see the PDF
+  within seconds; warm recompiles are fast.
+  AC: first compile OK on templates; unchanged-doc recompile ≈1s; status
+  shows timing.
+  Covered: `02-compile.spec.ts`.
+- **US-302** — As an Author, compile errors show plain-English hints with
+  line numbers, and clicking jumps to the offending line.
+  AC: hint text present; editor focused at line; missing-package hint names
+  the package.
+  Covered: `02-compile.spec.ts`, hints *manual*.
+- **US-303** — As an Author, auto-typeset compiles ~2s after I stop typing,
+  and can be toggled off.
+  AC: no compile storms while typing; toggle persists.
+  Covered: *manual*.
+- **US-304** — As an Author, SyncTeX works both ways (double-click PDF →
+  source; ⌘J → PDF position).
+  AC: correct line targeted in both directions, including subdir files.
+  Covered: `07-features.spec.ts`.
+- **US-305** — As an Author, I get live word count (and selection count),
+  spellcheck toggle, PDF zoom, and a ⌘K command palette.
+  AC: counts plausible for LaTeX; palette commands all execute.
+  Covered: `08-stretch.spec.ts` (partial), *manual*.
+- **US-306** — As an Operator, concurrent compiles queue instead of stacking
+  (per-node concurrency gate), and per-user quotas return HTTP 402 when
+  exhausted.
+  AC: burst of compiles serializes; over-quota surfaces a clear message.
+  Covered: *manual* / API.
+
+## 4. Real-time collaboration
+
+- **US-401** — As Collaborators, we edit the same file live with visible
+  cursors, names, and presence chips.
+  AC: keystrokes propagate <2s; presence deduplicates by client.
+  Covered: `03-collab.spec.ts`.
+- **US-402** — As a Collaborator, my edits survive server restarts and my
+  offline edits merge on reconnect without loss.
+  AC: no divergence after reconnect; debounced persistence flushes on
+  shutdown.
+  Covered: `e2e/c2-shutdown.mjs` (harness), *manual*.
+- **US-403** — As Collaborators, working on different branches of

--- a/e2e/c3-reconnect-dup.mjs
+++ b/e2e/c3-reconnect-dup.mjs
@@ -1,0 +1,52 @@
+// Regression for the document-duplication bug: reloading a Yjs doc by
+// reseeding from plain text mints fresh CRDT operations, so a client that
+// reconnects after a server restart MERGES its copy with the server's freshly
+// seeded copy → the document duplicates ("XX"). Loading from a binary Yjs
+// snapshot preserves operation identity, so the reconnect sync is a no-op.
+//
+// This exercises the exact Yjs primitives collab.ts uses (text-seed vs
+// snapshot round-trip) and simulates the Hocuspocus sync-on-reconnect via a
+// state exchange, deterministically — no server, no timing flake.
+import * as Y from 'yjs';
+
+const TEXT = 'THE-ONLY-COPY-OF-THIS-LINE\n';
+const copies = (s) => (s.match(/THE-ONLY-COPY-OF-THIS-LINE/g) || []).length;
+
+/** One round of the Yjs sync protocol between two docs (both directions). */
+function sync(a, b) {
+  Y.applyUpdate(a, Y.encodeStateAsUpdate(b, Y.encodeStateVector(a)));
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a, Y.encodeStateVector(b)));
+}
+
+// --- server incarnation 1 seeds the doc from disk text, client syncs ---
+const server1 = new Y.Doc();
+server1.getText('content').insert(0, TEXT); // onLoadDocument text-seed (server1's clientID)
+const client = new Y.Doc();
+sync(client, server1); // client now holds TEXT as server1's operations
+const snapshot = Buffer.from(Y.encodeStateAsUpdate(server1)); // what writeSnapshot() persists
+
+// --- server restarts; the client stays alive and will reconnect ---
+
+// OLD behaviour: incarnation 2 reseeds from plain text (new operations)
+const oldServer2 = new Y.Doc();
+oldServer2.getText('content').insert(0, TEXT); // fresh ops, different clientID
+const oldClient = new Y.Doc();
+sync(oldClient, client); // clone the live client's state
+sync(oldClient, oldServer2); // reconnect sync
+const oldCopies = copies(oldClient.getText('content').toString());
+
+// NEW behaviour: incarnation 2 loads from the snapshot (operation identity kept)
+const newServer2 = new Y.Doc();
+Y.applyUpdate(newServer2, snapshot); // onLoadDocument snapshot path
+const newClient = new Y.Doc();
+sync(newClient, client); // clone the live client's state
+sync(newClient, newServer2); // reconnect sync
+const newCopies = copies(newClient.getText('content').toString());
+
+console.log(`old (text-seed) reconnect → ${oldCopies} copies; new (snapshot) reconnect → ${newCopies} copies`);
+// The test asserts the FIX: exactly one copy. It also asserts the bug is real
+// (the old path duplicates), so a future regression that drops snapshotting fails here.
+const ok = newCopies === 1 && oldCopies > 1;
+console.log(ok ? 'C3 PASS: snapshot reload is reconnect-safe (old path duplicates, new path does not)'
+               : `C3 FAIL: expected new=1 & old>1, got new=${newCopies} old=${oldCopies}`);
+process.exit(ok ? 0 : 1);

--- a/e2e/inspect-visual.mjs
+++ b/e2e/inspect-visual.mjs
@@ -1,0 +1,99 @@
+// Manual QA driver: seeds a document exercising every visual-editor feature
+// and captures screenshots of each state for human (or agent) inspection.
+import { chromium } from '@playwright/test';
+import fs from 'node:fs';
+
+const OUT = process.env.OUT || '/tmp/visual-qa';
+const BASE = process.env.ALDINE_URL || 'http://localhost:5173';
+fs.mkdirSync(OUT, { recursive: true });
+
+const DOC = [
+  '\\section{Typography and Convergence}',
+  'Aldine renders \\textbf{bold}, \\emph{italic}, and \\underline{underlined} prose',
+  'while equations like $e^{i\\pi} + 1 = 0$ stay live. See \\cite{knuth1984texbook}.',
+  '',
+  '\\subsection{A list and a table}',
+  '\\begin{itemize}',
+  '\\item First, the visual layer never rewrites source',
+  '\\item Second, every widget is an exact-range edit',
+  '\\end{itemize}',
+  '',
+  '\\begin{tabular}{lll}',
+  'Editor & License & Byte-stable \\\\',
+  'Aldine & AGPL & yes \\\\',
+  'Overleaf & AGPL & no \\\\',
+  '\\end{tabular}',
+  '',
+  '\\subsection{Display math and figures}',
+  '\\[ \\int_0^1 x^2 \\, dx = \\tfrac{1}{3} \\]',
+  '\\begin{figure}',
+  '\\includegraphics{plot.png}',
+  '\\caption{A real image preview}',
+  '\\end{figure}',
+  '',
+  'Closing prose to park the caret in.',
+  '',
+].join('\n');
+
+const BIB = '@book{knuth1984texbook,\n  author = {Knuth, Donald E.},\n  title = {The {\\TeX}book},\n  year = {1984},\n  publisher = {Addison-Wesley}\n}\n';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 950 }, colorScheme: 'dark' });
+await ctx.addInitScript(() => {
+  localStorage.setItem('aldine.onboarded', '1');
+  localStorage.setItem('aldine.theme', 'dark');
+  localStorage.setItem('aldine.experimental.visualEditor', '1');
+  localStorage.setItem('aldine.editorMode', 'visual');
+});
+
+const res = await ctx.request.post(`${BASE}/api/projects`, { data: { name: 'Visual QA' } });
+const { id } = await res.json();
+await ctx.request.put(`${BASE}/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: DOC } });
+await ctx.request.put(`${BASE}/api/projects/${id}/file`, { data: { branch: 'main', path: 'references.bib', content: BIB } });
+// a real image for the figure preview
+const png = fs.readFileSync(new URL('./shots/branches-light.png', import.meta.url));
+await ctx.request.put(`${BASE}/api/projects/${id}/file`, {
+  data: { branch: 'main', path: 'plot.png', content: png.toString('base64'), encoding: 'base64' },
+});
+// a review suggestion for the tracked-change rendering
+await ctx.request.post(`${BASE}/api/projects/${id}/comments`, {
+  data: {
+    branch: 'main', file: 'main.tex',
+    anchor: { from: DOC.indexOf('Closing prose'), to: DOC.indexOf('Closing prose') + 'Closing prose'.length, quote: 'Closing prose' },
+    body: 'suggestion demo', suggestion: 'Final thoughts', author: 'Reviewer',
+  },
+});
+
+const page = await ctx.newPage();
+await page.goto(`${BASE}/p/${id}`);
+await page.waitForSelector('.cm-content');
+await page.locator('.cm-line', { hasText: 'park the caret' }).click();
+await page.waitForTimeout(1500); // katex/bib/image settle
+await page.screenshot({ path: `${OUT}/1-overview.png` });
+
+// MathLive popover on the inline equation
+await page.getByTestId('vis-math').first().click();
+await page.waitForSelector('[data-testid="math-popover"]');
+await page.waitForTimeout(800);
+await page.screenshot({ path: `${OUT}/2-mathlive.png` });
+await page.keyboard.press('Escape');
+
+// table cell editing
+await page.getByTestId('vis-table').locator('td', { hasText: 'AGPL' }).first().dispatchEvent('mousedown');
+await page.waitForTimeout(300);
+await page.screenshot({ path: `${OUT}/3-table-edit.png` });
+await page.keyboard.press('Escape');
+
+// cursor-reveal on bold
+await page.locator('.cm-vis-b').first().click();
+await page.waitForTimeout(300);
+await page.screenshot({ path: `${OUT}/4-reveal.png` });
+
+// source mode for contrast
+await page.getByTestId('mode-toggle').getByRole('tab', { name: 'Source' }).click();
+await page.waitForTimeout(400);
+await page.screenshot({ path: `${OUT}/5-source.png` });
+
+await ctx.request.delete(`${BASE}/api/projects/${id}`);
+await browser.close();
+console.log('shots in', OUT);

--- a/e2e/tests/07-features.spec.ts
+++ b/e2e/tests/07-features.spec.ts
@@ -92,6 +92,12 @@ test.describe('DOI / arXiv citation (references plugin)', () => {
       const bib = await request.get(`/api/projects/${id}/bib?branch=main`);
       const entries = await bib.json();
       expect(entries.some((e: { key: string }) => e.key === 'doe2020')).toBeTruthy();
+      // the &amp; from upstream must be decoded + LaTeX-escaped (compile-safe),
+      // never a bare & (an alignment tab that breaks the whole document)
+      const raw = await (await request.get(`/api/projects/${id}/file?branch=main&path=references.bib`)).text();
+      expect(raw).toContain('\\&');
+      expect(raw).not.toMatch(/(?<!\\)&/);
+      expect(raw).not.toContain('&amp;');
     } finally {
       await cleanup(request, id);
     }

--- a/e2e/tests/10-review.spec.ts
+++ b/e2e/tests/10-review.spec.ts
@@ -86,3 +86,26 @@ test.describe('real-time review', () => {
     }
   });
 });
+
+test.describe('comment re-anchoring (QA regression)', () => {
+  test('a comment highlight tracks its text after edits shift its offset', async ({ page, request }) => {
+    const id = await createProject(request, 'Reanchor');
+    try {
+      // seed a file and anchor a comment on ANCHOR_ME at offset 0 via the API
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: 'ANCHOR_ME here.\nmore lines\n' } });
+      const c = await request.post(`/api/projects/${id}/comments`, {
+        data: { branch: 'main', file: 'main.tex', anchor: { from: 0, to: 9, quote: 'ANCHOR_ME' }, body: 'anchor test', author: 'QA' },
+      });
+      expect(c.ok()).toBeTruthy();
+      // now shift ANCHOR_ME down by prepending text — the stored offset (0) is stale
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: 'PREPENDED LINE ONE\nPREPENDED LINE TWO\n' + 'ANCHOR_ME here.\nmore lines\n' } });
+      // open fresh: the client must re-anchor the comment to ANCHOR_ME by its quote,
+      // not leave the highlight on the (now different) text at offset 0
+      await openProject(page, id);
+      await expect(page.locator('.cm-comment-range')).toContainText('ANCHOR_ME', { timeout: 10_000 });
+      await expect(page.locator('.cm-comment-range')).not.toContainText('PREPENDED');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+});

--- a/e2e/tests/12-subdir-tree.spec.ts
+++ b/e2e/tests/12-subdir-tree.spec.ts
@@ -69,3 +69,36 @@ test.describe('file tree clutter', () => {
     } finally { await cleanup(request, id); }
   });
 });
+
+test.describe('file guards (QA regressions)', () => {
+  test('create/rename onto an existing name never destroys the file', async ({ request }) => {
+    const id = await createProject(request, 'Guards');
+    try {
+      const before = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(before.length).toBeGreaterThan(0);
+      // createOnly onto an existing file → 409, file untouched
+      const c = await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: '', createOnly: true } });
+      expect(c.status()).toBe(409);
+      // rename onto an existing file → 409, both files untouched
+      const r = await request.post(`/api/projects/${id}/file/rename`, { data: { branch: 'main', from: 'references.bib', to: 'main.tex' } });
+      expect(r.status()).toBe(409);
+      const after = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(after).toBe(before);
+      const bib = await request.get(`/api/projects/${id}/file?branch=main&path=references.bib`);
+      expect(bib.ok()).toBeTruthy();
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('deleting the typeset root reassigns rootFile to another .tex', async ({ request }) => {
+    const id = await createProject(request, 'Root Reassign');
+    try {
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'other.tex', content: '\\documentclass{article}\\begin{document}y\\end{document}\n' } });
+      const del = await request.delete(`/api/projects/${id}/file?branch=main&path=main.tex`);
+      expect((await del.json()).newRoot).toBe('other.tex');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+});

--- a/e2e/tests/13-visual.spec.ts
+++ b/e2e/tests/13-visual.spec.ts
@@ -94,6 +94,135 @@ test.describe('visual editor (experimental)', () => {
     }
   });
 
+  test('math renders via KaTeX and click reveals its source', async ({ page, request }) => {
+    const id = await createProject(request, 'Visual Math');
+    try {
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: 'Euler: $e^{i\\pi} + 1 = 0$ stays true.\n\\[ \\int_0^1 x^2 \\, dx = \\tfrac{1}{3} \\]\nplain end\n' } });
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'plain end' }).click();
+      await expect(page.getByTestId('vis-math')).toHaveCount(2);
+      await expect(page.locator('.katex').first()).toBeVisible();
+      await expect(page.locator('.cm-content')).not.toContainText('e^{i\\pi}');
+      // click the inline equation → raw source appears for editing
+      await page.getByTestId('vis-math').first().click();
+      await expect(page.locator('.cm-content')).toContainText('$e^{i\\pi} + 1 = 0$');
+      // leave → re-rendered
+      await page.locator('.cm-line', { hasText: 'plain end' }).click();
+      await expect(page.locator('.cm-content')).not.toContainText('e^{i\\pi}');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('lists render with markers; cite and figure become chips', async ({ page, request }) => {
+    const id = await createProject(request, 'Visual Chips');
+    const doc = [
+      'Intro text.',
+      '\\begin{itemize}',
+      '\\item First point',
+      '\\item Second point',
+      '\\end{itemize}',
+      'See \\cite{knuth1984} and Figure ref.',
+      '\\begin{figure}',
+      '\\caption{A very nice plot}',
+      '\\end{figure}',
+      'plain end',
+      '',
+    ].join('\n');
+    try {
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: doc } });
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'plain end' }).click();
+      await expect(page.getByTestId('vis-item')).toHaveCount(2);
+      await expect(page.locator('.cm-content')).not.toContainText('\\begin{itemize}');
+      await expect(page.getByTestId('vis-chip-cite')).toContainText('knuth1984');
+      await expect(page.getByTestId('vis-chip-figure')).toContainText('A very nice plot');
+      await expect(page.locator('.cm-content')).not.toContainText('\\caption');
+      // clicking the figure chip reveals its source
+      await page.getByTestId('vis-chip-figure').click();
+      await expect(page.locator('.cm-content')).toContainText('\\begin{figure}');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('Mod-B wraps and unwraps the selection byte-exactly', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Bold');
+    const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+    try {
+      await openProject(page, id);
+      const line = page.locator('.cm-line', { hasText: 'More prose here.' });
+      await line.click();
+      // select the word "prose" precisely
+      const box = (await line.boundingBox())!;
+      await page.mouse.dblclick(box.x + 42, box.y + box.height / 2);
+      await page.evaluate(() => window.getSelection()?.toString());
+      await page.keyboard.press(`${mod}+b`);
+      await page.waitForTimeout(2500); // collab flush
+      const wrapped = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(wrapped).toContain('\\textbf{');
+      // caret is inside the new bold → construct revealed; toggle again unwraps
+      await page.keyboard.press(`${mod}+b`);
+      await page.waitForTimeout(2500);
+      const unwrapped = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(unwrapped).toBe(DOC);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('dual-mode collab: visual and source peers stay byte-consistent', async ({ browser, request }) => {
+    const id = await seed(request, 'Dual Mode');
+    const mk = async (visual: boolean) => {
+      const ctx = await browser.newContext();
+      await ctx.addInitScript((v) => {
+        window.localStorage.setItem('aldine.onboarded', '1');
+        window.localStorage.setItem('aldine.experimental.visualEditor', v ? '1' : '0');
+        window.localStorage.setItem('aldine.editorMode', v ? 'visual' : 'source');
+        window.localStorage.setItem('aldine.name', v ? 'Ada' : 'Grace');
+      }, visual);
+      return { ctx, page: await ctx.newPage() };
+    };
+    const A = await mk(true);
+    const B = await mk(false);
+    try {
+      await openProject(A.page, id);
+      await openProject(B.page, id);
+      await A.page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+
+      // B (source) extends the heading; A (visual) sees the rendered heading update
+      await B.page.locator('.cm-line', { hasText: '\\section{Introduction}' }).click();
+      await B.page.keyboard.press('End');
+      await B.page.keyboard.press('ArrowLeft'); // inside the closing brace
+      await B.page.keyboard.type(' and Basics');
+      await expect(A.page.locator('.cm-line.cm-vis-h1')).toContainText('Introduction and Basics', { timeout: 10_000 });
+
+      // remote-caret force-reveal: B's caret sits inside \textbf{...} → A shows raw source
+      await B.page.locator('.cm-line', { hasText: '\\textbf{brave}' }).click();
+      await B.page.keyboard.press('Home');
+      for (let i = 0; i < 15; i++) await B.page.keyboard.press('ArrowRight'); // into "brave"
+      // (the remote caret label renders inside the word, so match the markup prefix)
+      await expect(A.page.locator('.cm-content')).toContainText('\\textbf{', { timeout: 10_000 });
+
+      // A (visual) types prose; B sees the exact source
+      await A.page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      await A.page.keyboard.press('End');
+      await A.page.keyboard.type(' Extra from A.');
+      await expect(B.page.locator('.cm-content')).toContainText('Extra from A.', { timeout: 10_000 });
+
+      // stored bytes match both peers' view of the world, exactly
+      await A.page.waitForTimeout(2500);
+      const text = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(text).toBe(DOC
+        .replace('\\section{Introduction}', '\\section{Introduction and Basics}')
+        .replace('More prose here.', 'More prose here. Extra from A.'));
+    } finally {
+      await A.ctx.close();
+      await B.ctx.close();
+      await cleanup(request, id);
+    }
+  });
+
   test('spellcheck toggle no longer remounts the editor', async ({ page, request }) => {
     const id = await seed(request, 'No Remount');
     try {

--- a/e2e/tests/13-visual.spec.ts
+++ b/e2e/tests/13-visual.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../fixtures';
+import { createProject, openProject, cleanup } from './helpers';
+
+const DOC = [
+  '\\section{Introduction}',
+  'Hello \\textbf{brave} new \\emph{world} of text.',
+  '',
+  '\\subsection{Details}',
+  'More prose here.',
+  '',
+].join('\n');
+
+test.describe('visual editor (experimental)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('aldine.experimental.visualEditor', '1');
+      window.localStorage.setItem('aldine.editorMode', 'visual');
+    });
+  });
+
+  async function seed(request: Parameters<typeof createProject>[0], name: string) {
+    const id = await createProject(request, name);
+    await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: DOC } });
+    return id;
+  }
+
+  test('renders headings and styles, toggles back to source without remount', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Render');
+    try {
+      await openProject(page, id);
+      // park the caret in plain prose — the construct under the caret is
+      // (correctly) revealed as source, and a fresh doc opens with caret at 0
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      // markup hidden, content rendered
+      await expect(page.locator('.cm-content')).toContainText('Introduction');
+      await expect(page.locator('.cm-content')).not.toContainText('\\section{');
+      await expect(page.locator('.cm-vis-h1')).toHaveCount(1);
+      await expect(page.locator('.cm-vis-h2')).toHaveCount(1);
+      await expect(page.locator('.cm-vis-b')).toContainText('brave');
+      await expect(page.locator('.cm-vis-i')).toContainText('world');
+
+      // tag the editor DOM, toggle to Source — same DOM node must survive (no remount)
+      await page.evaluate(() => { document.querySelector('.cm-content')!.setAttribute('data-mounted', 'once'); });
+      await page.getByTestId('mode-toggle').getByRole('tab', { name: 'Source' }).click();
+      await expect(page.locator('.cm-content')).toContainText('\\section{Introduction}');
+      await expect(page.locator('.cm-content[data-mounted="once"]')).toHaveCount(1);
+
+      // and back
+      await page.getByTestId('mode-toggle').getByRole('tab', { name: 'Visual' }).click();
+      await expect(page.locator('.cm-content')).not.toContainText('\\section{');
+      await expect(page.locator('.cm-content[data-mounted="once"]')).toHaveCount(1);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('cursor-reveal shows source for the construct under the caret', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Reveal');
+    try {
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      await expect(page.locator('.cm-vis-b')).toContainText('brave');
+      await page.locator('.cm-vis-b').click();
+      // the bold construct un-renders: raw markup visible
+      await expect(page.locator('.cm-content')).toContainText('\\textbf{brave}');
+      // click into plain prose → re-renders
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      await expect(page.locator('.cm-content')).not.toContainText('\\textbf{');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('a visual-mode cursor tour never changes a byte of source', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Bytes');
+    try {
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      await expect(page.locator('.cm-vis-h1')).toHaveCount(1);
+      // tour: click into every construct, arrow across atomic boundaries
+      for (const target of ['.cm-vis-b', '.cm-vis-i', '.cm-vis-h1', '.cm-vis-h2'] as const) {
+        await page.locator(target).first().click({ force: true }).catch(() => {});
+        for (let i = 0; i < 6; i++) await page.keyboard.press('ArrowRight');
+        for (let i = 0; i < 3; i++) await page.keyboard.press('ArrowLeft');
+      }
+      await page.keyboard.press('End');
+      await page.keyboard.press('Home');
+      // let the collab layer flush any (nonexistent) writes
+      await page.waitForTimeout(3000);
+      const res = await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`);
+      expect(await res.text()).toBe(DOC);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('spellcheck toggle no longer remounts the editor', async ({ page, request }) => {
+    const id = await seed(request, 'No Remount');
+    try {
+      await openProject(page, id);
+      await page.evaluate(() => { document.querySelector('.cm-content')!.setAttribute('data-mounted', 'once'); });
+      await page.keyboard.press(process.platform === 'darwin' ? 'Meta+k' : 'Control+k');
+      await page.getByTestId('palette-input').fill('spellcheck');
+      await page.keyboard.press('Enter');
+      await expect(page.locator('.cm-content[data-mounted="once"]')).toHaveCount(1);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+});

--- a/e2e/tests/13-visual.spec.ts
+++ b/e2e/tests/13-visual.spec.ts
@@ -202,12 +202,15 @@ test.describe('visual editor (experimental)', () => {
       await openProject(B.page, id);
       await A.page.locator('.cm-line', { hasText: 'More prose here.' }).click();
 
-      // B (source) extends the heading; A (visual) sees the rendered heading update
+      // B (source) extends the heading; A (visual) receives the edit. A renders
+      // it either as a styled heading or — because B's caret sits in that
+      // construct — as revealed raw source (remote-caret force-reveal). Either
+      // way the new text must be present in A's document.
       await B.page.locator('.cm-line', { hasText: '\\section{Introduction}' }).click();
       await B.page.keyboard.press('End');
       await B.page.keyboard.press('ArrowLeft'); // inside the closing brace
       await B.page.keyboard.type(' and Basics');
-      await expect(A.page.locator('.cm-line.cm-vis-h1')).toContainText('Introduction and Basics', { timeout: 10_000 });
+      await expect(A.page.locator('.cm-content')).toContainText('Introduction and Basics', { timeout: 10_000 });
 
       // remote-caret force-reveal: B's caret sits inside \textbf{...} → A shows raw source
       await B.page.locator('.cm-line', { hasText: '\\textbf{brave}' }).click();

--- a/e2e/tests/13-visual.spec.ts
+++ b/e2e/tests/13-visual.spec.ts
@@ -103,9 +103,21 @@ test.describe('visual editor (experimental)', () => {
       await expect(page.getByTestId('vis-math')).toHaveCount(2);
       await expect(page.locator('.katex').first()).toBeVisible();
       await expect(page.locator('.cm-content')).not.toContainText('e^{i\\pi}');
-      // click the inline equation → raw source appears for editing
+      // click the inline equation → the MathLive editor opens
       await page.getByTestId('vis-math').first().click();
-      await expect(page.locator('.cm-content')).toContainText('$e^{i\\pi} + 1 = 0$');
+      await expect(page.getByTestId('math-popover')).toBeVisible();
+      // editing through the math field writes back a precise source edit
+      await page.evaluate(() => {
+        (document.querySelector('[data-testid="math-field"]') as HTMLElement & { value: string }).value = 'e^{i\\pi} + 2 = 1';
+      });
+      await page.getByTestId('math-popover-done').click();
+      await page.waitForTimeout(2500);
+      const edited = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(edited).toContain('$e^{i\\pi} + 2 = 1$');
+      // the "TeX" button drops into raw source instead
+      await page.getByTestId('vis-math').first().click();
+      await page.getByTestId('math-popover-source').click();
+      await expect(page.locator('.cm-content')).toContainText('$e^{i\\pi} + 2 = 1$');
       // leave → re-rendered
       await page.locator('.cm-line', { hasText: 'plain end' }).click();
       await expect(page.locator('.cm-content')).not.toContainText('e^{i\\pi}');
@@ -135,7 +147,7 @@ test.describe('visual editor (experimental)', () => {
       await page.locator('.cm-line', { hasText: 'plain end' }).click();
       await expect(page.getByTestId('vis-item')).toHaveCount(2);
       await expect(page.locator('.cm-content')).not.toContainText('\\begin{itemize}');
-      await expect(page.getByTestId('vis-chip-cite')).toContainText('knuth1984');
+      await expect(page.getByTestId('vis-chip-cite')).toContainText(/knuth1984|Knuth 1984/);
       await expect(page.getByTestId('vis-chip-figure')).toContainText('A very nice plot');
       await expect(page.locator('.cm-content')).not.toContainText('\\caption');
       // clicking the figure chip reveals its source
@@ -219,6 +231,92 @@ test.describe('visual editor (experimental)', () => {
     } finally {
       await A.ctx.close();
       await B.ctx.close();
+      await cleanup(request, id);
+    }
+  });
+
+  test('table renders as an editable grid; cell edits are precise', async ({ page, request }) => {
+    const id = await createProject(request, 'Visual Table');
+    const doc = 'Before.\n\\begin{tabular}{ll}\na & b \\\\\nc & d \\\\\n\\end{tabular}\nplain end\n';
+    try {
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: doc } });
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'plain end' }).click();
+      await expect(page.getByTestId('vis-table')).toBeVisible();
+      // edit cell "b" → "beta"
+      await page.getByTestId('vis-table').locator('td', { hasText: 'b' }).first().dispatchEvent('mousedown');
+      const input = page.getByTestId('vis-table-cell-input');
+      await input.fill('beta');
+      await input.press('Enter');
+      await page.waitForTimeout(2500);
+      let text = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(text).toContain('a & beta');
+      // add a row
+      await page.getByTestId('vis-table-addrow').dispatchEvent('mousedown');
+      await page.waitForTimeout(2500);
+      text = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(text.match(/\\\\/g)!.length).toBeGreaterThanOrEqual(3);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('outline dropdown lists headings and jumps', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Outline');
+    try {
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      const dd = page.getByTestId('outline-dropdown');
+      await dd.focus();
+      await expect(dd.locator('option', { hasText: 'Introduction' })).toHaveCount(1);
+      await expect(dd.locator('option', { hasText: 'Details' })).toHaveCount(1);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('a suggestion renders as an inline tracked change and accepts', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Suggest');
+    try {
+      await request.post(`/api/projects/${id}/comments`, {
+        data: {
+          branch: 'main', file: 'main.tex',
+          anchor: { from: DOC.indexOf('More prose here.'), to: DOC.indexOf('More prose here.') + 'More prose'.length, quote: 'More prose' },
+          body: 'tighten this', suggestion: 'Less prose', author: 'Reviewer',
+        },
+      });
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'Hello' }).click();
+      await expect(page.getByTestId('vis-suggest')).toBeVisible();
+      await expect(page.locator('.cm-vis-strike')).toContainText('More prose');
+      await page.getByTestId('vis-suggest-accept').dispatchEvent('mousedown');
+      await page.waitForTimeout(2500);
+      const text = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(text).toContain('Less prose here.');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('pasting rich HTML converts to LaTeX', async ({ page, request }) => {
+    const id = await seed(request, 'Visual Paste');
+    try {
+      await openProject(page, id);
+      await page.locator('.cm-line', { hasText: 'More prose here.' }).click();
+      await page.keyboard.press('End');
+      await page.evaluate(() => {
+        const dt = new DataTransfer();
+        dt.setData('text/html', '<p>Copied <b>bold</b> and <i>slanted</i> words.</p><ul><li>alpha</li><li>beta</li></ul>');
+        dt.setData('text/plain', 'Copied bold and slanted words. alpha beta');
+        document.querySelector('.cm-content')!.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+      });
+      await page.waitForTimeout(2500);
+      const text = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(text).toContain('\\textbf{bold}');
+      expect(text).toContain('\\textit{slanted}');
+      expect(text).toContain('\\begin{itemize}');
+      expect(text).toContain('\\item alpha');
+    } finally {
       await cleanup(request, id);
     }
   });

--- a/e2e/tests/mock-zotero.mjs
+++ b/e2e/tests/mock-zotero.mjs
@@ -65,8 +65,11 @@ const server = http.createServer((req, res) => {
   }
 
   // --- DOI content negotiation (any 10.x path) ---
+  // Title carries an HTML &amp; like real CrossRef output — the server must
+  // decode + LaTeX-escape it so the .bib compiles (regression: a bare & is an
+  // alignment tab and breaks the whole document).
   if (url.pathname.startsWith('/10.')) {
-    return send(200, `@article{doe2020,\n  title = {A Mock Paper for Testing},\n  author = {Doe, Jane},\n  year = {2020},\n  doi = {${url.pathname.slice(1)}},\n}`);
+    return send(200, `@article{doe2020,\n  title = {Knowledge Discovery &amp; Data Mining},\n  author = {Doe, Jane},\n  year = {2020},\n  doi = {${url.pathname.slice(1)}},\n}`);
   }
   // --- arXiv Atom feed ---
   if (url.pathname === '/api/query') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "aldine",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
         "apps/web"
@@ -18,6 +19,7 @@
     "apps/server": {
       "name": "@aldine/server",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@fastify/static": "^8.1.1",
@@ -45,6 +47,7 @@
     "apps/web": {
       "name": "@aldine/web",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.8.1",
@@ -54,6 +57,8 @@
         "@codemirror/view": "^6.36.8",
         "@hocuspocus/provider": "^2.15.2",
         "codemirror-lang-latex": "^0.4.1",
+        "katex": "^0.18.1",
+        "mathlive": "^0.110.0",
         "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -62,12 +67,22 @@
         "yjs": "^13.6.27"
       },
       "devDependencies": {
+        "@types/katex": "^0.16.8",
         "@types/react": "^18.3.20",
         "@types/react-dom": "^18.3.6",
         "@vitejs/plugin-react": "^4.4.1",
         "typescript": "^5.8.3",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@aldine/server": {
+      "resolved": "apps/server",
+      "link": true
+    },
+    "node_modules/@aldine/web": {
+      "resolved": "apps/web",
+      "link": true
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.68.0",
@@ -88,6 +103,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@arnog/colors": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@arnog/colors/-/colors-0.5.0.tgz",
+      "integrity": "sha512-NB7yqrO7qvInsqJdqz6C6mDU+2oiKmbBbk3czMS0E7KkGxLRy538tEHCsB5TKqmaxxXpi6/U120TnGl8NsDePg==",
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/client-sesv2": {
       "version": "3.1090.0",
@@ -779,6 +800,21 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@cortex-js/compute-engine": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.58.0.tgz",
+      "integrity": "sha512-N0+vXjVZfKwJS7ZIGvq41mojI55m5TrdDXveAXzNjzjZ9iNiNrdEzXL2EmrcP+9GCWCwTonrEeZWAIG78f3INg==",
+      "license": "MIT",
+      "dependencies": {
+        "@arnog/colors": "^0.5.0",
+        "complex-esm": "^2.1.1-esm1",
+        "decimal.js": "^10.6.0"
+      },
+      "engines": {
+        "node": ">=21.7.3",
+        "npm": ">=10.5.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2512,14 +2548,6 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
-    "node_modules/@aldine/server": {
-      "resolved": "apps/server",
-      "link": true
-    },
-    "node_modules/@aldine/web": {
-      "resolved": "apps/web",
-      "link": true
-    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -3134,6 +3162,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3179,6 +3214,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.36",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
@@ -3189,10 +3235,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3314,6 +3374,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -3374,6 +3547,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-lock": {
@@ -3514,6 +3697,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -3548,6 +3741,25 @@
         "@lezer/generator": "^1.8.0",
         "@lezer/highlight": "^1.2.3",
         "@lezer/lr": "^1.4.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/complex-esm": {
+      "version": "2.1.1-esm1",
+      "resolved": "https://registry.npmjs.org/complex-esm/-/complex-esm-2.1.1-esm1.tgz",
+      "integrity": "sha512-IShBEWHILB9s7MnfyevqNGxV0A1cfcSnewL/4uPFiSxkcQL4Mm3FxJ0pXMtCXuWLjYz3lRRyk6OfkeDZcjD6nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
       }
     },
     "node_modules/content-disposition": {
@@ -3626,6 +3838,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -3670,6 +3888,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3727,6 +3952,26 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -4162,6 +4407,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
+      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -4278,6 +4539,29 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.110.0.tgz",
+      "integrity": "sha512-UOpJsQ6h1eeN0xZULGTl1MwUB/lZLCDuzKeHvKEh7Zra8U/rtgDNrssj5PZdJtBTIV48AfEhtv6rv47AeMOxJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cortex-js/compute-engine": "0.58.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -4366,6 +4650,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4422,6 +4720,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
       "version": "4.10.38",
@@ -5070,6 +5375,13 @@
       "license": "BSD-2-Clause",
       "optional": true
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5127,6 +5439,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -5142,6 +5461,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -5180,6 +5506,23 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5195,6 +5538,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -5899,6 +6252,96 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -5918,6 +6361,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/plugins/zotero/index.js
+++ b/plugins/zotero/index.js
@@ -63,7 +63,7 @@ export default {
 
         const connect = async () => {
           const key = state.apiKey.trim();
-          if (!key) return;
+          if (!key) { aldine.toast('Paste a Zotero API key first', 'error'); return; }
           setBusy(true);
           try {
             const info = await jfetch('/api/zotero/validate', { method: 'POST', body: JSON.stringify({ apiKey: key }) });

--- a/site/index.html
+++ b/site/index.html
@@ -229,9 +229,27 @@
       <strong>track changes, git, and Zotero</strong>, and the deployment is a Toolkit-managed
       monolith with Mongo and Redis. In Aldine every feature is free, and the whole thing is
       two containers.</p>
-      <p>Where Overleaf still wins: a huge template gallery, a visual editor, and a decade of
-      production maturity. We say so in the <a href="https://github.com/trahloff/Aldine#how-aldine-compares">README table</a>
-      too — the visual editor is next on the roadmap.</p>
+      <p>Where Overleaf still wins: a huge template gallery and a decade of production
+      maturity. We say so in the <a href="https://github.com/trahloff/Aldine#how-aldine-compares">README table</a>
+      too. On the visual editor, though, Aldine now goes further — see below.</p>
+    </div>
+  </section>
+
+  <section class="wrap">
+    <h3 class="sec">Visual editing, done right <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-3)">(experimental)</span></h3>
+    <div class="honest">
+      <p>Overleaf's visual editor is infamous for one thing: it rewrites your LaTeX in
+      arbitrary ways, so collaborators tell each other not to use it. Aldine's is a pure
+      rendering layer over the same source — <strong>it never changes a byte you didn't
+      deliberately edit</strong> (there's a test that proves it). And it does more:</p>
+      <div class="grid" style="margin-top:16px">
+        <div class="cell"><h4>WYSIWYG math</h4><p>Click an equation to edit it in a real math editor; your changes write back as precise LaTeX.</p></div>
+        <div class="cell"><h4>Editable tables</h4><p>Tables render as a grid — edit cells, add rows and columns — all as exact source edits.</p></div>
+        <div class="cell"><h4>Tracked changes</h4><p>Review suggestions show inline as strikethrough + proposed text, accepted or dismissed in place.</p></div>
+        <div class="cell"><h4>Paste to LaTeX</h4><p>Paste rich text from Word or Docs and it converts to clean LaTeX on the way in.</p></div>
+        <div class="cell"><h4>Live &amp; collab-safe</h4><p>The construct under your caret — or a co-author's — reveals its source; everything else stays rendered.</p></div>
+        <div class="cell"><h4>One keystroke away</h4><p>Toggle Source / Visual instantly, no reload. Off by default; enable it from the command palette.</p></div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
LaTeX renders as formatted text — styled headings, bold/italic, real lists, KaTeX math, editable tables, image-previewing figure chips, author-year cite chips — while the raw source stays the single source of truth.

## The core guarantee: byte-stable

The visual layer is a pure decoration layer over the shared Y.Text. It **never** rewrites source you didn't deliberately edit — proven by an e2e test that tours the cursor through every construct and asserts the stored file is string-identical afterwards. (This is the known failure mode of Overleaf's visual editor.)

## What's in

**Parity core**
- Rendered headings (8 levels), bold/italic/emph/underline/small-caps, itemize/enumerate/description lists, KaTeX math, verbatim always raw
- **Cursor-reveal**: the construct under any caret shows raw source — including *remote collaborators'* carets (mapped via `ySyncFacet`), which structurally prevents remote-caret-in-hidden-range bugs
- Whitelist-only rendering: unknown/broken constructs always stay raw
- Compartment-based mode switch: no remount, no socket reconnect (also fixes the old spellcheck full-remount)
- Mod-B/Mod-I + formatting toolbar — plain CM dispatches, collaborative + undoable

**Beyond parity**
- **MathLive**: click an equation → structured WYSIWYG math editing in a popover; Done writes one precise source edit (stale-range guarded); TeX button drops to source. Lazy 228 KB gzip chunk.
- **Editable tables**: tabular renders as a grid — click cells to edit, add row/column — all as exact source edits
- **Inline tracked changes**: review suggestions render as strikethrough + proposed text + accept/dismiss (same API as the Review panel)
- **Paste-to-LaTeX**: rich HTML from Word/Docs converts to clean LaTeX on paste
- **Contents dropdown**: heading outline with jump
- **Rich chips**: cites show author-year from the bibliography; figures show the actual image

## Gating

Behind `aldine.experimental.visualEditor` (default off; enable via ⌘K). Merges after launch settles.

## Validation

13 unit tests · 12 visual e2e (byte-stability, MathLive round-trip, table edits, suggestion accept, paste conversion, dual-mode collab byte-consistency, remote-caret reveal) · full regression 51 main + 15 auth e2e green · KaTeX/MathLive as lazy chunks, main bundle ~+5 KB gzip