### PR TITLE
deploy: optional staging service on the same load balancer

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -11,13 +11,26 @@ name: Deploy to AWS
 # `describe-services` always tells you which commit is running.
 # `:latest` is still pushed as a human alias / push-images.sh fallback.
 #
-# Manual trigger only (no surprise deploys/costs on every push). Requires:
+# Manual trigger only (no surprise deploys/costs on every push). `target`
+# picks the service: production (papyr) or staging (papyr-staging — exists
+# only when Terraform's staging_domain_name is set; dispatch it on a feature
+# branch that github_deploy_branches allows). Requires:
 #   - vars.AWS_DEPLOY_ROLE_ARN : an IAM role trusting GitHub OIDC (see
 #     deploy/aws/github-oidc.tf — needs ECR push, task-def registration,
 #     PassRole for the task roles, and service update)
 #   - vars.AWS_REGION          : e.g. eu-west-1
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: Service to roll
+        type: choice
+        options: [production, staging]
+        default: production
+
+env:
+  # Task-definition family and service share a name per target.
+  SERVICE: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
 
 permissions:
   id-token: write # OIDC
@@ -70,7 +83,7 @@ jobs:
           REG="${{ steps.ecr.outputs.registry }}"
           SHA="${{ github.sha }}"
           # Current task def → swap both images to the SHA tags → register.
-          aws ecs describe-task-definition --task-definition papyr \
+          aws ecs describe-task-definition --task-definition "$SERVICE" \
             --query taskDefinition --region "${{ vars.AWS_REGION }}" > td.json
           jq --arg s "$REG/papyr-server:$SHA" --arg c "$REG/papyr-compiler:$SHA" '
             .containerDefinitions |= map(
@@ -81,11 +94,11 @@ jobs:
                   .compatibilities, .registeredAt, .registeredBy)' td.json > td-new.json
           REV=$(aws ecs register-task-definition --cli-input-json file://td-new.json \
             --query 'taskDefinition.revision' --output text --region "${{ vars.AWS_REGION }}")
-          echo "Registered task definition papyr:$REV (commit $SHA)"
-          aws ecs update-service --cluster papyr --service papyr \
-            --task-definition "papyr:$REV" --region "${{ vars.AWS_REGION }}"
-          aws ecs wait services-stable --cluster papyr --services papyr \
+          echo "Registered task definition $SERVICE:$REV (commit $SHA)"
+          aws ecs update-service --cluster papyr --service "$SERVICE" \
+            --task-definition "$SERVICE:$REV" --region "${{ vars.AWS_REGION }}"
+          aws ecs wait services-stable --cluster papyr --services "$SERVICE" \
             --region "${{ vars.AWS_REGION }}"
-          echo "## Deployed" >> "$GITHUB_STEP_SUMMARY"
-          echo "- task definition: \`papyr:$REV\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Deployed (${{ inputs.target || 'production' }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- task definition: \`$SERVICE:$REV\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- commit: \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback-aws.yml
+++ b/.github/workflows/rollback-aws.yml
@@ -14,6 +14,14 @@ on:
       revision:
         description: Task-definition revision number (empty = previous)
         required: false
+      target:
+        description: Service to roll back
+        type: choice
+        options: [production, staging]
+        default: production
+
+env:
+  SERVICE: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
 
 permissions:
   id-token: write # OIDC
@@ -32,7 +40,7 @@ jobs:
       - name: Roll the service back
         run: |
           set -euo pipefail
-          CURRENT=$(aws ecs describe-services --cluster papyr --services papyr \
+          CURRENT=$(aws ecs describe-services --cluster papyr --services "$SERVICE" \
             --query 'services[0].taskDefinition' --output text --region "${{ vars.AWS_REGION }}")
           CUR_REV="${CURRENT##*:}"
           REV="${{ inputs.revision }}"
@@ -41,14 +49,14 @@ jobs:
             echo "Nothing to do (current revision: $CUR_REV, requested: $REV)"; exit 1
           fi
           # Surface which commit this revision carries (the SHA image tag).
-          IMG=$(aws ecs describe-task-definition --task-definition "papyr:$REV" \
+          IMG=$(aws ecs describe-task-definition --task-definition "$SERVICE:$REV" \
             --query 'taskDefinition.containerDefinitions[?name==`server`].image' \
             --output text --region "${{ vars.AWS_REGION }}")
-          echo "Rolling back: papyr:$CUR_REV → papyr:$REV ($IMG)"
-          aws ecs update-service --cluster papyr --service papyr \
-            --task-definition "papyr:$REV" --region "${{ vars.AWS_REGION }}"
-          aws ecs wait services-stable --cluster papyr --services papyr \
+          echo "Rolling back: $SERVICE:$CUR_REV → $SERVICE:$REV ($IMG)"
+          aws ecs update-service --cluster papyr --service "$SERVICE" \
+            --task-definition "$SERVICE:$REV" --region "${{ vars.AWS_REGION }}"
+          aws ecs wait services-stable --cluster papyr --services "$SERVICE" \
             --region "${{ vars.AWS_REGION }}"
-          echo "## Rolled back" >> "$GITHUB_STEP_SUMMARY"
-          echo "- from: \`papyr:$CUR_REV\` → to: \`papyr:$REV\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Rolled back (${{ inputs.target || 'production' }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- from: \`$SERVICE:$CUR_REV\` → to: \`$SERVICE:$REV\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- server image: \`$IMG\`" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- AWS deployment: an optional staging service on the same load balancer
+  (`staging_domain_name`), with its own filesystem, log group and certificate,
+  so a feature branch can be tried at a real URL before it reaches prod. The
+  deploy and rollback workflows take a `target` input (production or staging).
+
 ### Security
 - The minimal `docker-compose.yml` carries the compiler sandbox again: an
   `internal: true` network with no route to the internet, `cap_drop: [ALL]`,

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -93,6 +93,29 @@ Set the corresponding client id/secret in `secret_env`.
 The ECS deployment circuit breaker also rolls back on its own if the new tasks
 never reach a healthy state.
 
+## Staging on the same load balancer (optional)
+
+Set `staging_domain_name` (a hostname in the same Route53 zone) and apply:
+
+```hcl
+staging_domain_name    = "staging.latex.example.com"
+staging_env            = { ALDINE_MCP = "1" }   # anything you want to try before prod
+github_deploy_branches = ["my-feature"]         # branches CI may deploy to staging
+```
+
+That adds a second certificate on the HTTPS listener, a host-header rule to a
+second target group, and a second Fargate Spot service (`papyr-staging`) with
+its own EFS filesystem and log group (`/papyr/staging`). It shares the VPC,
+roles, ECR repositories and SSM secrets with prod — so OAuth sign-in only works
+there if the providers also list the staging callback URL; password sign-in
+always works. Cost is roughly one extra Spot task plus a few GB of EFS.
+
+Deploy a branch to it from the Actions tab: **Deploy to AWS → branch: my-feature
+→ target: staging**. Roll back the same way with **Rollback AWS deploy →
+target: staging**. Scale the service to 0 in the console to pause it; unset
+`staging_domain_name` and apply to remove it entirely (the EFS filesystem goes
+with it — staging data is disposable by design).
+
 ## Cost (eu-central-1, low traffic, ballpark)
 
 | Item | ~Monthly |

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -15,26 +15,93 @@ resource "aws_ecs_cluster_capacity_providers" "main" {
 }
 
 locals {
-  server_image   = "${aws_ecr_repository.repos["papyr-server"].repository_url}:${var.image_tag}"
-  compiler_image = "${aws_ecr_repository.repos["papyr-compiler"].repository_url}:${var.image_tag}"
-
   # Plain (non-secret) env for the server. Secrets come from SSM below.
   server_env = merge(
     {
-      NODE_ENV         = "production"
-      PORT             = "3000"
-      DATA_DIR         = "/data"
-      META_DIR         = "/secrets"
-      COMPILER_URL     = "http://localhost:4020"
+      NODE_ENV          = "production"
+      PORT              = "3000"
+      DATA_DIR          = "/data"
+      META_DIR          = "/secrets"
+      COMPILER_URL      = "http://localhost:4020"
       ALDINE_PUBLIC_URL = "https://${var.domain_name}"
-      COOKIE_SECURE    = "1"
-      TRUST_PROXY      = "1" # behind the ALB, so X-Forwarded-For is trusted for rate-limit keys
-      ALDINE_AI_MODEL  = var.ai_model
+      COOKIE_SECURE     = "1"
+      TRUST_PROXY       = "1" # behind the ALB, so X-Forwarded-For is trusted for rate-limit keys
+      ALDINE_AI_MODEL   = var.ai_model
     },
     var.auth_enabled ? { AUTH_ENABLED = "1" } : {},
     var.sso_only ? { ALDINE_SSO_ONLY = "1" } : {},
     var.enable_ses ? { SES_FROM = local.ses_from, AWS_REGION = var.region } : {},
   )
+
+  # One container spec for every deployment (prod, and staging when enabled —
+  # see staging.tf), so the two can only differ in image tag, env and log
+  # destination. Anything else that diverges here is a drift bug.
+  deployments = merge(
+    {
+      prod = {
+        image_tag = var.image_tag
+        env       = local.server_env
+        log_group = aws_cloudwatch_log_group.app.name
+      }
+    },
+    local.staging_enabled ? {
+      staging = {
+        image_tag = var.staging_image_tag
+        env       = local.staging_server_env
+        log_group = aws_cloudwatch_log_group.staging[0].name
+      }
+    } : {},
+  )
+
+  container_definitions = { for name, d in local.deployments : name => jsonencode([
+    {
+      name            = "compiler"
+      image           = "${aws_ecr_repository.repos["papyr-compiler"].repository_url}:${d.image_tag}"
+      essential       = true
+      linuxParameters = { initProcessEnabled = true } # reap orphaned pdflatex/biber
+      environment     = [{ name = "DATA_DIR", value = "/data" }, { name = "PORT", value = "4020" }]
+      mountPoints     = [{ sourceVolume = "data", containerPath = "/data", readOnly = false }]
+      healthCheck = {
+        command     = ["CMD-SHELL", "node -e \"require('http').get('http://localhost:4020/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = d.log_group
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "compiler"
+        }
+      }
+    },
+    {
+      name            = "server"
+      image           = "${aws_ecr_repository.repos["papyr-server"].repository_url}:${d.image_tag}"
+      essential       = true
+      linuxParameters = { initProcessEnabled = true } # reap orphaned git children
+      environment     = [for k, v in d.env : { name = k, value = tostring(v) }]
+      secrets         = [for k, p in aws_ssm_parameter.secret : { name = k, valueFrom = p.arn }]
+      dependsOn       = [{ containerName = "compiler", condition = "HEALTHY" }]
+      # Give the shutdown hook time to flush open Yjs docs + autosave-commit.
+      stopTimeout = 120
+      mountPoints = [
+        { sourceVolume = "data", containerPath = "/data", readOnly = false },
+        { sourceVolume = "secrets", containerPath = "/secrets", readOnly = false },
+      ]
+      portMappings = [{ containerPort = 3000, protocol = "tcp" }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = d.log_group
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "server"
+        }
+      }
+    },
+  ]) }
 }
 
 resource "aws_ecs_task_definition" "app" {
@@ -77,55 +144,7 @@ resource "aws_ecs_task_definition" "app" {
     }
   }
 
-  container_definitions = jsonencode([
-    {
-      name            = "compiler"
-      image           = local.compiler_image
-      essential       = true
-      linuxParameters = { initProcessEnabled = true } # reap orphaned pdflatex/biber
-      environment     = [{ name = "DATA_DIR", value = "/data" }, { name = "PORT", value = "4020" }]
-      mountPoints     = [{ sourceVolume = "data", containerPath = "/data", readOnly = false }]
-      healthCheck = {
-        command     = ["CMD-SHELL", "node -e \"require('http').get('http://localhost:4020/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
-        interval    = 30
-        timeout     = 5
-        retries     = 3
-        startPeriod = 60
-      }
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.app.name
-          "awslogs-region"        = var.region
-          "awslogs-stream-prefix" = "compiler"
-        }
-      }
-    },
-    {
-      name            = "server"
-      image           = local.server_image
-      essential       = true
-      linuxParameters = { initProcessEnabled = true } # reap orphaned git children
-      environment     = [for k, v in local.server_env : { name = k, value = tostring(v) }]
-      secrets     = [for k, p in aws_ssm_parameter.secret : { name = k, valueFrom = p.arn }]
-      dependsOn   = [{ containerName = "compiler", condition = "HEALTHY" }]
-      # Give the shutdown hook time to flush open Yjs docs + autosave-commit.
-      stopTimeout = 120
-      mountPoints = [
-        { sourceVolume = "data", containerPath = "/data", readOnly = false },
-        { sourceVolume = "secrets", containerPath = "/secrets", readOnly = false },
-      ]
-      portMappings = [{ containerPort = 3000, protocol = "tcp" }]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.app.name
-          "awslogs-region"        = var.region
-          "awslogs-stream-prefix" = "server"
-        }
-      }
-    },
-  ])
+  container_definitions = local.container_definitions.prod
 }
 
 resource "aws_ecs_service" "app" {

--- a/deploy/aws/github-oidc.tf
+++ b/deploy/aws/github-oidc.tf
@@ -7,19 +7,26 @@
 #   deploy role — ECR push + ECS roll only, for the app repo's image workflow.
 
 resource "aws_iam_openid_connect_provider" "github" {
-  count           = var.github_infra_repo != "" || var.github_deploy_repo != "" ? 1 : 0
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
+  count          = var.github_infra_repo != "" || var.github_deploy_repo != "" ? 1 : 0
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
   # AWS validates GitHub's cert against trusted root CAs; the thumbprint is
   # required by the API but no longer used for trust decisions.
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
 }
 
+locals {
+  # infra = Terraform (admin) → main only. deploy = image roll → main plus any
+  # branch listed in github_deploy_branches, so a feature branch can ship to
+  # staging from CI. Anyone who can push those branches can roll a service.
+  github_roles = { for k, v in {
+    infra  = { repo = var.github_infra_repo, branches = ["main"] }
+    deploy = { repo = var.github_deploy_repo, branches = distinct(concat(["main"], var.github_deploy_branches)) }
+  } : k => v if v.repo != "" }
+}
+
 data "aws_iam_policy_document" "github_assume" {
-  for_each = { for k, v in {
-    infra  = var.github_infra_repo
-    deploy = var.github_deploy_repo
-  } : k => v if v != "" }
+  for_each = local.github_roles
 
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -35,14 +42,14 @@ data "aws_iam_policy_document" "github_assume" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values = [
+      values = flatten([for b in each.value.branches : [
         # legacy name-only claim (repos created before 2026-07-15)
-        "repo:${each.value}:ref:refs/heads/main",
+        "repo:${each.value.repo}:ref:refs/heads/${b}",
         # immutable-ID claim (newer repos): owner@ID/name@ID. '@' cannot
         # appear in GitHub owner or repo names, so these wildcards cannot
         # match any other repo's claim.
-        "repo:${replace(each.value, "/", "@*/")}@*:ref:refs/heads/main",
-      ]
+        "repo:${replace(each.value.repo, "/", "@*/")}@*:ref:refs/heads/${b}",
+      ]])
     }
   }
 }
@@ -97,7 +104,7 @@ resource "aws_iam_role_policy" "github_deploy" {
         Sid      = "EcsRoll"
         Effect   = "Allow"
         Action   = ["ecs:UpdateService", "ecs:DescribeServices"]
-        Resource = [aws_ecs_service.app.id]
+        Resource = concat([aws_ecs_service.app.id], local.staging_enabled ? [aws_ecs_service.staging[0].id] : [])
       },
       {
         # SHA-pinned deploys: CI reads the live task def, swaps the image tags,
@@ -111,10 +118,10 @@ resource "aws_iam_role_policy" "github_deploy" {
       {
         # Registering a task def that references the task/execution roles
         # requires passing them — scoped to exactly those two, ECS only.
-        Sid      = "PassTaskRoles"
-        Effect   = "Allow"
-        Action   = "iam:PassRole"
-        Resource = [aws_iam_role.task.arn, aws_iam_role.execution.arn]
+        Sid       = "PassTaskRoles"
+        Effect    = "Allow"
+        Action    = "iam:PassRole"
+        Resource  = [aws_iam_role.task.arn, aws_iam_role.execution.arn]
         Condition = { StringEquals = { "iam:PassedToService" = "ecs-tasks.amazonaws.com" } }
       },
     ]

--- a/deploy/aws/outputs.tf
+++ b/deploy/aws/outputs.tf
@@ -35,3 +35,8 @@ output "github_deploy_role_arn" {
   description = "Assume this from the app repo's image-deploy workflow (empty github_deploy_repo → null)."
   value       = try(aws_iam_role.github_deploy[0].arn, null)
 }
+
+output "staging_url" {
+  description = "The staging deployment (null when staging_domain_name is empty)."
+  value       = local.staging_enabled ? "https://${var.staging_domain_name}" : null
+}

--- a/deploy/aws/staging.tf
+++ b/deploy/aws/staging.tf
@@ -1,0 +1,265 @@
+# Optional staging deployment on the SAME load balancer, enabled by setting
+# var.staging_domain_name. It gets its own certificate, target group, listener
+# rule, EFS filesystem, log group, task definition and service; it shares the
+# VPC, security groups, ECR repositories, IAM roles and SSM secrets with prod.
+#
+# The separate filesystem is not optional: collab is single-node and the
+# datastore is last-atomic-rename-wins, so two services on one /data would
+# corrupt each other's projects. The shared secrets mean OAuth sign-in fails
+# on staging unless the providers also list the staging callback URLs —
+# password sign-in works regardless.
+
+locals {
+  staging_enabled = var.staging_domain_name != ""
+
+  staging_server_env = merge(
+    local.server_env,
+    { ALDINE_PUBLIC_URL = "https://${var.staging_domain_name}" },
+    var.staging_env,
+  )
+}
+
+# ---- TLS: a second certificate on the HTTPS listener (SNI), so the prod
+# certificate is never touched when staging comes or goes.
+resource "aws_acm_certificate" "staging" {
+  count             = local.staging_enabled ? 1 : 0
+  domain_name       = var.staging_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "staging_cert_validation" {
+  for_each = local.staging_enabled ? {
+    for dvo in aws_acm_certificate.staging[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id         = data.aws_route53_zone.main.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "staging" {
+  count                   = local.staging_enabled ? 1 : 0
+  certificate_arn         = aws_acm_certificate.staging[0].arn
+  validation_record_fqdns = [for r in aws_route53_record.staging_cert_validation : r.fqdn]
+}
+
+resource "aws_lb_listener_certificate" "staging" {
+  count           = local.staging_enabled ? 1 : 0
+  listener_arn    = aws_lb_listener.https.arn
+  certificate_arn = aws_acm_certificate_validation.staging[0].certificate_arn
+}
+
+resource "aws_route53_record" "staging" {
+  count   = local.staging_enabled ? 1 : 0
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.staging_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# ---- routing: host header → staging target group; everything else still
+# hits the listener's default (prod) action.
+resource "aws_lb_target_group" "staging" {
+  count       = local.staging_enabled ? 1 : 0
+  name        = "papyr-staging"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
+  }
+
+  deregistration_delay = 30
+}
+
+resource "aws_lb_listener_rule" "staging" {
+  count        = local.staging_enabled ? 1 : 0
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.staging[0].arn
+  }
+
+  condition {
+    host_header {
+      values = [var.staging_domain_name]
+    }
+  }
+}
+
+# ---- storage: its own filesystem, no AWS Backup (staging data is disposable).
+resource "aws_efs_file_system" "staging" {
+  count          = local.staging_enabled ? 1 : 0
+  creation_token = "papyr-staging"
+  encrypted      = true
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+  lifecycle_policy {
+    transition_to_primary_storage_class = "AFTER_1_ACCESS"
+  }
+
+  tags = { Name = "papyr-staging" }
+}
+
+resource "aws_efs_mount_target" "staging" {
+  count           = local.staging_enabled ? length(aws_subnet.public) : 0
+  file_system_id  = aws_efs_file_system.staging[0].id
+  subnet_id       = aws_subnet.public[count.index].id
+  security_groups = [aws_security_group.efs.id]
+}
+
+# Same uid/gid coupling as efs.tf: both images run as root.
+resource "aws_efs_access_point" "staging_data" {
+  count          = local.staging_enabled ? 1 : 0
+  file_system_id = aws_efs_file_system.staging[0].id
+  root_directory {
+    path = "/data"
+    creation_info {
+      owner_uid   = 0
+      owner_gid   = 0
+      permissions = "0755"
+    }
+  }
+  tags = { Name = "papyr-staging-data" }
+}
+
+resource "aws_efs_access_point" "staging_secrets" {
+  count          = local.staging_enabled ? 1 : 0
+  file_system_id = aws_efs_file_system.staging[0].id
+  root_directory {
+    path = "/secrets"
+    creation_info {
+      owner_uid   = 0
+      owner_gid   = 0
+      permissions = "0700"
+    }
+  }
+  tags = { Name = "papyr-staging-secrets" }
+}
+
+resource "aws_cloudwatch_log_group" "staging" {
+  count             = local.staging_enabled ? 1 : 0
+  name              = "/papyr/staging"
+  retention_in_days = 7
+}
+
+# ---- compute: same task shape as prod (see ecs.tf for the shared container
+# spec and the reasons behind the 0/100 deployment and the 120 s stop timeout).
+resource "aws_ecs_task_definition" "staging" {
+  count                    = local.staging_enabled ? 1 : 0
+  family                   = "papyr-staging"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+
+  volume {
+    name = "data"
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.staging[0].id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = aws_efs_access_point.staging_data[0].id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "secrets"
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.staging[0].id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = aws_efs_access_point.staging_secrets[0].id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  container_definitions = local.container_definitions.staging
+}
+
+resource "aws_ecs_service" "staging" {
+  count           = local.staging_enabled ? 1 : 0
+  name            = "papyr-staging"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.staging[0].arn
+  desired_count   = 1
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+  }
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.task.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.staging[0].arn
+    container_name   = "server"
+    container_port   = 3000
+  }
+
+  health_check_grace_period_seconds = 180
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  depends_on = [aws_lb_listener_rule.staging, aws_ecs_cluster_capacity_providers.main]
+
+  lifecycle {
+    # desired_count: scale to 0 from the console to pause staging without a
+    # Terraform run. task_definition: the deploy workflow registers SHA-pinned
+    # revisions, exactly as for prod.
+    ignore_changes = [desired_count, task_definition]
+  }
+}

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -116,3 +116,28 @@ variable "github_deploy_repo" {
   type        = string
   default     = ""
 }
+
+# ---- staging (optional second service on the same ALB; see staging.tf) ----
+variable "staging_domain_name" {
+  description = "Hostname for a staging deployment that shares the ALB with prod (e.g. staging.latex.example.com, in the same Route53 zone). Empty = no staging resources."
+  type        = string
+  default     = ""
+}
+
+variable "staging_image_tag" {
+  description = "Initial image tag for the staging task definition. The deploy workflow (target=staging) registers SHA-pinned revisions afterwards."
+  type        = string
+  default     = "latest"
+}
+
+variable "staging_env" {
+  description = "Extra plain env for the staging server, merged over the prod env (e.g. { ALDINE_MCP = \"1\" } to try the Agent API before it reaches prod)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "github_deploy_branches" {
+  description = "Branches of github_deploy_repo allowed to assume the image-deploy role (main is always included). Add a feature branch here to deploy it to staging from CI."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Set `staging_domain_name` and the AWS stack adds a second certificate on the HTTPS listener, a host-header rule to a second target group, and a second Fargate Spot service (`papyr-staging`) with its own EFS filesystem and log group. Prod's task definition is untouched: the container spec moves into one shared local, and a plan against the live state shows no change to it.

- `deploy-aws.yml` / `rollback-aws.yml` gain a `target` input (production | staging).
- `github_deploy_branches` lists the feature branches CI may deploy with it.
- README section + CHANGELOG entry.

Plan against the live stack: 15 to add, 2 to change (deploy-role trust + policy, additive), 0 to destroy.
