### PR TITLE
compile: run to the end by default, bind SyncTeX to the run on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- Typesetting runs to the end of the document by default instead of stopping
+  at the first error: the preview shows the complete PDF and the errors sit in
+  the list beside it, like Overleaf. The old behaviour is a per-project setting,
+  "Stop on first error" (log dialog and command palette, `stopOnFirstError` in
+  `PATCH /api/projects/:id`); with it on, a failing run keeps the previous PDF
+  on screen as before.
+
+### Fixed
+- A SyncTeX jump from the PDF is refused (409, with a toast) when the preview
+  on screen and the SyncTeX file on disk come from different typeset runs,
+  instead of landing on the wrong line. Compile results carry a `compileId`
+  that the lookup sends back.
+
 ### Added
 - AWS deployment: an optional staging service on the same load balancer
   (`staging_domain_name`), with its own filesystem, log group and certificate,

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -118,7 +118,7 @@ async function compile(body) {
 }
 
 async function compileInner(body) {
-  const { projectDir, rootFile = 'main.tex', engine = 'pdf' } = body;
+  const { projectDir, rootFile = 'main.tex', engine = 'pdf', haltOnError = false } = body;
   if (!projectDir || projectDir.includes('..')) throw new Error('invalid projectDir');
   if (rootFile.includes('..') || path.isAbsolute(rootFile)) throw new Error('invalid rootFile');
   const absDir = path.resolve(DATA_DIR, projectDir);
@@ -137,7 +137,11 @@ async function compileInner(body) {
     engineFlag,
     ...(force ? ['-g'] : []), // -g: run even if latexmk thinks it's up-to-date
     '-interaction=nonstopmode',
-    '-halt-on-error',
+    // Without -halt-on-error TeX runs to the end of the document and latexmk
+    // still exits non-zero when errors occurred, so the caller gets a complete
+    // PDF plus the error list (the default). With it, the run stops at the
+    // first error and the PDF on disk is truncated at that page.
+    ...(haltOnError ? ['-halt-on-error'] : []),
     '-file-line-error',
     // no -no-shell-escape: the image sets texmf shell_escape=p (restricted),
     // so only whitelisted programs (epstopdf, kpsewhich, bibtex, …) run.
@@ -186,13 +190,21 @@ async function compileInner(body) {
     if (abs === absDir || abs.startsWith(absDir + path.sep)) e.file = path.relative(absDir, abs);
   }
   const ok = code === 0 && fs.existsSync(pdfPath);
+  // A previous run's PDF/SyncTeX stay on disk when this run fails, so existence
+  // alone says nothing about which run wrote them. "Fresh" = written by this
+  // run (mtime at or after its start, with slack for coarse filesystem clocks).
+  const freshSince = t0 - 2000;
+  const isFresh = (f) => { try { return fs.statSync(f).mtimeMs >= freshSince; } catch { return false; } };
+  const synctexPath = path.join(absDir, rootDir, OUT_SUBDIR, `${base}.synctex.gz`);
   return {
     ok,
     timedOut,
     exitCode: code,
     // paths relative to the project dir; the app server serves them
     pdf: fs.existsSync(pdfPath) ? rel(`${base}.pdf`) : null,
-    synctex: fs.existsSync(path.join(absDir, rootDir, OUT_SUBDIR, `${base}.synctex.gz`)) ? rel(`${base}.synctex.gz`) : null,
+    pdfFresh: isFresh(pdfPath),
+    synctex: fs.existsSync(synctexPath) ? rel(`${base}.synctex.gz`) : null,
+    synctexFresh: isFresh(synctexPath),
     log: log.length > 200_000 ? log.slice(-200_000) : log,
     latexmkOutput: out.length > 20_000 ? out.slice(-20_000) : out,
     errors,

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -12,8 +12,11 @@ export interface CompileResult {
   exitCode?: number;
   pdf: string | null;      // path relative to branch dir (.aldine-out/main.pdf)
   pdfUrl: string | null;   // URL the client can fetch
-  /** A failed run left the previous PDF on disk: pdfUrl is the last successful one, unchanged. */
+  /** This run produced no PDF: pdfUrl is the last one that did, unchanged. */
   pdfStale?: boolean;
+  /** Identifies the run whose PDF pdfUrl serves; SyncTeX lookups pass it back
+   *  so a jump is refused instead of resolving against a different run. */
+  compileId?: number;
   synctex: string | null;  // path relative to branch dir; informational
   log: string;
   errors: CompileError[];
@@ -40,7 +43,17 @@ const compileChain = new Map<string, Promise<unknown>>();
  * and misalign SyncTeX with the source. In-memory: after a restart the first
  * failed compile reports no PDF rather than an unknown one.
  */
-const lastGoodPdfUrl = new Map<string, string>();
+const lastGoodPdfUrl = new Map<string, { url: string; compileId: number }>();
+
+/** compileId of the run whose SyncTeX file is on disk, per project::branch. */
+const lastSynctexId = new Map<string, number>();
+
+let lastCompileId = 0;
+/** Strictly increasing even within one millisecond, so two quick runs never share a URL. */
+function nextCompileId(): number {
+  lastCompileId = Math.max(Date.now(), lastCompileId + 1);
+  return lastCompileId;
+}
 
 /**
  * Drop remembered URLs when the files behind them go: deleting a branch
@@ -49,8 +62,9 @@ const lastGoodPdfUrl = new Map<string, string>();
  * branch of the project is forgotten.
  */
 export function forgetPdfUrls(projectId: string, branch?: string): void {
-  if (branch !== undefined) { lastGoodPdfUrl.delete(`${projectId}::${branch}`); return; }
+  if (branch !== undefined) { lastGoodPdfUrl.delete(`${projectId}::${branch}`); lastSynctexId.delete(`${projectId}::${branch}`); return; }
   for (const key of lastGoodPdfUrl.keys()) if (key.startsWith(`${projectId}::`)) lastGoodPdfUrl.delete(key);
+  for (const key of lastSynctexId.keys()) if (key.startsWith(`${projectId}::`)) lastSynctexId.delete(key);
 }
 
 export function compileProject(projectId: string, branch: string): Promise<CompileResult> {
@@ -78,9 +92,10 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
       projectDir: relProjectDir(projectId, branch),
       rootFile: meta.rootFile,
       engine: meta.engine,
+      haltOnError: !!meta.stopOnFirstError,
     }),
   });
-  const raw = (await res.json()) as Partial<Omit<CompileResult, 'pdfUrl'>> & { error?: string };
+  const raw = (await res.json()) as Partial<Omit<CompileResult, 'pdfUrl'>> & { error?: string; pdfFresh?: boolean; synctexFresh?: boolean };
   // Normalize: the compiler may return a bare {ok:false,error} on a 4xx — always
   // hand the client a well-formed CompileResult so the UI never sees undefined fields.
   const body: Omit<CompileResult, 'pdfUrl' | 'pdfStale'> = {
@@ -95,17 +110,35 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
     error: raw.error,
   };
   const key = `${projectId}::${branch}`;
-  if (body.ok && body.pdf) {
-    const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${Date.now()}`;
-    lastGoodPdfUrl.set(key, pdfUrl);
-    return { ...body, pdfUrl };
+  const compileId = nextCompileId();
+  // Older compilers report only `ok`; treat their successful output as fresh.
+  const pdfFresh = raw.pdfFresh ?? body.ok;
+  const synctexFresh = raw.synctexFresh ?? body.ok;
+  if (synctexFresh && body.synctex) lastSynctexId.set(key, compileId);
+  // A run that wrote a PDF is shown even when it logged errors: TeX ran to the
+  // end, so the document is complete and the errors sit in the list beside
+  // it. With stopOnFirstError the PDF on disk is truncated at the first error,
+  // so only an error-free run is shown and the previous one stays on screen.
+  if (body.pdf && pdfFresh && (body.ok || !meta.stopOnFirstError)) {
+    const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${compileId}`;
+    lastGoodPdfUrl.set(key, { url: pdfUrl, compileId });
+    return { ...body, pdfUrl, compileId };
   }
   const previous = lastGoodPdfUrl.get(key) ?? null;
-  return { ...body, pdfUrl: previous, pdfStale: previous !== null };
+  return { ...body, pdfUrl: previous?.url ?? null, pdfStale: previous !== null, compileId: previous?.compileId };
 }
 
-export async function synctexLookup(projectId: string, branch: string, payload: Record<string, unknown>): Promise<unknown> {
+/** `{ stale: true }` when the caller's preview (compileId) is not the run whose SyncTeX is on disk. */
+export async function synctexLookup(projectId: string, branch: string, payload: Record<string, unknown>): Promise<{ stale?: boolean; ok?: boolean; error?: string } & Record<string, unknown>> {
   const meta = await readMeta(projectId);
+  const { compileId, ...rest } = payload;
+  if (typeof compileId === 'number') {
+    const current = lastSynctexId.get(`${projectId}::${branch}`);
+    if (current !== undefined && current !== compileId) {
+      return { ok: false, stale: true, error: 'The preview and the typeset output are from different runs — typeset again to jump accurately' };
+    }
+  }
+  payload = rest;
   const res = await fetch(`${config.compilerUrl}/synctex`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/apps/server/src/db/types.ts
+++ b/apps/server/src/db/types.ts
@@ -36,6 +36,10 @@ export interface ProjectMeta {
   name: string;
   rootFile: string;
   engine: 'pdf' | 'xelatex' | 'lualatex';
+  /** Pass -halt-on-error: the run stops at the first error and the preview
+   *  keeps the previous PDF. Off (default) runs to the end and shows the
+   *  complete PDF beside the error list. */
+  stopOnFirstError?: boolean;
   createdAt: string;
   /** Soft-delete marker: set when the project is moved to trash; purged after ~30 days. */
   deletedAt?: string;

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -467,11 +467,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     }
   });
 
-  app.patch<{ Params: { id: string }; Body: Partial<Pick<store.ProjectMeta, 'name' | 'rootFile' | 'engine'>> }>(
+  app.patch<{ Params: { id: string }; Body: Partial<Pick<store.ProjectMeta, 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>> }>(
     '/api/projects/:id', async (req, reply) => {
       const meta = await requireMember(req, reply, 'rename or reconfigure this project');
       if (!meta) return;
-      const { name, rootFile, engine } = req.body || {};
+      const { name, rootFile, engine, stopOnFirstError } = req.body || {};
       if (name !== undefined) {
         const trimmed = String(name).trim();
         if (!trimmed) return reply.code(400).send({ error: 'Project name cannot be empty' });
@@ -484,6 +484,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
           return reply.code(400).send({ error: `Unknown engine "${String(engine)}" — use one of ${ENGINES.join(', ')}` });
         }
         meta.engine = engine;
+      }
+      if (stopOnFirstError !== undefined) {
+        if (typeof stopOnFirstError !== 'boolean') return reply.code(400).send({ error: 'stopOnFirstError must be true or false' });
+        meta.stopOnFirstError = stopOnFirstError;
       }
       await store.writeMeta(meta);
       return publicMeta(meta, reqUser(req));
@@ -679,9 +683,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.post<{ Params: { id: string }; Body: Record<string, unknown> & { branch?: string } }>(
-    '/api/projects/:id/synctex', async (req) => {
+    '/api/projects/:id/synctex', async (req, reply) => {
       const { branch = 'main', ...payload } = req.body || {};
-      return synctexLookup(req.params.id, branch, payload);
+      const res = await synctexLookup(req.params.id, branch, payload);
+      if (res.stale) return reply.code(409).send({ error: res.error });
+      return res;
     });
 
   // ---------- bib + label indexes (for \cite / \ref autocomplete) ----------

--- a/apps/server/test/compile-stale.test.mjs
+++ b/apps/server/test/compile-stale.test.mjs
@@ -35,82 +35,86 @@ process.env.COMPILER_URL = `http://127.0.0.1:${mock.address().port}`;
 
 const { initDb, closeDb } = await import('../src/db/index.ts');
 const store = await import('../src/store.ts');
-const { compileProject, forgetPdfUrls } = await import('../src/compile.ts');
+const { compileProject, forgetPdfUrls, synctexLookup } = await import('../src/compile.ts');
 const gitops = await import('../src/gitops.ts');
 
 await initDb();
 const meta = await store.createProject('Stale test');
-const good = { ok: true, pdf: '.aldine-out/main.pdf', synctex: '.aldine-out/main.synctex.gz', log: 'ok', errors: [], durationMs: 5 };
-const bad = { ok: false, exitCode: 12, pdf: '.aldine-out/main.pdf', synctex: '.aldine-out/main.synctex.gz', log: '! Undefined control sequence.', errors: [{ type: 'error', line: 3, message: 'Undefined control sequence' }], durationMs: 5 };
+const good = { ok: true, pdf: '.aldine-out/main.pdf', pdfFresh: true, synctex: '.aldine-out/main.synctex.gz', synctexFresh: true, log: 'ok', errors: [], durationMs: 5 };
+// Errors, but TeX ran to the end: the PDF and SyncTeX on disk are this run's.
+const errorsFull = { ok: false, exitCode: 12, pdf: '.aldine-out/main.pdf', pdfFresh: true, synctex: '.aldine-out/main.synctex.gz', synctexFresh: true, log: '! Undefined control sequence.', errors: [{ type: 'error', line: 3, message: 'Undefined control sequence' }], durationMs: 5 };
+// Nothing written (missing root, crash, timeout): whatever is on disk is old.
+const fatal = { ok: false, exitCode: 1, pdf: '.aldine-out/main.pdf', pdfFresh: false, synctex: '.aldine-out/main.synctex.gz', synctexFresh: false, log: '! Emergency stop.', errors: [{ type: 'error', line: null, message: 'Emergency stop' }], durationMs: 5 };
+// A compiler from before pdfFresh existed reports ok only.
+const legacyBad = { ok: false, exitCode: 12, pdf: '.aldine-out/main.pdf', synctex: '.aldine-out/main.synctex.gz', log: '! Undefined control sequence.', errors: [{ type: 'error', line: 3, message: 'Undefined control sequence' }], durationMs: 5 };
 
 try {
-  queue.push({ ...bad });
+  queue.push({ ...fatal });
   let r = await compileProject(meta.id, 'main');
   eq(r.ok, false, 'first run fails');
-  eq(r.pdfUrl, null, 'no previous success → no URL to show, even though the compiler found a PDF');
+  eq(r.pdfUrl, null, 'no previous output → no URL to show, even though the compiler found a PDF');
   eq(r.pdfStale, false, 'nothing stale when nothing is shown');
   eq(r.pdf, '.aldine-out/main.pdf', 'the on-disk path is still reported');
+  eq(requests.at(-1).haltOnError, false, 'default: the compiler is asked to run to the end');
 
   queue.push({ ...good });
   r = await compileProject(meta.id, 'main');
   eq(r.ok, true, 'success');
   check(typeof r.pdfUrl === 'string' && /[?&]t=\d+/.test(r.pdfUrl), `success mints a cache-busted URL: ${r.pdfUrl}`);
   eq(r.pdfStale, undefined, 'a fresh result is not stale');
+  eq(typeof r.compileId, 'number', 'a shown run carries its compileId');
   eq(r.synctex, '.aldine-out/main.synctex.gz', 'synctex path forwarded');
   const fresh = r.pdfUrl;
+  const freshId = r.compileId;
 
-  await new Promise((res) => setTimeout(res, 5)); // a re-minted URL would differ in t=
-  queue.push({ ...bad });
+  queue.push({ ...errorsFull });
   r = await compileProject(meta.id, 'main');
-  eq(r.ok, false, 'failure after a success');
-  eq(r.pdfUrl, fresh, 'pdfUrl is the last successful one, byte-identical');
-  eq(r.pdfStale, true, 'flagged stale');
+  eq(r.ok, false, 'errors are reported');
+  check(r.pdfUrl !== fresh, 'a run that wrote a complete PDF is shown, errors and all');
+  eq(r.pdfStale, undefined, 'not stale: the PDF on screen is this run\'s');
   eq(r.errors.length, 1, 'errors pass through');
-  eq(r.synctex, '.aldine-out/main.synctex.gz', 'synctex still reported (informational)');
+  check(r.compileId > freshId, 'compileId increases');
+  const withErrors = r.pdfUrl;
+  const withErrorsId = r.compileId;
 
-  queue.push({ ...bad });
+  // SyncTeX binding: a lookup for a preview from another run is refused
+  // before the compiler is asked; the current run's id goes through.
+  let sx = await synctexLookup(meta.id, 'main', { direction: 'inverse', page: 1, x: 1, y: 1, compileId: freshId });
+  eq(sx.stale, true, 'lookup with an older compileId is stale');
+  const before = requests.length;
+  queue.push({ ok: true, records: [] });
+  sx = await synctexLookup(meta.id, 'main', { direction: 'inverse', page: 1, x: 1, y: 1, compileId: withErrorsId });
+  eq(sx.ok, true, 'lookup with the current compileId reaches the compiler');
+  eq(requests.length, before + 1, 'exactly one compiler request');
+  eq(requests.at(-1).compileId, undefined, 'compileId is not forwarded to the compiler');
+
+  queue.push({ ...fatal });
   r = await compileProject(meta.id, 'main');
-  eq(r.pdfUrl, fresh, 'repeated failures keep the same URL');
+  eq(r.ok, false, 'fatal after output');
+  eq(r.pdfUrl, withErrors, 'pdfUrl is the last shown one, byte-identical');
+  eq(r.pdfStale, true, 'flagged stale');
+
+  queue.push({ ...legacyBad });
+  r = await compileProject(meta.id, 'main');
+  eq(r.pdfUrl, withErrors, 'a legacy compiler without pdfFresh: failure keeps the last URL');
   eq(r.pdfStale, true, 'still stale');
+
+  // stopOnFirstError: a failing run is truncated, so only ok runs are shown.
+  meta.stopOnFirstError = true;
+  await store.writeMeta(meta);
+  queue.push({ ...errorsFull });
+  r = await compileProject(meta.id, 'main');
+  eq(requests.at(-1).haltOnError, true, 'the compiler is asked to halt');
+  eq(r.pdfUrl, withErrors, 'with stop-on-first-error a failing run keeps the previous PDF');
+  eq(r.pdfStale, true, 'and flags it');
+  meta.stopOnFirstError = false;
+  await store.writeMeta(meta);
 
   await new Promise((res) => setTimeout(res, 5));
   queue.push({ ...good });
   r = await compileProject(meta.id, 'main');
   eq(r.ok, true, 'recovered');
-  check(r.pdfUrl !== fresh, 'a new success mints a new URL');
-  eq(r.pdfStale, undefined, 'no longer stale');
-
-  // a 4xx bare error from the compiler (e.g. missing root) is a failure too
-  queue.push({ ok: false, error: 'root file not found: main.tex' });
-  r = await compileProject(meta.id, 'main');
-  eq(r.ok, false, 'bare error → not ok');
-  check(typeof r.pdfUrl === 'string', 'keeps the last good URL');
-  eq(r.pdfStale, true, 'and marks it stale');
-  eq(r.log, 'Compiler error: root file not found: main.tex', 'error becomes the log');
-  eq(r.synctex, null, 'no synctex from a bare error');
-
-  // a deleted branch takes its worktree (and PDF) with it: the recreated
-  // branch must not inherit the URL
-  await gitops.createBranch(meta.id, 'draft', 'main');
-  queue.push({ ...good });
-  r = await compileProject(meta.id, 'draft');
-  check(typeof r.pdfUrl === 'string', 'draft succeeds and is remembered');
-  forgetPdfUrls(meta.id, 'draft');
-  queue.push({ ...bad });
-  r = await compileProject(meta.id, 'draft');
-  eq(r.pdfUrl, null, 'after the branch is forgotten a failure shows no URL');
-  eq(r.pdfStale, false, 'and nothing is stale');
-  queue.push({ ...bad });
-  r = await compileProject(meta.id, 'main');
-  check(typeof r.pdfUrl === 'string', 'forgetting one branch leaves the others alone');
-
-  forgetPdfUrls(meta.id);
-  queue.push({ ...bad });
-  r = await compileProject(meta.id, 'main');
-  eq(r.pdfUrl, null, 'forgetting the project drops every branch');
-
-  eq(requests[0].engine, 'pdf', 'engine forwarded to the compiler');
-  console.log('compile stale: all checks passed');
+  check(r.pdfUrl !== withErrors, 'a new success mints a new URL');
 } finally {
   await closeDb();
   mock.close();

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -5,6 +5,7 @@ export interface ProjectSummary {
   name: string;
   rootFile: string;
   engine: string;
+  stopOnFirstError?: boolean;
   createdAt: string;
   ownerId?: string;
   ownerName?: string;
@@ -33,6 +34,8 @@ export interface CompileResult {
   pdfUrl: string | null;
   /** The run failed and pdfUrl is the last successful one, unchanged. */
   pdfStale?: boolean;
+  /** The run whose PDF pdfUrl serves; sent back with SyncTeX lookups. */
+  compileId?: number;
   synctex?: string | null;
   log: string;
   errors: CompileError[];
@@ -85,7 +88,7 @@ export const api = {
   importZip: (name: string, zipBase64: string) =>
     req<ProjectSummary>('/api/projects/import', { method: 'POST', body: JSON.stringify({ name, zipBase64 }) }),
   getProject: (id: string) => req<ProjectDetail>(`/api/projects/${id}`),
-  patchProject: (id: string, patch: Partial<Pick<ProjectSummary, 'name' | 'rootFile' | 'engine'>>) =>
+  patchProject: (id: string, patch: Partial<Pick<ProjectSummary, 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>>) =>
     req<ProjectSummary>(`/api/projects/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
   deleteProject: (id: string, permanent = false) => req<{ ok: boolean }>(`/api/projects/${id}${permanent ? '?permanent=1' : ''}`, { method: 'DELETE' }),
   restoreProject: (id: string) => req<{ ok: boolean }>(`/api/projects/${id}/restore`, { method: 'POST' }),

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { api, CompileResult, ProjectDetail, TreeEntry, Comment, localUser } from '../api';
+import { api, ApiError, CompileResult, ProjectDetail, TreeEntry, Comment, localUser } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
 import ShareModal from '../components/ShareModal';
@@ -223,6 +223,20 @@ export default function Editor() {
     }
   };
 
+  const setStopOnFirstError = useCallback(async (on: boolean) => {
+    if (!project || on === !!project.stopOnFirstError) return;
+    // The checkbox is controlled: flip it now so it follows the click, and
+    // roll back if the server refuses.
+    setProject((prev) => (prev ? { ...prev, stopOnFirstError: on } : prev));
+    try {
+      await api.patchProject(id, { stopOnFirstError: on });
+      toast(on ? 'Typesetting now stops at the first error' : 'Typesetting now runs to the end and lists the errors', 'ok');
+    } catch (err: any) {
+      setProject((prev) => (prev ? { ...prev, stopOnFirstError: !on } : prev));
+      toast(`Could not change the setting: ${err.message}`, 'error');
+    }
+  }, [id, project, toast]);
+
   const setEngine = useCallback(async (engine: string) => {
     if (!project || engine === project.engine) return;
     try {
@@ -322,18 +336,22 @@ export default function Editor() {
   }, [comments, id, acceptSuggestion, loadComments, bumpComments]);
 
 
-  // The preview is stale when the last run failed: the server keeps the previous
-  // pdfUrl and flags it, or the run never produced a result and the pane still
-  // shows the old canvases. A ref so the inverse callback reads the live value.
-  const pdfStale = compile.status === 'error' || !!compile.result?.pdfStale;
+  // The preview is stale when the last run produced no PDF: the server keeps
+  // the previous pdfUrl and flags it, or the run never produced a result and
+  // the pane still shows the old canvases. A run that logged errors but wrote
+  // a PDF is current — the errors sit in the list beside it. Refs so the
+  // inverse callback reads the live values.
+  const pdfStale = (compile.status === 'error' && !compile.result) || !!compile.result?.pdfStale;
   const pdfStaleRef = useRef(pdfStale);
   pdfStaleRef.current = pdfStale;
+  const compileIdRef = useRef<number | undefined>(undefined);
+  compileIdRef.current = compile.result?.compileId;
 
   // Inverse SyncTeX: double-click in the PDF → open the source file at that line.
   const onPdfInverse = useCallback(async (page: number, x: number, y: number) => {
     if (pdfStaleRef.current) toast('This preview is from the last successful typeset — fix the errors and typeset again to jump accurately');
     try {
-      const res = await api.synctex(id, branch, { direction: 'inverse', page, x, y });
+      const res = await api.synctex(id, branch, { direction: 'inverse', page, x, y, compileId: compileIdRef.current });
       const rec = res.records?.find((r) => r.input || r.line != null);
       if (!rec) { toast('No source location for that spot', 'error'); return; }
       const line = Number(rec.line);
@@ -349,7 +367,9 @@ export default function Editor() {
       if (match) file = match.path;
       if (file && files.some((f) => f.path === file)) setActiveFile(file);
       if (!Number.isNaN(line)) requestAnimationFrame(() => setTimeout(() => codeRef.current?.gotoLine(line), 80));
-    } catch {
+    } catch (err: any) {
+      // 409: the preview on screen and the SyncTeX on disk are different runs.
+      if (err instanceof ApiError && err.status === 409) { toast(err.message); return; }
       toast('Jump to source unavailable — typeset first', 'error');
     }
   }, [id, branch, files, toast]);
@@ -409,6 +429,7 @@ export default function Editor() {
       { id: 'auto', group: 'Action', title: auto ? 'Turn auto-typeset off' : 'Turn auto-typeset on', run: toggleAuto },
       { id: 'jump-pdf', group: 'Action', title: 'Jump PDF to cursor', hint: shortcut('J'), run: () => jumpToPdf() },
       ...ENGINES.map((e) => ({ id: `engine-${e.id}`, group: 'Action', title: `Typeset with ${e.label}`, run: () => setEngine(e.id) })),
+      { id: 'stop-on-error', group: 'Action', title: project?.stopOnFirstError ? 'Stop on first error: on' : 'Stop on first error: off', run: () => setStopOnFirstError(!project?.stopOnFirstError) },
       { id: 'spell', group: 'Action', title: spellcheck ? 'Turn spellcheck off' : 'Turn spellcheck on', run: () => setSpellcheck((s) => { localStorage.setItem('aldine.spellcheck', s ? '0' : '1'); return !s; }) },
       { id: 'theme', group: 'View', title: 'Toggle light/dark theme', run: () => { toggleTheme(); } },
       { id: 'about', group: 'View', title: 'About Aldine and its source code', run: () => setAboutOpen(true) },
@@ -456,7 +477,7 @@ export default function Editor() {
       cmds.push({ id: `open-${f.path}`, group: 'Open', title: f.path, run: () => setActiveFile(f.path) });
     }
     return cmds;
-  }, [files, activeFile, id, branch, auto, spellcheck, doCompile, toggleAuto, jumpToPdf, setEngine, insertAtCursor, loadFiles, loadProject, toast]);
+  }, [files, activeFile, id, branch, auto, spellcheck, doCompile, toggleAuto, jumpToPdf, setEngine, setStopOnFirstError, project?.stopOnFirstError, insertAtCursor, loadFiles, loadProject, toast]);
 
   const errors = compile.result?.errors?.filter((e) => e.type !== 'typesetting') || [];
   const errCount = errors.filter((e) => e.type === 'error').length;
@@ -818,6 +839,10 @@ export default function Editor() {
             <h2>Typesetting log</h2>
             <pre className="logview" data-testid="log-view">{compile.result.log || '(no log)'}</pre>
             <div className="modal__row">
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginRight: 'auto', fontSize: 12.5 }} title="On: the run stops at the first error and the preview keeps the previous PDF. Off: the run continues to the end and the complete PDF is shown beside the errors">
+                <input type="checkbox" data-testid="stop-on-error-toggle" checked={!!project?.stopOnFirstError} onChange={(e) => setStopOnFirstError(e.target.checked)} />
+                Stop on first error
+              </label>
               <button className="btn" onClick={() => setShowLog(false)}>Close</button>
             </div>
           </div>

--- a/e2e/tests/17-feedback-round1.spec.ts
+++ b/e2e/tests/17-feedback-round1.spec.ts
@@ -110,11 +110,66 @@ test.describe('forward SyncTeX', () => {
   });
 });
 
+const compileResponse = (page: import('@playwright/test').Page) =>
+  page.waitForResponse((r) => r.url().includes('/compile') && r.request().method() === 'POST');
+
+test.describe('compile to completion', () => {
+  test('an error mid-document still yields a complete PDF, listed beside it; stop-on-first-error restores the old behaviour', async ({ page, request }) => {
+    const id = await createPaperProject(request, 'Run To End');
+    try {
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+
+      const first = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const ok = await (await first).json();
+      expect(ok.ok).toBe(true);
+      await expectTypesetOk(page);
+      const pagesBefore = await page.locator('canvas.pdf-page').count();
+
+      // an undefined macro inside the second section: TeX reports it and carries on
+      const content = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex',
+        content: content.replace('\\section{Convergence}', '\\section{Convergence}\n\\thisMacroDoesNotExist\n') } });
+      const second = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const withErrors = await (await second).json();
+      expect(withErrors.ok).toBe(false);
+      expect(withErrors.pdfStale).toBeFalsy();
+      expect(withErrors.pdfUrl).not.toBe(ok.pdfUrl);
+      expect(withErrors.errors.some((e: { message: string }) => /undefined control sequence/i.test(e.message))).toBe(true);
+
+      await expect(page.getByTestId('errors-panel')).toBeVisible();
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+      await expect.poll(() => page.locator('canvas.pdf-page').count()).toBe(pagesBefore);
+
+      // a jump from the current PDF resolves against this run's SyncTeX
+      const box = await page.locator('canvas.pdf-page').first().boundingBox();
+      await page.mouse.dblclick(box!.x + box!.width * 0.5, box!.y + box!.height * 0.55);
+      await expect(page.locator('.toast').filter({ hasText: /last successful typeset|different runs|unavailable/ })).toHaveCount(0);
+
+      // the toggle lives in the log dialog and is project meta
+      await page.getByTestId('view-log').click();
+      await page.getByTestId('stop-on-error-toggle').check();
+      await expect.poll(async () => (await (await request.get(`/api/projects/${id}`)).json()).stopOnFirstError).toBe(true);
+      await page.keyboard.press('Escape');
+
+      const third = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const halted = await (await third).json();
+      expect(halted.ok).toBe(false);
+      expect(halted.pdfStale).toBe(true);
+      expect(halted.pdfUrl).toBe(withErrors.pdfUrl);
+      await expect(page.getByTestId('pdf-stale')).toBeVisible();
+    } finally { await cleanup(request, id); }
+  });
+});
+
 test.describe('stale preview', () => {
   test('a failed typeset keeps the PDF, flags it, and clears once it compiles again', async ({ page, request }) => {
     const id = await createPaperProject(request, 'Stale Preview');
-    const compileResponse = (page: import('@playwright/test').Page) =>
-      page.waitForResponse((r) => r.url().includes('/compile') && r.request().method() === 'POST');
+    // this test is about the halting mode; the default now runs to the end
+    expect((await request.patch(`/api/projects/${id}`, { data: { stopOnFirstError: true } })).ok()).toBeTruthy();
     try {
       // an on-open compile would be the response the first wait matches
       await withoutAutoTypeset(page);
@@ -153,6 +208,8 @@ test.describe('stale preview', () => {
 
   test('switching branches empties the preview so a failure there cannot claim the other branch\'s PDF', async ({ page, request }) => {
     const id = await createPaperProject(request, 'Stale Branch');
+    // halting mode: these tests are about a run that leaves no PDF to show
+    expect((await request.patch(`/api/projects/${id}`, { data: { stopOnFirstError: true } })).ok()).toBeTruthy();
     try {
       await withoutAutoTypeset(page);
       await openProject(page, id);
@@ -182,6 +239,8 @@ test.describe('stale preview', () => {
 
   test('a recreated branch does not inherit the deleted branch\'s PDF', async ({ request }) => {
     const id = await createPaperProject(request, 'Stale Recreated');
+    // halting mode: these tests are about a run that leaves no PDF to show
+    expect((await request.patch(`/api/projects/${id}`, { data: { stopOnFirstError: true } })).ok()).toBeTruthy();
     try {
       expect((await request.post(`/api/projects/${id}/branches`, { data: { name: 'draft' } })).ok()).toBe(true);
       const ok = await (await request.post(`/api/projects/${id}/compile`, { data: { branch: 'draft' } })).json();


### PR DESCRIPTION
Closes #6.

- The compiler passes `-halt-on-error` only when the project sets `stopOnFirstError` (new per-project setting: log dialog checkbox, command palette, `PATCH /api/projects/:id`). Default off: TeX runs to the end and the complete PDF is shown with the errors listed beside it, like Overleaf.
- The compiler reports `pdfFresh` / `synctexFresh` (written by this run), so a leftover PDF is never mistaken for output. A run with nothing written keeps the previous PDF and flags it stale, as before.
- Compile results carry a `compileId`; inverse SyncTeX lookups send it back and get a 409 with a toast when the preview and the SyncTeX on disk are from different runs.

Checks: server + web typecheck, server unit suite (stale-PDF test rewritten for the new semantics, SyncTeX binding covered), web vitest, e2e `17-feedback-round1` 11/11 with a new compile-to-completion test.
