### PR TITLE
demo: never replace the box for a cloud-init change

### DIFF
--- a/deploy/demo/main.tf
+++ b/deploy/demo/main.tf
@@ -61,6 +61,14 @@ resource "hcloud_server" "demo" {
     repo_url           = var.repo_url
     protected_projects = var.protected_projects
   })
+
+  # cloud-init runs once, at first boot. A template change must be applied on
+  # the running box (git pull + compose up, or the units edited in place) — a
+  # plan that replaces the server would destroy the data volume and the Caddy
+  # certificate volume, and a fresh box hits Let's Encrypt's rate limit.
+  lifecycle {
+    ignore_changes = [user_data]
+  }
 }
 
 output "ip" {


### PR DESCRIPTION
The ops-CI plan for the demo stack has wanted to replace `hcloud_server.demo` since the wipe-timer template fix (applied on the box by hand). Replacement would destroy the data and Caddy certificate volumes and re-trigger the Let's Encrypt rate limit. `ignore_changes = [user_data]` matches how cloud-init actually works (first boot only). `tofu validate` passes.