### PR TITLE
Import, engine picker, SyncTeX jumps, stale preview, full TeX Live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ All notable changes to Aldine are documented here. The format follows
   names.
 
 ### Changed
+- The compiler image defaults to full TeX Live (`TEXLIVE_SCHEME=full`): every
+  script and language compiles out of the box. The `medium` scheme stays for
+  constrained hosts and now includes the publisher classes and the Arabic/Persian,
+  Cyrillic, Greek and other-script collections (Persian via xepersian or
+  polyglossia verified). Self-hosters: rebuild the compiler image; expect ~9 GB
+  on disk for the default.
+- The compiler image installs `collection-publishers` (elsarticle, IEEEtran,
+  acmart, revtex4-2, agujournal, copernicus, and the other journal and
+  conference classes) on the medium scheme, and the full scheme's base image
+  is pinned by digest like the medium one. Self-hosters must rebuild the
+  compiler image (`docker compose build compiler`) to get the classes.
 - `deploy/papyr-backup.service` / `.timer` are renamed to `aldine-backup.*`, the
   names the runbook has always used, so the install commands work as written. If
   you installed the old units, disable and delete them or both timers will run.
@@ -55,6 +66,60 @@ All notable changes to Aldine are documented here. The format follows
   behind a paid tier.
 
 ### Fixed
+- Importing a ZIP larger than about 24 MB no longer fails with a bare
+  "Payload Too Large": the import route now accepts the 60 MB the dialog
+  promises (the ZIP travels base64-encoded inside JSON, so the global 32 MB
+  body limit cut it off early), and a ZIP over the limit says so with both
+  numbers ("ZIP is 65 MB; the limit is 60 MB"). The import dialog's own
+  pre-flight toast states both numbers too, and a 413 from a proxy in front of
+  the app is reported as "ZIP too large for this server" with the size rather
+  than as a generic import failure. Self-hosters running their own nginx:
+  raise `client_max_body_size` to 81m as `deploy/nginx.conf` now does
+  (`deploy/README.md` said 32m was the load-bearing value; it names 81m now).
+- A ZIP whose entry names escape the project (`../x`, absolute paths, drive
+  letters) is rejected as a whole before anything is created, and any failure
+  after the project exists removes it again, so a bad import no longer leaves
+  a half-imported project in the list. Names with dots inside (`data..csv`)
+  and Windows-style backslash paths import correctly instead of being dropped
+  or written under a literal backslash name.
+- Root-file detection on import finds the manuscript instead of the largest
+  file: it looks past comment banners longer than 4 KB, prefers a file with
+  `\begin{document}` over a class stub, prefers conventional names
+  (`main`, `paper`, `manuscript`, `ms`, `article`, `thesis`) and the
+  shallowest path, and among equals takes the smaller file rather than a
+  bundled template. Without any `\documentclass` it names a `.tex` that is
+  actually in the archive instead of a non-existent `main.tex`.
+- Setting the typeset engine to anything the compiler cannot run is refused
+  with a 400 naming the valid engines (`pdf`, `xelatex`, `lualatex`); it used
+  to be stored and then silently typeset with pdflatex. The engine is now
+  visible and switchable in the app: a picker in the preview toolbar and
+  "Typeset with pdfLaTeX / XeLaTeX / LuaLaTeX" in the command palette, which
+  re-typeset straight away when a PDF is on screen (before, the only way to
+  change it was the API).
+- Forward SyncTeX (editor to PDF) works when the root file lives in a
+  subdirectory: the compiler now hands `synctex` the file name relative to
+  the compile directory, the way the `.synctex.gz` records it, mirroring the
+  inverse direction. In the app the jump is now discoverable and honest: a
+  "Jump to PDF" button in the editor header with the shortcut, ⌘J / Ctrl+J
+  works from anywhere in the editor page (it used to work only while the code
+  editor had focus), and a jump that cannot land says why ("No PDF location
+  for this line — typeset first" / "Jump unavailable for this file") instead
+  of doing nothing.
+- A failed typeset no longer presents the previous PDF as a fresh result. The
+  compile result keeps the last successful `pdfUrl` unchanged (the preview
+  keeps showing what it showed) and reports `pdfStale: true`, so inverse
+  SyncTeX jumps and the preview can say the PDF is from the last successful
+  typeset instead of quietly landing lines off. The preview pane shows a
+  "Preview is from the last successful typeset" ribbon while the last run
+  failed, a double-click on that stale preview says the jump may be off
+  before attempting it, and a double-click with no source location says so
+  instead of doing nothing. The result also carries the `synctex` path
+  again. Deleting a branch (or the project) forgets its remembered PDF, so a
+  branch recreated under the same name cannot be handed a URL to a file that
+  went with the old worktree; and switching branches empties the preview, so
+  a failed first typeset on the new branch no longer labels the previous
+  branch's pages as its "last successful typeset". ⌘J / Ctrl+J is left alone
+  while typing in a comment, dialog, or palette field.
 - The demo box's nightly wipe no longer destroys Caddy's certificate store. It
   used `docker compose down -v`, so every wipe re-issued a certificate for the
   same hostname; on the fifth day in a rolling week Let's Encrypt refuses, and

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ what `deploy/backup.sh` looks for.
   installs LaTeX packages; expect 15–40 minutes.
 - **Need packages beyond the curated set?** Build the full file with all of
   CTAN preinstalled (~9 GB on disk):
-  `ALDINE_TEXLIVE_SCHEME=full docker compose -f docker-compose.full.yml up -d --build`.
+  `ALDINE_TEXLIVE_SCHEME=medium docker compose -f docker-compose.full.yml up -d --build` for a slimmer image (curated packages, no CJK).
 
 ## How Aldine compares
 
@@ -180,7 +180,7 @@ what `deploy/backup.sh` looks for.
 | Zotero | Whole library **or one collection**, free | Premium, whole library | Via Better BibTeX, manual |
 | Warm recompile | ~2s (persistent latexmk cache) | Comparable | Fastest (local) |
 | Templates gallery | 4 built-in | Huge community gallery | CTAN / your own |
-| Package coverage | Curated set, or **all of CTAN** (`ALDINE_TEXLIVE_SCHEME=full`) | All of TeX Live | Whatever you install |
+| Package coverage | **All of TeX Live** by default (`ALDINE_TEXLIVE_SCHEME=medium` for a curated slim image) | All of TeX Live | Whatever you install |
 | Rich-text / visual editing | ✅ experimental: byte-stable, WYSIWYG math, editable tables, tracked changes | ✅ (rewrites your source) | ❌ |
 | Maturity | Young (v0.x, 2026) | A decade in production | Very mature |
 | License | AGPL-3.0 | AGPL | MIT/varies |

--- a/apps/compiler/Dockerfile
+++ b/apps/compiler/Dockerfile
@@ -1,31 +1,42 @@
 # Two selectable TeX Live schemes (build arg TEXLIVE_SCHEME=medium|full):
 #
-#   medium (default) — ~1 GB of packages plus a pinned set of extras real
-#     papers commonly need. The slim self-host default.
-#   full — everything on CTAN preinstalled (~9 GB on disk). Choose this when your
-#     documents need packages beyond the pinned set:
-#       ALDINE_TEXLIVE_SCHEME=full docker compose up -d --build
+#   full (default) — everything on CTAN preinstalled (~9 GB on disk). Every
+#     script and language TeX Live supports compiles out of the box; this is what
+#     an Overleaf user expects.
+#   medium — ~1.3 GB of packages plus a pinned set of extras real papers commonly
+#     need, the publisher classes, and the Arabic/Persian, Cyrillic, Greek and
+#     "other" script collections (CJK is the one family left to full). For
+#     constrained hosts:
+#       ALDINE_TEXLIVE_SCHEME=medium docker compose up -d --build
 #
-# The medium base is pinned by digest so tlmgr revisions are reproducible (a
-# floating tag makes the snapshot-repository date below drift out of sync and
-# the build fail). The digest must be OLDER than the snapshot date, never
-# newer. The full base needs no tlmgr at build time (nothing to install), so
-# it can float and mirror skew cannot bite.
-ARG TEXLIVE_SCHEME=medium
+# Both bases are pinned by digest. For medium the pin keeps tlmgr revisions
+# reproducible (a floating tag makes the snapshot-repository date below drift
+# out of sync and the build fail); its digest must be OLDER than the snapshot
+# date, never newer. For full nothing is installed at build time, so the pin
+# only makes a rebuild reproduce the same image. Each digest is the multi-arch
+# index digest reported by
+#   docker buildx imagetools inspect texlive/texlive:<tag>
+# (the top-level "Digest:" line, not a per-platform manifest).
+ARG TEXLIVE_SCHEME=full
 
 FROM texlive/texlive:latest-medium@sha256:0a5aa82d0d9d6e3b3a25f87e221ef61d7c077e83639ab5065cf298b1a01ec00c AS texlive-medium
 
-# Packages beyond scheme-medium that real papers commonly need
-# (newtx fonts, cleveref, etc.). A dated tlnet snapshot (not a random CTAN
+# Packages beyond scheme-medium that real papers commonly need (newtx fonts,
+# cleveref, etc.) plus collection-publishers: the journal and conference
+# classes (elsarticle, IEEEtran, acmart, revtex4-2, agujournal, copernicus, …)
+# that scheme-medium leaves out, the script collections (langarabic makes
+# xepersian/bidi/polyglossia compile — verified against a Persian document —
+# and needs zref from latexextra), and cyrillic/greek/other. A dated tlnet snapshot (not a random CTAN
 # mirror) because live mirrors regularly lag the texlive image's revisions,
 # which makes `tlmgr install` fail with "remote database is older than the
 # local installation". Bump the date together with the base-image digest.
 RUN tlmgr option repository https://texlive.info/tlnet-archive/2026/07/18/tlnet/ \
     && tlmgr update --self \
-    && tlmgr install newtx txfonts fontaxes lastpage titlesec xstring fancyhdr cleveref \
+    && tlmgr install collection-publishers collection-langarabic collection-langcyrillic \
+       collection-langgreek collection-langother zref newtx txfonts fontaxes lastpage titlesec xstring fancyhdr cleveref \
        enumitem wrapfig threeparttable placeins multirow doclicense algorithmicx xurl sttools acro translations
 
-FROM texlive/texlive:latest-full AS texlive-full
+FROM texlive/texlive:latest-full@sha256:4984977ccf5afe883cb382d0163f267de0d029d140bb7a9e8f4c19f0b781d57b AS texlive-full
 # scheme-full already contains every CTAN package — nothing to install.
 
 FROM texlive-${TEXLIVE_SCHEME} AS base

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -212,7 +212,11 @@ async function synctex(body) {
   const pdf = path.join(rootDir, OUT_SUBDIR, `${base}.pdf`);
   let args;
   if (direction === 'forward') {
-    args = ['view', '-i', `${line}:${column}:${body.file || rootFile}`, '-o', pdf];
+    // synctex records inputs as TeX opened them — relative to the compile dir
+    // (the root file's dir, thanks to latexmk -cd) — while the client names
+    // files project-relative. The inverse direction undoes this below; mirror it.
+    const input = path.relative(rootDir, body.file || rootFile) || path.basename(rootFile);
+    args = ['view', '-i', `${line}:${column}:${input}`, '-o', pdf];
   } else {
     args = ['edit', '-o', `${page}:${x}:${y}:${pdf}`];
   }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -12,6 +12,9 @@ export interface CompileResult {
   exitCode?: number;
   pdf: string | null;      // path relative to branch dir (.aldine-out/main.pdf)
   pdfUrl: string | null;   // URL the client can fetch
+  /** A failed run left the previous PDF on disk: pdfUrl is the last successful one, unchanged. */
+  pdfStale?: boolean;
+  synctex: string | null;  // path relative to branch dir; informational
   log: string;
   errors: CompileError[];
   durationMs: number;
@@ -29,6 +32,26 @@ function relProjectDir(projectId: string, branch: string): string {
  * A queued request coalesces onto the in-flight one's successor.
  */
 const compileChain = new Map<string, Promise<unknown>>();
+
+/**
+ * Last successful pdfUrl per project::branch. A failed latexmk run leaves the
+ * previous PDF on disk (the compiler reports it by existence, not by `ok`), so
+ * minting a fresh cache-buster would present that old PDF as this run's result
+ * and misalign SyncTeX with the source. In-memory: after a restart the first
+ * failed compile reports no PDF rather than an unknown one.
+ */
+const lastGoodPdfUrl = new Map<string, string>();
+
+/**
+ * Drop remembered URLs when the files behind them go: deleting a branch
+ * removes its worktree (and .aldine-out), so a branch recreated under the
+ * same name must not inherit a URL that now 404s. Without `branch`, every
+ * branch of the project is forgotten.
+ */
+export function forgetPdfUrls(projectId: string, branch?: string): void {
+  if (branch !== undefined) { lastGoodPdfUrl.delete(`${projectId}::${branch}`); return; }
+  for (const key of lastGoodPdfUrl.keys()) if (key.startsWith(`${projectId}::`)) lastGoodPdfUrl.delete(key);
+}
 
 export function compileProject(projectId: string, branch: string): Promise<CompileResult> {
   const key = `${projectId}::${branch}`;
@@ -60,20 +83,25 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   const raw = (await res.json()) as Partial<Omit<CompileResult, 'pdfUrl'>> & { error?: string };
   // Normalize: the compiler may return a bare {ok:false,error} on a 4xx — always
   // hand the client a well-formed CompileResult so the UI never sees undefined fields.
-  const body: Omit<CompileResult, 'pdfUrl'> = {
+  const body: Omit<CompileResult, 'pdfUrl' | 'pdfStale'> = {
     ok: !!raw.ok,
     timedOut: raw.timedOut,
     exitCode: raw.exitCode,
     pdf: raw.pdf ?? null,
+    synctex: raw.synctex ?? null,
     log: raw.log ?? (raw.error ? `Compiler error: ${raw.error}` : ''),
     errors: Array.isArray(raw.errors) ? raw.errors : [],
     durationMs: raw.durationMs ?? 0,
     error: raw.error,
   };
-  const pdfUrl = body.pdf
-    ? `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${Date.now()}`
-    : null;
-  return { ...body, pdfUrl };
+  const key = `${projectId}::${branch}`;
+  if (body.ok && body.pdf) {
+    const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${Date.now()}`;
+    lastGoodPdfUrl.set(key, pdfUrl);
+    return { ...body, pdfUrl };
+  }
+  const previous = lastGoodPdfUrl.get(key) ?? null;
+  return { ...body, pdfUrl: previous, pdfStale: previous !== null };
 }
 
 export async function synctexLookup(projectId: string, branch: string, payload: Record<string, unknown>): Promise<unknown> {

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -5,7 +5,7 @@ import crypto from 'node:crypto';
 import * as store from './store.js';
 import * as gitops from './gitops.js';
 import * as zotero from './zotero.js';
-import { compileProject, synctexLookup } from './compile.js';
+import { compileProject, synctexLookup, forgetPdfUrls } from './compile.js';
 import * as usage from './usage.js';
 import * as github from './github.js';
 import { flushBranchDocs, refreshBranchDocsFromDisk, evictDoc, scheduleCommit, closeProjectConnections, bumpContentVersion, contentVersion, applySuggestionToDoc, protectedProjects } from './collab.js';
@@ -23,7 +23,7 @@ import * as oauth from './oauth.js';
 import * as email from './email.js';
 import { canAccess, isListed, isMember, isOwner, ownerName } from './authz.js';
 import { loginLimiter, registerLimiter, aiLimiter, refLimiter, compileGate, compileLimiter, clientKey } from './ratelimit.js';
-import { safeJoin, isTextFile, newId, BRANCH_RE } from './util.js';
+import { safeJoin, isTextFile, importPath, newId, BRANCH_RE } from './util.js';
 
 type Q = { branch?: string; path?: string; name?: string; force?: string };
 
@@ -63,6 +63,13 @@ function publicBase(req: FastifyRequest): string {
 /** Last HEAD we successfully pushed per project — lets auto-sync skip a no-op
  *  network push. In-memory (single-node); cleared on restart → push-when-unsure. */
 const lastPushedHead = new Map<string, string>();
+
+/** Raw ZIP size the import route accepts; the web import dialog states the same figure. */
+export const IMPORT_MAX_ZIP_BYTES = 60 * 1024 * 1024;
+const mb = (bytes: number) => Math.round(bytes / (1024 * 1024));
+
+/** Engines the compiler distinguishes; anything else silently became pdflatex. */
+export const ENGINES = ['pdf', 'xelatex', 'lualatex'] as const;
 
 /** git internals and compile output are never user-addressable — at any depth. */
 function isHiddenPath(rel: string): boolean {
@@ -403,32 +410,49 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/templates', async () => listTemplates());
 
   // Import an Overleaf/project ZIP (base64) as a new project.
-  app.post<{ Body: { name?: string; zipBase64: string } }>('/api/projects/import', async (req, reply) => {
+  // The ZIP arrives base64-encoded inside JSON (×4/3 of the raw size), so the
+  // route needs its own body limit: the global 32 MB one would cap imports at
+  // ~24 MB while the UI promises IMPORT_MAX_ZIP_BYTES. deploy/nginx.conf's
+  // client_max_body_size must stay ≥ this figure.
+  const importBodyLimit = Math.ceil(IMPORT_MAX_ZIP_BYTES * 4 / 3) + 1024 * 1024;
+  app.post<{ Body: { name?: string; zipBase64: string } }>('/api/projects/import', { bodyLimit: importBodyLimit }, async (req, reply) => {
     const { name, zipBase64 } = req.body || {};
     if (!zipBase64) return reply.code(400).send({ error: 'zipBase64 required' });
+    let created: store.ProjectMeta | null = null;
     try {
       const buf = Buffer.from(zipBase64, 'base64');
-      if (buf.length > 60 * 1024 * 1024) return reply.code(413).send({ error: 'ZIP too large (max 60 MB)' });
+      if (buf.length > IMPORT_MAX_ZIP_BYTES) {
+        return reply.code(413).send({ error: `ZIP is ${mb(buf.length)} MB; the limit is ${mb(IMPORT_MAX_ZIP_BYTES)} MB` });
+      }
       const entries = unzip(buf);
-      const paths = Object.keys(entries).filter((p) => !p.includes('..') && !p.startsWith('/') && !p.startsWith('__MACOSX/') && !isHiddenPath(p));
-      if (!paths.length) return reply.code(400).send({ error: 'ZIP had no usable files' });
+      // Every entry is placed (or rejected) before the project exists, so a bad
+      // path can never leave a half-imported project behind.
+      const files: Record<string, Buffer> = {};
+      for (const [entry, data] of Object.entries(entries)) {
+        const p = importPath(entry);
+        if (p === null) return reply.code(400).send({ error: `ZIP entry "${entry}" points outside the project` });
+        if (p.startsWith('__MACOSX/') || isHiddenPath(p)) continue;
+        files[p] = data;
+      }
+      if (!Object.keys(files).length) return reply.code(400).send({ error: 'ZIP had no usable files' });
       // create with text files seeded; write binaries as buffers afterward
       const textFiles: Record<string, string> = {};
       const binFiles: string[] = [];
-      for (const p of paths) {
-        const data = entries[p];
+      for (const [p, data] of Object.entries(files)) {
         // treat as text only if the extension says so AND there's no NUL byte in the head
         const looksBinary = data.subarray(0, 8000).includes(0);
         if (isTextFile(p) && !looksBinary) textFiles[p] = data.toString('utf8');
         else binFiles.push(p);
       }
       const meta = await store.createProject(name || 'Imported project', textFiles, reqUser(req)?.id);
-      for (const p of binFiles) store.writeFile(meta.id, 'main', p, entries[p]);
+      created = meta;
+      for (const p of binFiles) store.writeFile(meta.id, 'main', p, files[p]);
       if (binFiles.length) await gitops.commitAll(meta.id, 'main', 'aldine: import assets').catch(() => {});
-      const root = guessRoot(entries);
+      const root = guessRoot(files);
       if (root) { meta.rootFile = root; await store.writeMeta(meta); }
       return publicMeta(meta, reqUser(req));
     } catch (err: any) {
+      if (created) await store.deleteProject(created.id).catch(() => {});
       return reply.code(400).send({ error: `Could not import ZIP: ${err.message}` });
     }
   });
@@ -455,7 +479,12 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
         meta.name = trimmed;
       }
       if (rootFile) meta.rootFile = rootFile;
-      if (engine) meta.engine = engine;
+      if (engine !== undefined) {
+        if (!(ENGINES as readonly string[]).includes(engine as string)) {
+          return reply.code(400).send({ error: `Unknown engine "${String(engine)}" — use one of ${ENGINES.join(', ')}` });
+        }
+        meta.engine = engine;
+      }
       await store.writeMeta(meta);
       return publicMeta(meta, reqUser(req));
     });
@@ -468,6 +497,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     if (req.query.permanent === '1') await store.deleteProject(req.params.id);
     else await store.softDeleteProject(req.params.id);
     lastPushedHead.delete(req.params.id); // don't leak the push-dedup entry (or reuse a stale hash)
+    forgetPdfUrls(req.params.id);
     // Deleting revokes access just like un-sharing: drop live collab sessions
     // (here and on peer nodes) so nobody keeps editing a trashed project.
     closeProjectConnections(req.params.id);
@@ -761,6 +791,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     } catch (err) {
       return reply.code(409).send({ error: `Could not delete branch: ${(err as Error).message}` });
     }
+    forgetPdfUrls(req.params.id, name);
     return { ok: true };
   });
 

--- a/apps/server/src/unzip.ts
+++ b/apps/server/src/unzip.ts
@@ -49,15 +49,40 @@ export function unzip(buf: Buffer): Record<string, Buffer> {
   return out;
 }
 
-/** Guess the root .tex (has \documentclass; break ties by size). */
+/** \documentclass or \begin{document} outside a `%` comment — a commented-out
+ *  preamble in a snippet must not make it a root candidate. */
+const HAS_DOCUMENTCLASS = /^[^%\n]*\\documentclass\b/m;
+const HAS_BEGIN_DOCUMENT = /^[^%\n]*\\begin\{document\}/m;
+// Journal templates open with comment banners well past 4 KB; scanning this
+// much of each .tex keeps the cost bounded on a 200 MB archive.
+const ROOT_SCAN_BYTES = 256 * 1024;
+const ROOT_NAMES = /^(main|paper|manuscript|ms|article|thesis)$/i;
+
+/**
+ * Pick the root .tex of an imported archive. Candidates carry \documentclass;
+ * among them prefer \begin{document} (a template's class stub has none), then
+ * a conventional root name, then the shallowest path, then the smallest file
+ * (a bundled sample/template outsizes the manuscript). Without any candidate,
+ * the shallowest .tex — never a name that is not in the archive.
+ */
 export function guessRoot(files: Record<string, Buffer>): string | undefined {
-  let best: { path: string; size: number } | null = null;
+  type Ranked = { path: string; key: number[] };
+  const depth = (p: string) => p.split('/').length;
+  const named = (p: string) => (ROOT_NAMES.test(p.split('/').pop()!.replace(/\.tex$/i, '')) ? 0 : 1);
+  const before = (a: Ranked, b: Ranked) => {
+    for (let i = 0; i < a.key.length; i++) if (a.key[i] !== b.key[i]) return a.key[i] < b.key[i];
+    return a.path < b.path;
+  };
+  let best: Ranked | null = null;
+  let fallback: Ranked | null = null;
   for (const [path, data] of Object.entries(files)) {
-    if (!path.endsWith('.tex')) continue;
-    const head = data.toString('utf8', 0, Math.min(data.length, 4096));
-    if (/\\documentclass/.test(head) && (!best || data.length > best.size)) {
-      best = { path, size: data.length };
-    }
+    if (!/\.tex$/i.test(path)) continue;
+    const shallow: Ranked = { path, key: [depth(path), named(path), data.length] };
+    if (!fallback || before(shallow, fallback)) fallback = shallow;
+    const head = data.toString('utf8', 0, Math.min(data.length, ROOT_SCAN_BYTES));
+    if (!HAS_DOCUMENTCLASS.test(head)) continue;
+    const ranked: Ranked = { path, key: [HAS_BEGIN_DOCUMENT.test(head) ? 0 : 1, named(path), depth(path), data.length] };
+    if (!best || before(ranked, best)) best = ranked;
   }
-  return best?.path;
+  return (best ?? fallback)?.path;
 }

--- a/apps/server/src/util.ts
+++ b/apps/server/src/util.ts
@@ -19,6 +19,21 @@ export function safeJoin(base: string, rel: string): string {
   return abs;
 }
 
+/**
+ * Normalize a ZIP entry name to a project-relative posix path, or null when it
+ * cannot live inside a project: absolute, drive-lettered, a `..` segment, or
+ * nothing left after dropping `.` segments. Windows-made archives use `\\` as
+ * the separator; those become `/`. A legitimate name like `data..csv` is not
+ * an escape — only whole `..` segments are (the safeJoin rule above).
+ */
+export function importPath(entry: string): string | null {
+  const unified = entry.replace(/\\/g, '/');
+  if (unified.startsWith('/') || /^[A-Za-z]:/.test(unified) || unified.includes('\0')) return null;
+  const segments = unified.split('/').filter((seg) => seg !== '' && seg !== '.');
+  if (!segments.length || segments.includes('..')) return null;
+  return segments.join('/');
+}
+
 export function isTextFile(p: string): boolean {
   return /\.(tex|bib|cls|sty|bst|bbx|cbx|md|txt|csv|json|yml|yaml|def|clo|dtx|ins|lco|tikz|pgf|toml|cfg|gitignore)$/i.test(p) || !path.basename(p).includes('.');
 }

--- a/apps/server/test/compile-stale.test.mjs
+++ b/apps/server/test/compile-stale.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * Stale-preview honesty: a failed compile must not mint a fresh pdfUrl for
+ * the old PDF the compiler still finds on disk. The client keeps the URL it
+ * already shows and learns it is stale; a later success mints a new one.
+ * The compiler is a mock that answers whatever the test queues next.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { check, eq } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-compile-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+const queue = [];
+const requests = [];
+const mock = http.createServer((req, res) => {
+  let raw = '';
+  req.on('data', (d) => { raw += d; });
+  req.on('end', () => {
+    requests.push(JSON.parse(raw));
+    const body = queue.shift() ?? { ok: false, error: 'mock queue empty' };
+    const buf = Buffer.from(JSON.stringify(body));
+    res.writeHead(200, { 'content-type': 'application/json', 'content-length': buf.length });
+    res.end(buf);
+  });
+});
+await new Promise((r) => mock.listen(0, '127.0.0.1', r));
+process.env.COMPILER_URL = `http://127.0.0.1:${mock.address().port}`;
+
+const { initDb, closeDb } = await import('../src/db/index.ts');
+const store = await import('../src/store.ts');
+const { compileProject, forgetPdfUrls } = await import('../src/compile.ts');
+const gitops = await import('../src/gitops.ts');
+
+await initDb();
+const meta = await store.createProject('Stale test');
+const good = { ok: true, pdf: '.aldine-out/main.pdf', synctex: '.aldine-out/main.synctex.gz', log: 'ok', errors: [], durationMs: 5 };
+const bad = { ok: false, exitCode: 12, pdf: '.aldine-out/main.pdf', synctex: '.aldine-out/main.synctex.gz', log: '! Undefined control sequence.', errors: [{ type: 'error', line: 3, message: 'Undefined control sequence' }], durationMs: 5 };
+
+try {
+  queue.push({ ...bad });
+  let r = await compileProject(meta.id, 'main');
+  eq(r.ok, false, 'first run fails');
+  eq(r.pdfUrl, null, 'no previous success → no URL to show, even though the compiler found a PDF');
+  eq(r.pdfStale, false, 'nothing stale when nothing is shown');
+  eq(r.pdf, '.aldine-out/main.pdf', 'the on-disk path is still reported');
+
+  queue.push({ ...good });
+  r = await compileProject(meta.id, 'main');
+  eq(r.ok, true, 'success');
+  check(typeof r.pdfUrl === 'string' && /[?&]t=\d+/.test(r.pdfUrl), `success mints a cache-busted URL: ${r.pdfUrl}`);
+  eq(r.pdfStale, undefined, 'a fresh result is not stale');
+  eq(r.synctex, '.aldine-out/main.synctex.gz', 'synctex path forwarded');
+  const fresh = r.pdfUrl;
+
+  await new Promise((res) => setTimeout(res, 5)); // a re-minted URL would differ in t=
+  queue.push({ ...bad });
+  r = await compileProject(meta.id, 'main');
+  eq(r.ok, false, 'failure after a success');
+  eq(r.pdfUrl, fresh, 'pdfUrl is the last successful one, byte-identical');
+  eq(r.pdfStale, true, 'flagged stale');
+  eq(r.errors.length, 1, 'errors pass through');
+  eq(r.synctex, '.aldine-out/main.synctex.gz', 'synctex still reported (informational)');
+
+  queue.push({ ...bad });
+  r = await compileProject(meta.id, 'main');
+  eq(r.pdfUrl, fresh, 'repeated failures keep the same URL');
+  eq(r.pdfStale, true, 'still stale');
+
+  await new Promise((res) => setTimeout(res, 5));
+  queue.push({ ...good });
+  r = await compileProject(meta.id, 'main');
+  eq(r.ok, true, 'recovered');
+  check(r.pdfUrl !== fresh, 'a new success mints a new URL');
+  eq(r.pdfStale, undefined, 'no longer stale');
+
+  // a 4xx bare error from the compiler (e.g. missing root) is a failure too
+  queue.push({ ok: false, error: 'root file not found: main.tex' });
+  r = await compileProject(meta.id, 'main');
+  eq(r.ok, false, 'bare error → not ok');
+  check(typeof r.pdfUrl === 'string', 'keeps the last good URL');
+  eq(r.pdfStale, true, 'and marks it stale');
+  eq(r.log, 'Compiler error: root file not found: main.tex', 'error becomes the log');
+  eq(r.synctex, null, 'no synctex from a bare error');
+
+  // a deleted branch takes its worktree (and PDF) with it: the recreated
+  // branch must not inherit the URL
+  await gitops.createBranch(meta.id, 'draft', 'main');
+  queue.push({ ...good });
+  r = await compileProject(meta.id, 'draft');
+  check(typeof r.pdfUrl === 'string', 'draft succeeds and is remembered');
+  forgetPdfUrls(meta.id, 'draft');
+  queue.push({ ...bad });
+  r = await compileProject(meta.id, 'draft');
+  eq(r.pdfUrl, null, 'after the branch is forgotten a failure shows no URL');
+  eq(r.pdfStale, false, 'and nothing is stale');
+  queue.push({ ...bad });
+  r = await compileProject(meta.id, 'main');
+  check(typeof r.pdfUrl === 'string', 'forgetting one branch leaves the others alone');
+
+  forgetPdfUrls(meta.id);
+  queue.push({ ...bad });
+  r = await compileProject(meta.id, 'main');
+  eq(r.pdfUrl, null, 'forgetting the project drops every branch');
+
+  eq(requests[0].engine, 'pdf', 'engine forwarded to the compiler');
+  console.log('compile stale: all checks passed');
+} finally {
+  await closeDb();
+  mock.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+process.exit(0);

--- a/apps/server/test/guess-root.test.mjs
+++ b/apps/server/test/guess-root.test.mjs
@@ -1,0 +1,29 @@
+/**
+ * Root detection on imported archives: the manuscript, not the biggest file;
+ * banners longer than 4 KB; class stubs without \begin{document}; nested
+ * roots; and never a name the archive does not contain.
+ */
+import { check, eq } from './assert.mjs';
+
+const { guessRoot } = await import('../src/unzip.ts');
+
+const B = (s) => Buffer.from(s);
+const doc = (extra = '') => `\\documentclass{article}\n${extra}\\begin{document}\nHello\n\\end{document}\n`;
+const banner = '%'.repeat(79).concat('\n').repeat(80); // ~6.4 KB of comment lines
+
+eq(guessRoot({ 'main.tex': B(doc()), 'chapter.tex': B('\\section{One}\n'.repeat(200)) }), 'main.tex', 'the file with \\documentclass, not the largest');
+eq(guessRoot({ 'article.tex': B(banner + doc()) }), 'article.tex', '\\documentclass after a >4 KB banner');
+eq(guessRoot({ 'elsarticle-template.tex': B(doc('\\usepackage{lipsum}\n'.repeat(300))), 'manuscript.tex': B(doc()) }), 'manuscript.tex', 'conventional root name beats a larger template');
+eq(guessRoot({ 'sample.tex': B(doc('\\usepackage{lipsum}\n'.repeat(300))), 'mypaper.tex': B(doc()) }), 'mypaper.tex', 'no conventional name: the smaller candidate wins over a bundled sample');
+eq(guessRoot({ 'sub/notes.tex': B(doc()), 'paper/sections/intro.tex': B('\\section{Intro}'), 'paper/main.tex': B(doc()) }), 'paper/main.tex', 'nested root by name');
+eq(guessRoot({ 'a/b/c/deep.tex': B(doc()), 'top.tex': B(doc()) }), 'top.tex', 'shallowest path among equals');
+eq(guessRoot({ 'mycls.tex': B('\\documentclass{article}\n% class docs, no body\n'), 'thesis.tex': B(doc()) }), 'thesis.tex', '\\begin{document} beats a preamble-only file');
+eq(guessRoot({ 'snippet.tex': B('% \\documentclass{article}\ntext'), 'main.tex': B(doc()) }), 'main.tex', 'commented-out \\documentclass is not a candidate');
+eq(guessRoot({ 'zz.tex': B('text'), 'aa/inner.tex': B('text'), 'b.tex': B('more') }), 'b.tex', 'no \\documentclass anywhere: shallowest .tex, smallest first');
+eq(guessRoot({ 'Main.TEX': B(doc()) }), 'Main.TEX', 'extension match is case-insensitive');
+check(guessRoot({ 'refs.bib': B('@book{x}') }) === undefined, 'no .tex at all → nothing (never an invented main.tex)');
+
+const late = B('%'.repeat(300 * 1024) + '\n' + doc());
+eq(guessRoot({ 'huge.tex': late, 'main.tex': B('text') }), 'main.tex', '\\documentclass beyond the 256 KB scan window is not seen; fallback still names a real file');
+
+console.log('guessRoot: all checks passed');

--- a/apps/server/test/import-path.test.mjs
+++ b/apps/server/test/import-path.test.mjs
@@ -1,0 +1,28 @@
+/**
+ * ZIP entry names → project paths. Whole `..` segments and absolute names are
+ * escapes; `data..csv` is a file name; Windows archives use backslashes.
+ */
+import { check, eq } from './assert.mjs';
+
+const { importPath } = await import('../src/util.ts');
+
+eq(importPath('main.tex'), 'main.tex', 'plain name');
+eq(importPath('paper/sections/a.tex'), 'paper/sections/a.tex', 'nested path');
+eq(importPath('./figs/x.png'), 'figs/x.png', 'leading ./ dropped');
+eq(importPath('figs//x.png'), 'figs/x.png', 'doubled separator collapsed');
+eq(importPath('data..csv'), 'data..csv', 'dots inside a name are not an escape');
+eq(importPath('a/..b/c.tex'), 'a/..b/c.tex', '..-prefixed segment is a name');
+eq(importPath('figs\\x.png'), 'figs/x.png', 'backslash separators become /');
+eq(importPath('paper\\sections\\a.tex'), 'paper/sections/a.tex', 'deep backslash path');
+
+check(importPath('../x.tex') === null, 'leading .. rejected');
+check(importPath('a/../../x.tex') === null, 'inner .. rejected');
+check(importPath('a\\..\\x.tex') === null, 'backslash .. rejected');
+check(importPath('/etc/passwd') === null, 'absolute rejected');
+check(importPath('C:\\Users\\x.tex') === null, 'drive letter rejected');
+check(importPath('c:/x.tex') === null, 'lower-case drive letter rejected');
+check(importPath('') === null, 'empty rejected');
+check(importPath('./') === null, 'only dots rejected');
+check(importPath('a\0b.tex') === null, 'NUL rejected');
+
+console.log('importPath: all checks passed');

--- a/apps/server/test/import-route.test.mjs
+++ b/apps/server/test/import-route.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Import and project-settings routes against a throwaway data dir:
+ *  - a ZIP entry that escapes the project → 400 and NO project left behind
+ *  - a failure after the project exists (file/dir collision) → 400, cleaned up
+ *  - a base64 body past the global 32 MB limit is accepted on the import route
+ *  - a ZIP over the limit gets the honest size message, not a bare 413
+ *  - PATCH engine rejects anything the compiler cannot run
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { check, eq } from './assert.mjs';
+import { buildZip } from './zip.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-import-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+const { default: Fastify } = await import('fastify');
+const { initDb, closeDb } = await import('../src/db/index.ts');
+const { registerRoutes, IMPORT_MAX_ZIP_BYTES } = await import('../src/routes.ts');
+const store = await import('../src/store.ts');
+
+await initDb();
+const app = Fastify({ logger: false, bodyLimit: 32 * 1024 * 1024 });
+await registerRoutes(app);
+await app.ready();
+
+const projectIds = async () => (await store.listProjects()).map((m) => m.id).sort();
+const importZip = (entries, name = 'T') => app.inject({ method: 'POST', url: '/api/projects/import', payload: { name, zipBase64: buildZip(entries).toString('base64') } });
+const doc = '\\documentclass{article}\\begin{document}Hi\\end{document}\n';
+
+try {
+  // ---- escaping entry: rejected before anything is created ----
+  let before = await projectIds();
+  let res = await importZip({ 'main.tex': doc, '../evil.tex': 'x' });
+  eq(res.statusCode, 400, 'escaping entry → 400');
+  check(res.json().error.includes('../evil.tex'), `error names the entry: ${res.json().error}`);
+  eq(await projectIds(), before, 'no project created for an escaping entry');
+  check(!fs.existsSync(path.join(process.env.DATA_DIR, 'projects')) || fs.readdirSync(path.join(process.env.DATA_DIR, 'projects')).length === 0, 'no repo dir left on disk');
+
+  res = await importZip({ 'main.tex': doc, 'a\\..\\evil.tex': 'x' });
+  eq(res.statusCode, 400, 'backslash escape → 400');
+  eq(await projectIds(), before, 'no project created for a backslash escape');
+
+  // ---- failure after createProject: binary write collides with a text file ----
+  const bin = Buffer.concat([Buffer.from([0, 1, 2, 3]), crypto.randomBytes(64)]);
+  res = await importZip({ 'main.tex': doc, 'figs': 'a text file named like the dir', 'figs/plot.png': bin });
+  eq(res.statusCode, 400, 'collision → 400');
+  check(res.json().error.startsWith('Could not import ZIP'), `collision reports the import failure: ${res.json().error}`);
+  eq(await projectIds(), before, 'half-imported project removed');
+  eq(fs.readdirSync(path.join(process.env.DATA_DIR, 'projects')), [], 'orphan repo dir removed');
+
+  // ---- happy path: backslash names, __MACOSX junk, data..csv, nested root ----
+  res = await importZip({ '__MACOSX/._main.tex': 'junk', 'paper\\main.tex': doc, 'paper/data..csv': '1,2', 'paper/figs/plot.png': bin });
+  eq(res.statusCode, 200, `windows-style archive imports: ${res.body}`);
+  const meta = res.json();
+  eq(meta.rootFile, 'paper/main.tex', 'root detected from the normalized path');
+  const files = store.listFiles(meta.id, 'main').filter((f) => f.type === 'file' && f.path !== '.gitignore').map((f) => f.path).sort();
+  eq(files, ['paper/data..csv', 'paper/figs/plot.png', 'paper/main.tex'], 'files placed under normalized paths, junk dropped');
+  eq(store.readFile(meta.id, 'main', 'paper/figs/plot.png').equals(bin), true, 'binary written byte-exact');
+  before = await projectIds();
+
+  // ---- body past the global limit is accepted on this route ----
+  const big = crypto.randomBytes(26 * 1024 * 1024); // base64 ≈ 34.7 MB > 32 MB global bodyLimit
+  res = await importZip({ 'main.tex': doc, 'assets/blob.bin': big });
+  eq(res.statusCode, 200, `>32 MB base64 body accepted: ${res.statusCode} ${res.body.slice(0, 200)}`);
+  eq(store.readFile(res.json().id, 'main', 'assets/blob.bin').length, big.length, 'large asset intact');
+  before = await projectIds();
+
+  // ---- over the raw limit: the message states both numbers ----
+  res = await importZip({ 'main.tex': doc, 'pad.bin': Buffer.alloc(IMPORT_MAX_ZIP_BYTES) });
+  eq(res.statusCode, 413, 'ZIP over the limit → 413');
+  eq(res.json().error, 'ZIP is 60 MB; the limit is 60 MB', 'honest size message');
+  eq(await projectIds(), before, 'over-limit import created nothing');
+
+  // ---- engine validation ----
+  const id = meta.id;
+  res = await app.inject({ method: 'PATCH', url: `/api/projects/${id}`, payload: { engine: 'latex' } });
+  eq(res.statusCode, 400, 'unknown engine → 400');
+  check(res.json().error.includes('latex') && res.json().error.includes('lualatex'), `error names the engine and the options: ${res.json().error}`);
+  eq((await store.readMeta(id)).engine, 'pdf', 'engine unchanged after a rejected value');
+  res = await app.inject({ method: 'PATCH', url: `/api/projects/${id}`, payload: { engine: '' } });
+  eq(res.statusCode, 400, 'empty engine → 400');
+  res = await app.inject({ method: 'PATCH', url: `/api/projects/${id}`, payload: { engine: 'xelatex' } });
+  eq(res.statusCode, 200, 'known engine accepted');
+  eq((await store.readMeta(id)).engine, 'xelatex', 'engine persisted');
+  res = await app.inject({ method: 'PATCH', url: `/api/projects/${id}`, payload: { name: 'Renamed' } });
+  eq(res.statusCode, 200, 'PATCH without engine still works');
+  eq((await store.readMeta(id)).engine, 'xelatex', 'engine untouched by a name-only patch');
+
+  console.log('import route: all checks passed');
+} finally {
+  await app.close();
+  await closeDb();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+process.exit(0);

--- a/apps/server/test/zip.mjs
+++ b/apps/server/test/zip.mjs
@@ -1,0 +1,50 @@
+/**
+ * Build a stored (method 0) ZIP from { name -> Buffer|string } for tests. Entry
+ * names are written verbatim, so a test can put `../x` or `a\b` in an archive
+ * the way a hostile or Windows-made zip would.
+ */
+import zlib from 'node:zlib';
+
+export function buildZip(entries) {
+  const locals = [];
+  const centrals = [];
+  let offset = 0;
+  for (const [name, raw] of Object.entries(entries)) {
+    const data = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+    const nameBuf = Buffer.from(name, 'utf8');
+    const crc = zlib.crc32 ? zlib.crc32(data) : 0;
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28);
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0, 10);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(data.length, 20);
+    central.writeUInt32LE(data.length, 24);
+    central.writeUInt16LE(nameBuf.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt32LE(offset, 42);
+    locals.push(local, nameBuf, data);
+    centrals.push(central, nameBuf);
+    offset += local.length + nameBuf.length + data.length;
+  }
+  const cdSize = centrals.reduce((n, b) => n + b.length, 0);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(Object.keys(entries).length, 8);
+  eocd.writeUInt16LE(Object.keys(entries).length, 10);
+  eocd.writeUInt32LE(cdSize, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, ...centrals, eocd]);
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -31,6 +31,9 @@ export interface CompileResult {
   timedOut?: boolean;
   pdf: string | null;
   pdfUrl: string | null;
+  /** The run failed and pdfUrl is the last successful one, unchanged. */
+  pdfStale?: boolean;
+  synctex?: string | null;
   log: string;
   errors: CompileError[];
   durationMs: number;
@@ -53,6 +56,12 @@ export interface Comment {
   replies: CommentReply[];
 }
 
+/** Carries the HTTP status so callers can tell a body-limit 413 (proxy or
+ *  framework, no JSON `error` text worth quoting) from a route's own message. */
+export class ApiError extends Error {
+  constructor(message: string, public readonly status: number) { super(message); }
+}
+
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {
     headers: init?.body ? { 'content-type': 'application/json' } : undefined,
@@ -61,7 +70,7 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     let msg = `HTTP ${res.status}`;
     try { msg = ((await res.json()) as { error?: string }).error || msg; } catch { /* keep */ }
-    throw new Error(msg);
+    throw new ApiError(msg, res.status);
   }
   return res.json() as Promise<T>;
 }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -621,6 +621,18 @@
 }
 .pdf-status { display: flex; align-items: center; gap: 6px; font-weight: 500; color: var(--text-2); font-size: 12px; }
 .pdf-pane__inner { position: relative; }
+/* pinned over the pages while the last typeset failed */
+.pdf-stale {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--warn-text);
+  background: var(--warn-soft);
+  border-bottom: 1px solid var(--hairline);
+}
 .pdf-flash {
   position: absolute;
   background: var(--accent);

--- a/apps/web/src/components/PdfPane.tsx
+++ b/apps/web/src/components/PdfPane.tsx
@@ -11,16 +11,20 @@ export interface PdfPaneHandle {
 
 interface Props {
   pdfUrl: string | null;
+  /** The branch whose PDF is shown; a change empties the pane (see below). */
+  branch?: string;
   status: 'idle' | 'compiling' | 'ok' | 'error';
   zoom?: number; // multiplier on fit-width (1 = fit width)
   /** Whether the failed compile produced actual parsed errors — gates the "fix the errors" copy. */
   hasErrors?: boolean;
+  /** The last run failed: whatever is on screen is from the last successful typeset. */
+  stale?: boolean;
   onFirstOpen(): void;
   /** Inverse SyncTeX: user double-clicked at (page, pdfX, pdfY) in PDF points. */
   onInverse?(page: number, x: number, y: number): void;
 }
 
-const PdfPane = forwardRef<PdfPaneHandle, Props>(function PdfPane({ pdfUrl, status, zoom = 1, hasErrors = false, onFirstOpen, onInverse }, ref) {
+const PdfPane = forwardRef<PdfPaneHandle, Props>(function PdfPane({ pdfUrl, branch, status, zoom = 1, hasErrors = false, stale = false, onFirstOpen, onInverse }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const [rendered, setRendered] = useState(false);
@@ -63,6 +67,16 @@ const PdfPane = forwardRef<PdfPaneHandle, Props>(function PdfPane({ pdfUrl, stat
     const t = setTimeout(() => setLayoutZoom(zoom), 150);
     return () => clearTimeout(t);
   }, [zoom]);
+
+  // A branch switch nulls pdfUrl, which alone never touches the canvases —
+  // the pane would keep showing the previous branch's pages, and a failed
+  // typeset on the new branch would label them as its last successful one.
+  useEffect(() => {
+    renderTask.current++;
+    innerRef.current?.replaceChildren();
+    pageInfo.current = [];
+    setRendered(false);
+  }, [branch]);
 
   useEffect(() => {
     if (!pdfUrl || !innerRef.current) return;
@@ -194,6 +208,9 @@ const PdfPane = forwardRef<PdfPaneHandle, Props>(function PdfPane({ pdfUrl, stat
 
   return (
     <div className="pdf-pane" ref={scrollRef} data-testid="pdf-pane">
+      {stale && rendered && (
+        <div className="pdf-stale" data-testid="pdf-stale">Preview is from the last successful typeset</div>
+      )}
       <div className="pdf-pane__inner" ref={innerRef} onDoubleClick={handleDblClick} title={onInverse ? 'Double-click to jump to source' : undefined} />
       {!rendered && (
         <div className="pdf-empty">

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -28,6 +28,21 @@ import { shortcut } from '../platform';
 
 type CompileStatus = 'idle' | 'compiling' | 'ok' | 'error';
 
+/** The engines the server accepts (PATCH rejects anything else with 400). */
+const ENGINES: Array<{ id: string; label: string }> = [
+  { id: 'pdf', label: 'pdfLaTeX' },
+  { id: 'xelatex', label: 'XeLaTeX' },
+  { id: 'lualatex', label: 'LuaLaTeX' },
+];
+
+/** A text field that is not the code editor (whose own keymap owns Mod-j). */
+function inTextField(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.closest !== 'function') return false;
+  if (el.closest('.cm-editor')) return false;
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable;
+}
+
 export default function Editor() {
   const { id = '' } = useParams();
   const [params, setParams] = useSearchParams();
@@ -190,21 +205,6 @@ export default function Editor() {
     localStorage.setItem('aldine.autoTypeset', next ? '1' : '0');
   };
 
-  // Cmd+S → typeset, Cmd+K → command palette
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
-        e.preventDefault();
-        doCompile();
-      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault();
-        setPaletteOpen((o) => !o);
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [doCompile]);
-
   const switchBranch = (name: string) => {
     setParams(name === 'main' ? {} : { branch: name });
     setCompile({ status: 'idle', result: null });
@@ -222,6 +222,18 @@ export default function Editor() {
       toast(`Could not rename: ${err.message}`, 'error');
     }
   };
+
+  const setEngine = useCallback(async (engine: string) => {
+    if (!project || engine === project.engine) return;
+    try {
+      await api.patchProject(id, { engine });
+      await loadProject();
+      // A PDF on screen was typeset with the old engine — rebuild it.
+      if (compile.result) doCompile();
+    } catch (err: any) {
+      toast(`Could not change the engine: ${err.message}`, 'error');
+    }
+  }, [id, project, compile.result, loadProject, doCompile, toast]);
 
   const jumpToLine = (line: number | null, file?: string) => {
     if (line == null || !project) return;
@@ -310,12 +322,20 @@ export default function Editor() {
   }, [comments, id, acceptSuggestion, loadComments, bumpComments]);
 
 
+  // The preview is stale when the last run failed: the server keeps the previous
+  // pdfUrl and flags it, or the run never produced a result and the pane still
+  // shows the old canvases. A ref so the inverse callback reads the live value.
+  const pdfStale = compile.status === 'error' || !!compile.result?.pdfStale;
+  const pdfStaleRef = useRef(pdfStale);
+  pdfStaleRef.current = pdfStale;
+
   // Inverse SyncTeX: double-click in the PDF → open the source file at that line.
   const onPdfInverse = useCallback(async (page: number, x: number, y: number) => {
+    if (pdfStaleRef.current) toast('This preview is from the last successful typeset — fix the errors and typeset again to jump accurately');
     try {
       const res = await api.synctex(id, branch, { direction: 'inverse', page, x, y });
       const rec = res.records?.find((r) => r.input || r.line != null);
-      if (!rec) return;
+      if (!rec) { toast('No source location for that spot', 'error'); return; }
       const line = Number(rec.line);
       // Older compilers return the path as TeX opened it (…/paper/./ch1.tex);
       // collapse "/./" segments or the suffix match below never fires and the
@@ -329,8 +349,10 @@ export default function Editor() {
       if (match) file = match.path;
       if (file && files.some((f) => f.path === file)) setActiveFile(file);
       if (!Number.isNaN(line)) requestAnimationFrame(() => setTimeout(() => codeRef.current?.gotoLine(line), 80));
-    } catch { /* synctex unavailable */ }
-  }, [id, branch, files]);
+    } catch {
+      toast('Jump to source unavailable — typeset first', 'error');
+    }
+  }, [id, branch, files, toast]);
 
   // Forward SyncTeX: from the editor, jump the PDF to the current line.
   const jumpToPdf = useCallback(async () => {
@@ -340,10 +362,34 @@ export default function Editor() {
     try {
       const res = await api.synctex(id, branch, { direction: 'forward', file: activeFile, line, column: 0 });
       const rec = res.records?.find((r) => r.page != null && (r.y != null || r.v != null));
-      if (!rec) return;
+      if (!rec) { toast('No PDF location for this line — typeset first', 'error'); return; }
       pdfRef.current?.showForward(Number(rec.page), Number(rec.y ?? rec.v));
-    } catch { /* synctex unavailable */ }
-  }, [id, branch, activeFile]);
+    } catch {
+      toast('Jump unavailable for this file', 'error');
+    }
+  }, [id, branch, activeFile, toast]);
+
+  // Cmd+S → typeset, Cmd+K → command palette, Cmd+J → jump the PDF to the cursor
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        doCompile();
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setPaletteOpen((o) => !o);
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'j' && !e.defaultPrevented && !inTextField(e.target)) {
+        // CodeMirror binds Mod-j itself (and prevents default) when the editor
+        // has focus; this catches the shortcut from the PDF pane, tree, etc.
+        // Other text fields (comment composer, dialogs, palette) keep the
+        // keystroke: a jump against the editor's cursor from there is noise.
+        e.preventDefault();
+        jumpToPdf();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [doCompile, jumpToPdf]);
 
   const pluginCtx = useMemo(() => ({
     projectId: id,
@@ -362,6 +408,7 @@ export default function Editor() {
       { id: 'typeset', group: 'Action', title: 'Typeset document', hint: shortcut('S'), run: doCompile },
       { id: 'auto', group: 'Action', title: auto ? 'Turn auto-typeset off' : 'Turn auto-typeset on', run: toggleAuto },
       { id: 'jump-pdf', group: 'Action', title: 'Jump PDF to cursor', hint: shortcut('J'), run: () => jumpToPdf() },
+      ...ENGINES.map((e) => ({ id: `engine-${e.id}`, group: 'Action', title: `Typeset with ${e.label}`, run: () => setEngine(e.id) })),
       { id: 'spell', group: 'Action', title: spellcheck ? 'Turn spellcheck off' : 'Turn spellcheck on', run: () => setSpellcheck((s) => { localStorage.setItem('aldine.spellcheck', s ? '0' : '1'); return !s; }) },
       { id: 'theme', group: 'View', title: 'Toggle light/dark theme', run: () => { toggleTheme(); } },
       { id: 'about', group: 'View', title: 'About Aldine and its source code', run: () => setAboutOpen(true) },
@@ -409,7 +456,7 @@ export default function Editor() {
       cmds.push({ id: `open-${f.path}`, group: 'Open', title: f.path, run: () => setActiveFile(f.path) });
     }
     return cmds;
-  }, [files, activeFile, id, branch, auto, spellcheck, doCompile, toggleAuto, jumpToPdf, insertAtCursor, loadFiles, loadProject, toast]);
+  }, [files, activeFile, id, branch, auto, spellcheck, doCompile, toggleAuto, jumpToPdf, setEngine, insertAtCursor, loadFiles, loadProject, toast]);
 
   const errors = compile.result?.errors?.filter((e) => e.type !== 'typesetting') || [];
   const errCount = errors.filter((e) => e.type === 'error').length;
@@ -565,6 +612,14 @@ export default function Editor() {
                 <span className="statusbar__file">{activeFile}</span>
                 {visualEnabled && mode === 'visual' && <FormatToolbar target={codeRef} />}
                 <span className="toolbar__spacer" />
+                <button
+                  className="btn btn--ghost btn--small"
+                  onClick={() => jumpToPdf()}
+                  title={`Show this line in the PDF (${shortcut('J')})`}
+                  data-testid="jump-to-pdf"
+                >
+                  Jump to PDF <span className="kbd">{shortcut('J')}</span>
+                </button>
                 {(() => {
                   // document total with the open file's count kept live; a file
                   // outside the include graph falls back to its own count
@@ -685,6 +740,16 @@ export default function Editor() {
               {compile.status === 'error' && <><span className="dot dot--error" /> {errCount > 0 ? `${errCount} error${errCount === 1 ? '' : 's'}` : 'Failed'}</>}
             </span>
             <span className="toolbar__spacer" />
+            <select
+              className="fmt__select"
+              value={ENGINES.some((e) => e.id === project.engine) ? project.engine : 'pdf'}
+              onChange={(e) => setEngine(e.target.value)}
+              title="Typesetting engine"
+              aria-label="Typesetting engine"
+              data-testid="engine-select"
+            >
+              {ENGINES.map((e) => <option key={e.id} value={e.id}>{e.label}</option>)}
+            </select>
             <div className="zoom" data-testid="zoom-controls">
               <button className="btn btn--ghost btn--small" onClick={() => setZoom((z) => Math.max(0.5, +(z - 0.1).toFixed(2)))} title="Zoom out" aria-label="Zoom out">−</button>
               <button className="zoom__label" onClick={() => setZoom(1)} title="Reset to fit width" aria-label={`PDF zoom ${Math.round(zoom * 100)}%, click to reset`}>{Math.round(zoom * 100)}%</button>
@@ -714,9 +779,11 @@ export default function Editor() {
           <PdfPane
             ref={pdfRef}
             pdfUrl={compile.result?.pdfUrl || null}
+            branch={branch}
             status={compile.status}
             zoom={zoom}
             hasErrors={errCount > 0}
+            stale={pdfStale}
             // The on-open typeset is auto-typeset's job — a user who turned the
             // toggle off gets the "Press ⌘S" empty state, not a surprise compile.
             onFirstOpen={() => { if (autoRef.current) doCompile(); }}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { api, ProjectSummary, TemplateInfo } from '../api';
+import { api, ApiError, ProjectSummary, TemplateInfo } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
 import Modal from '../components/Modal';
@@ -12,6 +12,11 @@ import GithubImport from '../components/GithubImport';
 import Onboarding from '../components/Onboarding';
 import About from '../components/About';
 import { friendlyDate } from '../util/dates';
+
+/** Mirrors IMPORT_MAX_ZIP_BYTES in apps/server/src/routes.ts — the server
+ *  enforces it; this pre-flight only spares the upload. */
+const IMPORT_MAX_ZIP_MB = 60;
+const IMPORT_MAX_ZIP_BYTES = IMPORT_MAX_ZIP_MB * 1024 * 1024;
 
 export default function Home() {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null);
@@ -61,7 +66,8 @@ export default function Home() {
 
   const importZip = async (file: File) => {
     if (!/\.zip$/i.test(file.name)) { toast('Please drop a .zip file', 'error'); return; }
-    if (file.size > 60 * 1024 * 1024) { toast('ZIP is larger than 60 MB', 'error'); return; }
+    const sizeMb = Number((file.size / (1024 * 1024)).toFixed(1));
+    if (file.size > IMPORT_MAX_ZIP_BYTES) { toast(`ZIP is ${sizeMb} MB; the limit is ${IMPORT_MAX_ZIP_MB} MB`, 'error'); return; }
     toast('Importing…');
     try {
       const buf = new Uint8Array(await file.arrayBuffer());
@@ -70,6 +76,12 @@ export default function Home() {
       const p = await api.importZip(file.name.replace(/\.zip$/i, ''), btoa(bin));
       navigate(`/p/${p.id}`);
     } catch (err: any) {
+      // A 413 without the route's own text comes from a proxy or body limit
+      // below what the app allows — the size is the only number worth stating.
+      if (err instanceof ApiError && err.status === 413 && !/limit is/.test(err.message)) {
+        toast(`ZIP too large for this server: ${sizeMb} MB was refused before it reached the app, which allows ${IMPORT_MAX_ZIP_MB} MB`, 'error');
+        return;
+      }
       toast(`Import failed: ${err.message}`, 'error');
     }
   };

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -98,8 +98,8 @@ docker compose -f docker-compose.full.yml -f deploy/docker-compose.prod.yml up -
 
 Then pick the ingress you already run. Aldine is one upstream (`127.0.0.1:8080`)
 serving the app, `/api`, `/plugins`, and the `/collab` WebSocket — any reverse
-proxy works as long as it forwards WebSocket upgrades and allows 32 MB bodies
-(uploads / ZIP import).
+proxy works as long as it forwards WebSocket upgrades and allows 81 MB bodies
+(a 60 MB ZIP import travels base64-encoded inside JSON; uploads need 32 MB).
 
 ### 3a. nginx (most common)
 
@@ -113,7 +113,8 @@ sudo nginx -t && sudo systemctl reload nginx
 ```
 
 See [`deploy/nginx.conf`](nginx.conf) — the load-bearing lines are
-`client_max_body_size 32m` (nginx's 1 MB default breaks ZIP import) and the
+`client_max_body_size 81m` (nginx's 1 MB default breaks ZIP import; 32m from
+an older copy cuts a ZIP import off at about 24 MB) and the
 `Upgrade`/`Connection` headers on `/collab` (without them the editor loads but
 live cursors never appear).
 
@@ -246,5 +247,5 @@ Everything is env-gated; blank/unset means "off" or the listed default.
 | `RL_COMPILE_CONCURRENCY` | Max concurrent compiles the app forwards (default 2) |
 | `COMPILE_TIMEOUT_MS`, `MAX_CONCURRENT_COMPILES` | Compiler-container limits: per-compile timeout (default 120000 ms) and compiles in flight (default 2). `docker-compose.full.yml` passes both through from `.env` |
 | `ALDINE_PROJECT` | Compose project name for `backup.sh`/`restore.sh` (default `aldine`) |
-| `ALDINE_TEXLIVE_SCHEME` | Compiler image build: `medium` (default, curated set) or `full` (all of CTAN, ~9 GB on disk) |
+| `ALDINE_TEXLIVE_SCHEME` | Compiler image build: `full` (default, all of TeX Live, ~9 GB on disk) or `medium` (curated set + publisher classes + Arabic/Cyrillic/Greek scripts, no CJK, ~3 GB) |
 | `ALDINE_TRASH_DAYS` | Days deleted projects stay restorable in the trash before the daily sweep purges them (default `30`) |

--- a/deploy/aws/alb.tf
+++ b/deploy/aws/alb.tf
@@ -7,6 +7,19 @@ resource "aws_lb" "main" {
   # WebSocket collab connections are long-lived; keep the idle timeout high so
   # the ALB doesn't cut an open /collab socket during quiet stretches.
   idle_timeout = 4000
+
+  # Edge-level request log (status, target status, URL) — the app logs errors
+  # only, so without this a failed upload or a 4xx has no trace anywhere.
+  dynamic "access_logs" {
+    for_each = var.alb_access_logs ? [1] : []
+    content {
+      bucket  = aws_s3_bucket.alb_logs[0].bucket
+      prefix  = "alb"
+      enabled = true
+    }
+  }
+
+  depends_on = [aws_s3_bucket_policy.alb_logs]
 }
 
 resource "aws_lb_target_group" "app" {

--- a/deploy/aws/alb_logs.tf
+++ b/deploy/aws/alb_logs.tf
@@ -1,0 +1,56 @@
+# ALB access logs: the only record of which request got which status at the edge.
+# The app logs errors only, so a client-side or 4xx failure is otherwise invisible.
+# Objects expire after 30 days; the bucket is private and the ELB log-delivery
+# account for the region is the sole writer.
+
+variable "alb_access_logs" {
+  type        = bool
+  default     = false
+  description = "Write ALB access logs to S3 (30-day retention)"
+}
+
+data "aws_elb_service_account" "main" {
+  count = var.alb_access_logs ? 1 : 0
+}
+
+resource "aws_s3_bucket" "alb_logs" {
+  count         = var.alb_access_logs ? 1 : 0
+  bucket        = "papyr-alb-logs-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_logs" {
+  count                   = var.alb_access_logs ? 1 : 0
+  bucket                  = aws_s3_bucket.alb_logs[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  count  = var.alb_access_logs ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs[0].id
+  rule {
+    id     = "expire"
+    status = "Enabled"
+    filter {}
+    expiration { days = 30 }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  count  = var.alb_access_logs ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { AWS = data.aws_elb_service_account.main[0].arn }
+      Action    = "s3:PutObject"
+      Resource  = "${aws_s3_bucket.alb_logs[0].arn}/alb/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    }]
+  })
+}
+
+data "aws_caller_identity" "current" {}

--- a/deploy/aws/push-images.sh
+++ b/deploy/aws/push-images.sh
@@ -33,9 +33,9 @@ docker buildx build --platform "${PLATFORM}" \
   -f "${REPO_ROOT}/apps/server/Dockerfile" \
   -t "${SERVER_REPO}:${TAG}" --push "${REPO_ROOT}"
 
-echo "→ Building + pushing compiler image (${COMPILER_REPO}:${TAG}, scheme ${ALDINE_TEXLIVE_SCHEME:-medium})"
+echo "→ Building + pushing compiler image (${COMPILER_REPO}:${TAG}, scheme ${ALDINE_TEXLIVE_SCHEME:-full})"
 docker buildx build --platform "${PLATFORM}" \
-  --build-arg "TEXLIVE_SCHEME=${ALDINE_TEXLIVE_SCHEME:-medium}" \
+  --build-arg "TEXLIVE_SCHEME=${ALDINE_TEXLIVE_SCHEME:-full}" \
   -f "${REPO_ROOT}/apps/compiler/Dockerfile" \
   -t "${COMPILER_REPO}:${TAG}" --push "${REPO_ROOT}/apps/compiler"
 

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -8,7 +8,9 @@
 #
 # The two settings people miss:
 #   - client_max_body_size: nginx defaults to 1m, which breaks project-ZIP
-#     import and file uploads. The app accepts up to 32m.
+#     import and file uploads. The app accepts 32m in general and 81m on the
+#     ZIP-import route (a 60 MB ZIP, base64-encoded, plus headroom); a lower
+#     limit here turns a valid import into a bare 413 before the app sees it.
 #   - WebSocket upgrade for /collab: without it, live collaboration silently
 #     degrades (editor loads, cursors never appear).
 
@@ -35,7 +37,7 @@ server {
     ssl_certificate     /etc/letsencrypt/live/aldine.example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/aldine.example.com/privkey.pem;
 
-    client_max_body_size 32m;
+    client_max_body_size 81m;
 
     # everything (app, /api, /plugins) — one upstream, no path games
     location / {

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -80,8 +80,8 @@ services:
       context: apps/compiler
       args:
         # medium (default, ~1 GB + pinned extras) or full (all of CTAN, ~9 GB on disk):
-        #   ALDINE_TEXLIVE_SCHEME=full docker compose up -d --build
-        TEXLIVE_SCHEME: ${ALDINE_TEXLIVE_SCHEME:-medium}
+        #   ALDINE_TEXLIVE_SCHEME=medium docker compose up -d --build
+        TEXLIVE_SCHEME: ${ALDINE_TEXLIVE_SCHEME:-full}
     environment:
       DATA_DIR: /data
       COMPILE_TIMEOUT_MS: ${COMPILE_TIMEOUT_MS:-120000}

--- a/docs/plans/hotfix-feedback-round1.md
+++ b/docs/plans/hotfix-feedback-round1.md
@@ -1,0 +1,95 @@
+# Hotfix: feedback round 1 (bugs only, no behavior changes)
+
+Branch `hotfix/feedback-round1` off `main` (e52c4a0). Ships as its own release before
+the Agent API branch. Scope is strictly bugs + the missing engine UI; anything that
+changes compile semantics (`-halt-on-error`), import auto-detection, blank projects,
+templates, ORCID is OUT (tracked as GitHub issues).
+
+Source: user feedback from a long-time Overleaf user on prod + code diagnosis
+(file:line below are on main).
+
+## H1 Import: body limit and honest messaging (S)
+- `apps/server/src/index.ts:30` global `bodyLimit` 32 MB caps zip imports at ~24 MB raw
+  (base64 ×4/3) while `apps/web/src/pages/Home.tsx:64` and `routes.ts:411` promise 60 MB.
+  Reproduced: 25 MB zip → 413 "Payload Too Large" in 5 ms.
+- Fix: route-level `bodyLimit` on `POST /api/projects/import` = 60 MB × 4/3 + 1 MB
+  (keep the global limit unchanged); `deploy/nginx.conf:38` `client_max_body_size`
+  raised to match (+ fix its comment at :10-11). Toasts state the real limit and size
+  ("ZIP is 25 MB; the limit is 60 MB" / on 413: "ZIP too large for this server").
+- Orphan on failure: `routes.ts:410-433` creates the project BEFORE writing binaries; a
+  path failure in the loop returns 400 but leaves a half-imported project. Validate all
+  entry paths (segment-wise `..` check — `p.includes('..')` at :413 also drops legitimate
+  `data..csv`; use the `util.ts:16` segment logic; also reject/convert backslash paths)
+  BEFORE `createProject`, and delete the project in the catch if creation already happened.
+- Tests: server test with a >32 MB base64 body (route accepts), orphan test (bad path
+  → 400 AND no project left), unit for path filter.
+
+## H2 Import: root-file detection (S)
+- `apps/server/src/unzip.ts:52-63` `guessRoot`: largest `.tex` with `\documentclass` in
+  the first 4 KB. Journal templates have >4 KB comment banners (missed); bundled
+  `sample.tex` outsizes the manuscript (wrong root); fallback picks the first `.tex` in
+  central-directory order or the literal `main.tex`.
+- Fix: scan whole file (cap ~256 KB) for `\documentclass` AND prefer files containing
+  `\begin{document}`; prefer names `main|paper|manuscript|ms|article|thesis(.tex)`;
+  prefer shallowest path; tie-break smallest. Never return a non-existent `main.tex`:
+  if nothing qualifies, first `.tex` by shallowest path.
+- Tests: unit table for the above cases (banner, sample.tex decoy, nested root,
+  no-documentclass fallback).
+
+## H3 Compiler image: publisher classes (S)
+- `apps/compiler/Dockerfile:25-26` `tlmgr install` list lacks `collection-publishers`
+  (elsarticle, IEEEtran, acmart, revtex4-2, agujournal, copernicus…). Add
+  `collection-publishers` to the medium install line. Keep the snapshot pin.
+- Also pin `latest-full` (`Dockerfile:28`) by digest like medium — hygiene, no
+  behavior change. (Document the digest source in the existing comment style.)
+- Note in CHANGELOG that self-hosters must rebuild the compiler image.
+
+## H4 Engine: validation + picker (S)
+- `routes.ts:458` PATCH accepts any string for `engine`; compiler silently falls back
+  to pdflatex. Validate against `['pdf','xelatex','lualatex']` → 400 otherwise.
+- UI: a `<select>` in the Preview pane header (`Editor.tsx:739-773`, next to zoom)
+  labelled by engine name (pdfLaTeX / XeLaTeX / LuaLaTeX), calling `api.patchProject`
+  then `loadProject()` — copy the `rootFile` pattern at `Editor.tsx:596-600`. Plus three
+  palette commands "Typeset with pdfLaTeX/XeLaTeX/LuaLaTeX" in the `commands` memo
+  (`Editor.tsx:417-433`). `data-testid="engine-select"`. Changing engine triggers a
+  re-typeset if a compile result exists.
+- e2e: switch engine via select → project meta reflects it → palette command works.
+
+## H5 Forward SyncTeX (editor → PDF) (S)
+- Exists (`Editor.tsx:393-403` `jumpToPdf`, ⌘J at `CodePane.tsx:308`, palette
+  `Editor.tsx:421`) but: (a) broken for sub-directory roots — `apps/compiler/server.js:214-215`
+  passes the project-relative file while synctex records root-dir-relative names (the
+  inverse direction normalizes at `:230-240`; mirror it: `path.relative(rootDir, body.file)`
+  with cwd consistent); (b) ⌘J bound only inside CodeMirror — add to the window handler
+  at `Editor.tsx:251-263` like ⌘S; (c) silent failure at `Editor.tsx:400/402` — toast
+  "No PDF location for this line — typeset first" / "Jump unavailable for this file";
+  (d) no affordance — add a small "Jump to PDF" button in the editor pane header with
+  the shortcut hint, `data-testid="jump-to-pdf"`.
+- e2e: project with root in a subfolder (`paper/main.tex` + `paper/sections/a.tex`):
+  ⌘J from a line in `sections/a.tex` → PdfPane scrolls + `.pdf-flash` appears. Runs the
+  compiler.
+
+## H6 Inverse SyncTeX + stale preview honesty (S)
+- On a failed compile the compiler returns the OLD pdf (`server.js:188-195` keys on file
+  existence, not `ok`) and `compile.ts:73-75` mints a FRESH cache-buster → the pane
+  re-renders a stale/truncated PDF as if fresh, while the editor has moved on → inverse
+  jumps land N lines off. `Editor.tsx:783` passes `onInverse` unconditionally; every
+  failure path is silent (`Editor.tsx:375,387,389`).
+- Fix (no compile-semantics change): (a) `compile.ts` — when `!ok`, do NOT mint a new
+  `pdfUrl`; keep the previous result's URL (client keeps showing what it showed) and
+  set `pdfStale: true` in the result; (b) `PdfPane.tsx` — persistent "Preview is from
+  the last successful typeset" ribbon when `status==='error'` and a PDF is showing,
+  `data-testid="pdf-stale"`; (c) `onPdfInverse` — when stale, toast "This preview is
+  from the last successful typeset — fix the errors and typeset again to jump
+  accurately", still attempt the jump; when no record → toast "No source location for
+  that spot"; (d) restore the dropped `synctex` field in `compile.ts:63-72` (informational).
+- e2e: compile ok → break the doc → compile fails → ribbon visible, pdfUrl unchanged,
+  double-click shows the stale toast; fix → compile ok → ribbon gone.
+
+## Out of scope (issues): drop `-halt-on-error`; generation token binding pdf↔synctex;
+latexmkrc/fontspec engine detection on import; latin-1 fallback; ZIP64/codepages;
+blank project; templates + license tracking; ORCID.
+
+## Conventions
+CHANGELOG (Fixed/Added under Unreleased) with each item; data-testids; sentence-case
+strings; comments = constraints only; e2e for every user-visible change; no new deps.

--- a/e2e/tests/17-feedback-round1.spec.ts
+++ b/e2e/tests/17-feedback-round1.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect } from '../fixtures';
+import { createProject, createPaperProject, openProject, cleanup, buildZip, expectTypesetOk } from './helpers';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+/** Auto-typeset (on by default) compiles on open; tests that count compile
+ *  responses or need an untypeset project turn it off before the page loads. */
+async function withoutAutoTypeset(page: import('@playwright/test').Page): Promise<void> {
+  await page.addInitScript(() => window.localStorage.setItem('aldine.autoTypeset', '0'));
+}
+
+async function engineOf(request: import('@playwright/test').APIRequestContext, id: string): Promise<string> {
+  return (await (await request.get(`/api/projects/${id}`)).json()).engine;
+}
+
+test.describe('engine picker', () => {
+  test('the preview select and the palette both persist the engine', async ({ page, request }) => {
+    const id = await createProject(request, 'Engine Picker');
+    try {
+      await openProject(page, id);
+      const sel = page.getByTestId('engine-select');
+      await expect(sel).toHaveValue('pdf');
+      await sel.selectOption('xelatex');
+      await expect.poll(() => engineOf(request, id)).toBe('xelatex');
+      await expect(sel).toHaveValue('xelatex');
+
+      await page.keyboard.press(`${mod}+k`);
+      await page.getByTestId('palette-input').fill('Typeset with LuaLaTeX');
+      await page.getByTestId('palette-item-engine-lualatex').click();
+      await expect.poll(() => engineOf(request, id)).toBe('lualatex');
+      await expect(sel).toHaveValue('lualatex');
+
+      // the value survives a reload — it is project meta, not UI state
+      await page.reload();
+      await expect(page.getByTestId('engine-select')).toHaveValue('lualatex');
+    } finally { await cleanup(request, id); }
+  });
+
+  test('the server refuses an engine it cannot run', async ({ request }) => {
+    const id = await createProject(request, 'Engine Reject');
+    try {
+      const res = await request.patch(`/api/projects/${id}`, { data: { engine: 'latex' } });
+      expect(res.status()).toBe(400);
+      expect((await res.json()).error).toContain('Unknown engine');
+      expect(await engineOf(request, id)).toBe('pdf');
+    } finally { await cleanup(request, id); }
+  });
+});
+
+test.describe('forward SyncTeX', () => {
+  test('jump to PDF from a section file under a sub-directory root', async ({ page, request }) => {
+    const id = await createProject(request, 'Jump Nested');
+    const section = ['\\section{Section A}', ...Array.from({ length: 12 }, (_, i) => `Section paragraph ${i + 1} with enough text to fill a line.\n`)].join('\n');
+    try {
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'paper/main.tex',
+        content: '\\documentclass{article}\n\\begin{document}\nIntro.\n\\input{sections/a}\n\\end{document}\n' } });
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'paper/sections/a.tex', content: section } });
+      await request.patch(`/api/projects/${id}`, { data: { rootFile: 'paper/main.tex' } });
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      await page.getByTestId('typeset-button').click();
+      await expectTypesetOk(page);
+
+      await page.getByTestId('file-paper/sections/a.tex').click();
+      await expect(page.locator('.cm-content')).toContainText('Section paragraph');
+      await page.locator('.cm-line').nth(6).click();
+      await page.getByTestId('jump-to-pdf').click();
+      await expect(page.locator('.pdf-flash')).toBeVisible({ timeout: 10_000 });
+      await expect(page.locator('.pdf-flash')).toHaveCount(0, { timeout: 10_000 });
+
+      // the shortcut works outside the editor too (window handler, not CodeMirror)
+      await page.getByTestId('pdf-pane').click();
+      await page.keyboard.press(`${mod}+j`);
+      await expect(page.locator('.pdf-flash')).toBeVisible({ timeout: 10_000 });
+    } finally { await cleanup(request, id); }
+  });
+
+  test('jumping before any typeset says so instead of failing silently', async ({ page, request }) => {
+    const id = await createProject(request, 'Jump Untypeset');
+    try {
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      await page.locator('.cm-content').click();
+      await page.getByTestId('jump-to-pdf').click();
+      await expect(page.locator('.toast').filter({ hasText: /typeset first|Jump unavailable/ })).toBeVisible();
+    } finally { await cleanup(request, id); }
+  });
+
+  test('the shortcut is left alone while typing in another text field', async ({ page, request }) => {
+    const id = await createProject(request, 'Jump Field Guard');
+    const jumpToast = page.locator('.toast').filter({ hasText: /typeset first|Jump unavailable/ });
+    try {
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      await page.keyboard.press(`${mod}+k`);
+      await expect(page.getByTestId('palette-input')).toBeFocused();
+      await page.keyboard.press(`${mod}+j`);
+      await page.waitForTimeout(800);
+      await expect(jumpToast).toHaveCount(0);
+      await page.keyboard.press('Escape');
+
+      // positive control: from the PDF pane the same keystroke still jumps
+      await page.getByTestId('pdf-pane').click();
+      await page.keyboard.press(`${mod}+j`);
+      await expect(jumpToast).toBeVisible();
+    } finally { await cleanup(request, id); }
+  });
+});
+
+test.describe('stale preview', () => {
+  test('a failed typeset keeps the PDF, flags it, and clears once it compiles again', async ({ page, request }) => {
+    const id = await createPaperProject(request, 'Stale Preview');
+    const compileResponse = (page: import('@playwright/test').Page) =>
+      page.waitForResponse((r) => r.url().includes('/compile') && r.request().method() === 'POST');
+    try {
+      // an on-open compile would be the response the first wait matches
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+
+      const first = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const ok = await (await first).json();
+      expect(ok.ok).toBe(true);
+      await expectTypesetOk(page);
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+
+      const content = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex',
+        content: content.replace('\\begin{document}', '\\begin{document}\n\\begin{itemize}\n') } });
+      const second = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const failed = await (await second).json();
+      expect(failed.ok).toBe(false);
+      expect(failed.pdfStale).toBe(true);
+      expect(failed.pdfUrl).toBe(ok.pdfUrl);
+
+      await expect(page.getByTestId('pdf-stale')).toBeVisible();
+      await expect(page.getByTestId('pdf-stale')).toContainText('last successful typeset');
+      await expect(page.locator('canvas.pdf-page').first()).toBeVisible();
+      const box = await page.locator('canvas.pdf-page').first().boundingBox();
+      await page.mouse.dblclick(box!.x + box!.width * 0.5, box!.y + box!.height * 0.55);
+      await expect(page.locator('.toast').filter({ hasText: 'last successful typeset' })).toBeVisible();
+
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content } });
+      await page.getByTestId('typeset-button').click();
+      await expectTypesetOk(page);
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+    } finally { await cleanup(request, id); }
+  });
+
+  test('switching branches empties the preview so a failure there cannot claim the other branch\'s PDF', async ({ page, request }) => {
+    const id = await createPaperProject(request, 'Stale Branch');
+    try {
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      await page.getByTestId('typeset-button').click();
+      await expectTypesetOk(page);
+
+      expect((await request.post(`/api/projects/${id}/branches`, { data: { name: 'draft' } })).ok()).toBe(true);
+      await page.getByTestId('branch-menu').click();
+      await page.getByTestId('branch-draft').click();
+      await expect(page).toHaveURL(/branch=draft/);
+      await expect(page.locator('canvas.pdf-page')).toHaveCount(0);
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+
+      const content = await (await request.get(`/api/projects/${id}/file?branch=draft&path=main.tex`)).text();
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'draft', path: 'main.tex',
+        content: content.replace('\\begin{document}', '\\begin{document}\n\\begin{itemize}\n') } });
+      const failed = page.waitForResponse((r) => r.url().includes('/compile') && r.request().method() === 'POST');
+      await page.getByTestId('typeset-button').click();
+      const body = await (await failed).json();
+      expect(body.ok).toBe(false);
+      expect(body.pdfUrl).toBeNull();
+      await expect(page.getByTestId('pdf-status')).toContainText(/fail|error/i);
+      await expect(page.locator('canvas.pdf-page')).toHaveCount(0);
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+    } finally { await cleanup(request, id); }
+  });
+
+  test('a recreated branch does not inherit the deleted branch\'s PDF', async ({ request }) => {
+    const id = await createPaperProject(request, 'Stale Recreated');
+    try {
+      expect((await request.post(`/api/projects/${id}/branches`, { data: { name: 'draft' } })).ok()).toBe(true);
+      const ok = await (await request.post(`/api/projects/${id}/compile`, { data: { branch: 'draft' } })).json();
+      expect(ok.ok).toBe(true);
+      expect(typeof ok.pdfUrl).toBe('string');
+
+      expect((await request.delete(`/api/projects/${id}/branches?name=draft`)).ok()).toBe(true);
+      expect((await request.post(`/api/projects/${id}/branches`, { data: { name: 'draft' } })).ok()).toBe(true);
+      const content = await (await request.get(`/api/projects/${id}/file?branch=draft&path=main.tex`)).text();
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'draft', path: 'main.tex',
+        content: content.replace('\\begin{document}', '\\begin{document}\n\\begin{itemize}\n') } });
+      const failed = await (await request.post(`/api/projects/${id}/compile`, { data: { branch: 'draft' } })).json();
+      expect(failed.ok).toBe(false);
+      expect(failed.pdfUrl).toBeNull();
+      expect(failed.pdfStale).toBe(false);
+    } finally { await cleanup(request, id); }
+  });
+});
+
+test.describe('ZIP import root detection and path safety', () => {
+  const tmpZip = (name: string, entries: Record<string, Buffer | string>) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-r1-'));
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, buildZip(entries));
+    return { dir, file };
+  };
+
+  test('a long comment banner and a bigger sample.tex do not hide the manuscript', async ({ page, request }) => {
+    // 5 KB of `%` banner before \documentclass, like a journal template ships
+    const banner = Array.from({ length: 80 }, (_, i) => `% Journal template banner line ${i + 1}: do not remove, see the guide for authors.`).join('\n');
+    expect(banner.length).toBeGreaterThan(4096);
+    const manuscript = `${banner}\n\\documentclass{article}\n\\begin{document}\nBANNER-MANUSCRIPT\n\\end{document}\n`;
+    const sample = `\\documentclass{article}\n\\begin{document}\n${'Sample text that outsizes the manuscript.\n'.repeat(400)}\\end{document}\n`;
+    expect(sample.length).toBeGreaterThan(manuscript.length);
+    const name = `banner-${Date.now()}`;
+    const { dir, file } = tmpZip(`${name}.zip`, { 'submission.tex': manuscript, 'sample.tex': sample, 'refs.bib': '' });
+    let id: string | null = null;
+    try {
+      await page.goto('/');
+      await page.getByTestId('import-input').setInputFiles(file);
+      await expect(page.getByTestId('editor-shell')).toBeVisible({ timeout: 20_000 });
+      id = new URL(page.url()).pathname.split('/')[2];
+      const meta = await (await request.get(`/api/projects/${id}`)).json();
+      expect(meta.rootFile).toBe('submission.tex');
+      await expect(page.locator('.tree__item--active')).toContainText('submission.tex');
+      await expect(page.locator('.cm-line').first()).toContainText('Journal template banner line 1');
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an entry escaping the project is refused and leaves no project behind', async ({ page, request }) => {
+    const name = `bad-path-${Date.now()}`;
+    const { dir, file } = tmpZip(`${name}.zip`, {
+      'main.tex': '\\documentclass{article}\\begin{document}x\\end{document}',
+      '../escape.tex': 'outside',
+    });
+    try {
+      await page.goto('/');
+      await page.getByTestId('import-input').setInputFiles(file);
+      await expect(page.locator('.toast').filter({ hasText: 'points outside the project' })).toBeVisible();
+      await expect(page.getByTestId('editor-shell')).toHaveCount(0);
+      const list = await (await request.get('/api/projects')).json();
+      expect(list.some((p: { name: string }) => p.name === name)).toBe(false);
+      await page.reload();
+      await expect(page.getByTestId('theme-toggle')).toBeVisible();
+      await expect(page.getByText(name)).toHaveCount(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { APIRequestContext, Page, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
+import zlib from 'node:zlib';
 
 export const PAPER_DIR = process.env.PAPER_DIR || path.resolve(__dirname, '..', 'fixtures', 'demo-paper');
 
@@ -63,4 +64,47 @@ export async function expectTypesetOk(page: Page, timeout = 120_000): Promise<vo
 export async function cleanup(request: APIRequestContext, id: string): Promise<void> {
   // permanent: tests must actually remove their data, not fill the trash
   await request.delete(`/api/projects/${id}?permanent=1`).catch(() => {});
+}
+
+/**
+ * A stored (method 0) ZIP with entry names written verbatim — the `zip` CLI
+ * refuses the `../x` names an import test needs to send.
+ */
+export function buildZip(entries: Record<string, Buffer | string>): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const [name, raw] of Object.entries(entries)) {
+    const data = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+    const nameBuf = Buffer.from(name, 'utf8');
+    const crc = zlib.crc32(data);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(data.length, 20);
+    central.writeUInt32LE(data.length, 24);
+    central.writeUInt16LE(nameBuf.length, 28);
+    central.writeUInt32LE(offset, 42);
+    locals.push(local, nameBuf, data);
+    centrals.push(central, nameBuf);
+    offset += local.length + nameBuf.length + data.length;
+  }
+  const count = Object.keys(entries).length;
+  const cdSize = centrals.reduce((n, b) => n + b.length, 0);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(count, 8);
+  eocd.writeUInt16LE(count, 10);
+  eocd.writeUInt32LE(cdSize, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, ...centrals, eocd]);
 }


### PR DESCRIPTION
Fixes from the first round of user feedback on the hosted instance, plus two decisions.

**Fixes**
- ZIP import accepts the advertised 60 MB and says the real size and limit when it refuses; a bad archive no longer leaves a half-imported project behind.
- Root-file detection handles journal templates (comment banners, bundled samples, nested roots).
- Engine is validated and switchable from the preview header and the command palette.
- Forward SyncTeX works for projects with a subfolder root, is bound globally, has a button, and explains when it cannot jump.
- A failed typeset keeps the previous PDF and marks it stale instead of re-rendering it as fresh.

**Decisions**
- Compiler image defaults to full TeX Live (~9 GB on disk); `medium` stays as the slim scheme and gains publisher classes and Arabic/Persian, Cyrillic, Greek and other-script support. Self-hosters rebuild the compiler image.
- Optional ALB access logs (`alb_access_logs`), off by default.

**Verified**: server + web typecheck, server unit suites (import path, root detection, import route incl. 26 MB archive, stale-preview semantics), web tests, e2e 17-feedback-round1 (10), 02/04/07/08/12/13 and the auth suite. The two `07-features` BasicTeX failures are the documented pair. Persian compiled in the pinned image with the added collections.

Deploy note: first task start after this merge pulls a larger compiler image; allow a few extra minutes.
