### PR TITLE
compile: an unchanged document is not stale; sentinel-based freshness

### DIFF
--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -160,6 +160,13 @@ async function compileInner(body) {
   // First pass without -g: latexmk skips work that is already up to date, so an
   // unchanged document "recompiles" in ~a second instead of a full rebuild.
   const runOpts = { cwd: absDir, detached: true, env: { ...process.env, HOME: process.env.HOME || '/tmp' } };
+  // Freshness reference on the SAME filesystem clock as the outputs: a file
+  // touched now. Comparing output mtimes against Date.now() needs slack for
+  // coarse or skewed clocks, and that slack lets a run started right after
+  // the last one mistake an untouched PDF for its own output.
+  const sentinel = path.join(outAbs, '.aldine-run');
+  fs.writeFileSync(sentinel, '');
+  const freshSince = fs.statSync(sentinel).mtimeMs;
   const t0 = Date.now();
   let { code, out, timedOut } = await run('latexmk', mkArgs(false), runOpts, TIMEOUT_MS);
   if (code === 0 && !timedOut && !fs.existsSync(pdfPath)) {
@@ -192,8 +199,8 @@ async function compileInner(body) {
   const ok = code === 0 && fs.existsSync(pdfPath);
   // A previous run's PDF/SyncTeX stay on disk when this run fails, so existence
   // alone says nothing about which run wrote them. "Fresh" = written by this
-  // run (mtime at or after its start, with slack for coarse filesystem clocks).
-  const freshSince = t0 - 2000;
+  // run: mtime at or after the sentinel's (same clock, second granularity at
+  // worst, and a write in the sentinel's own second still counts).
   const isFresh = (f) => { try { return fs.statSync(f).mtimeMs >= freshSince; } catch { return false; } };
   const synctexPath = path.join(absDir, rootDir, OUT_SUBDIR, `${base}.synctex.gz`);
   return {

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -119,12 +119,23 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   // end, so the document is complete and the errors sit in the list beside
   // it. With stopOnFirstError the PDF on disk is truncated at the first error,
   // so only an error-free run is shown and the previous one stays on screen.
+  const previous = lastGoodPdfUrl.get(key) ?? null;
   if (body.pdf && pdfFresh && (body.ok || !meta.stopOnFirstError)) {
     const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${compileId}`;
     lastGoodPdfUrl.set(key, { url: pdfUrl, compileId });
     return { ...body, pdfUrl, compileId };
   }
-  const previous = lastGoodPdfUrl.get(key) ?? null;
+  // latexmk found nothing to redo: the PDF on disk is this run's result even
+  // though nothing was rewritten. It keeps its URL and compileId — a fresh
+  // cache-buster would refetch identical bytes and unbind SyncTeX, and
+  // calling it stale would flag every typeset of an unchanged document.
+  if (body.ok && body.pdf) {
+    const id = previous?.compileId ?? compileId;
+    const pdfUrl = previous?.url ?? `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${id}`;
+    if (!previous) lastGoodPdfUrl.set(key, { url: pdfUrl, compileId: id });
+    if (!lastSynctexId.has(key) && body.synctex) lastSynctexId.set(key, id);
+    return { ...body, pdfUrl, compileId: id };
+  }
   return { ...body, pdfUrl: previous?.url ?? null, pdfStale: previous !== null, compileId: previous?.compileId };
 }
 

--- a/apps/server/test/compile-stale.test.mjs
+++ b/apps/server/test/compile-stale.test.mjs
@@ -77,6 +77,15 @@ try {
   const withErrors = r.pdfUrl;
   const withErrorsId = r.compileId;
 
+  // latexmk had nothing to redo (ok, PDF on disk, nothing rewritten): the
+  // document is unchanged, so it is neither stale nor a new run.
+  queue.push({ ...good, pdfFresh: false, synctexFresh: false });
+  r = await compileProject(meta.id, 'main');
+  eq(r.ok, true, 'unchanged document typesets ok');
+  eq(r.pdfUrl, withErrors, 'an unchanged document keeps its URL');
+  eq(r.pdfStale, undefined, 'and is not stale');
+  eq(r.compileId, withErrorsId, 'and keeps its compileId so SyncTeX stays bound');
+
   // SyncTeX binding: a lookup for a preview from another run is refused
   // before the compiler is asked; the current run's id goes through.
   let sx = await synctexLookup(meta.id, 'main', { direction: 'inverse', page: 1, x: 1, y: 1, compileId: freshId });

--- a/e2e/auth-tests/auth.spec.ts
+++ b/e2e/auth-tests/auth.spec.ts
@@ -269,7 +269,7 @@ test.describe('auth depth', () => {
     await ctx.request.post('/api/auth/logout');
     // replay the stale cookie in a fresh context → must be rejected (revoked)
     const stale = await browser.newContext();
-    await stale.addCookies([{ name: 'aldine_session', value: session!.value, url: 'http://localhost:3200' }]);
+    await stale.addCookies([{ name: 'aldine_session', value: session!.value, url: `http://localhost:${process.env.E2E_AUTH_PORT || 3200}` }]);
     const me = await (await stale.request.get('/api/auth/me')).json();
     expect(me.user).toBeNull();
     await ctx.close(); await stale.close();

--- a/e2e/playwright.auth.config.ts
+++ b/e2e/playwright.auth.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
 /** Auth-enabled stack on :3200, isolated from the main (no-auth) suite. */
-const BASE = process.env.ALDINE_AUTH_URL || 'http://localhost:3200';
+const PORT = Number(process.env.E2E_AUTH_PORT || 3200);
+const BASE = process.env.ALDINE_AUTH_URL || `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: './auth-tests',
@@ -12,9 +13,9 @@ export default defineConfig({
   reporter: [['list']],
   use: { baseURL: BASE, trace: 'retain-on-failure', viewport: { width: 1440, height: 900 } },
   webServer: process.env.ALDINE_AUTH_URL ? undefined : {
-    command: 'npm run build -w apps/web && PORT=3200 AUTH_ENABLED=1 ALDINE_RESET_ECHO=1 ALDINE_TEST_HOOKS=1 TRUST_PROXY=1 RL_REGISTER_BURST=200 DATA_DIR=$(pwd)/.data-auth META_DIR=$(pwd)/.secrets-auth npx tsx apps/server/src/index.ts',
+    command: `npm run build -w apps/web && PORT=${PORT} AUTH_ENABLED=1 ALDINE_RESET_ECHO=1 ALDINE_TEST_HOOKS=1 TRUST_PROXY=1 RL_REGISTER_BURST=200 DATA_DIR=$(pwd)/.data-auth META_DIR=$(pwd)/.secrets-auth npx tsx apps/server/src/index.ts`,
     cwd: '..',
-    port: 3200,
+    port: PORT,
     reuseExistingServer: true,
     timeout: 600_000,
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,7 +9,11 @@ import { defineConfig } from '@playwright/test';
  * Set ALDINE_URL to test an already-running stack (e.g. docker compose on :8080);
  * webServers are skipped via reuseExistingServer when ports are taken.
  */
-const BASE = process.env.ALDINE_URL || 'http://localhost:3100';
+// E2E_PORT / E2E_MOCK_PORT let two checkouts run this suite side by side
+// (reuseExistingServer would otherwise make one run test the other's server).
+const PORT = Number(process.env.E2E_PORT || 3100);
+const MOCK = Number(process.env.E2E_MOCK_PORT || 4919);
+const BASE = process.env.ALDINE_URL || `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: './tests',
@@ -26,17 +30,17 @@ export default defineConfig({
   },
   webServer: process.env.ALDINE_URL ? undefined : [
     {
-      command: 'node tests/mock-zotero.mjs',
-      port: 4919,
+      command: `E2E_MOCK_PORT=${MOCK} node tests/mock-zotero.mjs`,
+      port: MOCK,
       reuseExistingServer: true,
       timeout: 10_000,
     },
     {
       // OPENROUTER_API_KEY/OPENAI_API_KEY are emptied so an ambient key can't
       // override the mock Anthropic endpoint the AI-fix test relies on.
-      command: 'npm run build -w apps/web && PORT=3100 DATA_DIR=$(pwd)/.data-e2e OPENROUTER_API_KEY= OPENAI_API_KEY= ZOTERO_API_BASE=http://localhost:4919 DOI_API_BASE=http://localhost:4919 ARXIV_API_BASE=http://localhost:4919 OPENALEX_API_BASE=http://localhost:4919 ANTHROPIC_API_KEY=test-ai-key ANTHROPIC_BASE_URL=http://localhost:4919 npx tsx apps/server/src/index.ts',
+      command: `npm run build -w apps/web && PORT=${PORT} DATA_DIR=$(pwd)/.data-e2e OPENROUTER_API_KEY= OPENAI_API_KEY= ZOTERO_API_BASE=http://localhost:${MOCK} DOI_API_BASE=http://localhost:${MOCK} ARXIV_API_BASE=http://localhost:${MOCK} OPENALEX_API_BASE=http://localhost:${MOCK} ANTHROPIC_API_KEY=test-ai-key ANTHROPIC_BASE_URL=http://localhost:${MOCK} npx tsx apps/server/src/index.ts`,
       cwd: '..',
-      port: 3100,
+      port: PORT,
       reuseExistingServer: true,
       timeout: 600_000,
     },

--- a/e2e/tests/17-feedback-round1.spec.ts
+++ b/e2e/tests/17-feedback-round1.spec.ts
@@ -127,6 +127,17 @@ test.describe('compile to completion', () => {
       await expectTypesetOk(page);
       const pagesBefore = await page.locator('canvas.pdf-page').count();
 
+      // typesetting an unchanged document is not a failure and not stale:
+      // latexmk rewrites nothing, the PDF keeps its link
+      const again = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const unchanged = await (await again).json();
+      expect(unchanged.ok).toBe(true);
+      expect(unchanged.pdfStale).toBeFalsy();
+      expect(unchanged.pdfUrl).toBe(ok.pdfUrl);
+      await expectTypesetOk(page);
+      await expect(page.getByTestId('pdf-stale')).toHaveCount(0);
+
       // an undefined macro inside the second section: TeX reports it and carries on
       const content = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
       await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex',

--- a/e2e/tests/mock-zotero.mjs
+++ b/e2e/tests/mock-zotero.mjs
@@ -103,4 +103,5 @@ const server = http.createServer((req, res) => {
   send(404, { error: 'not found' });
 });
 
-server.listen(4919, () => console.log('[mock-zotero] on :4919'));
+const port = Number(process.env.E2E_MOCK_PORT || 4919);
+server.listen(port, () => console.log(`[mock-zotero] on :${port}`));


### PR DESCRIPTION
Typesetting a document with no changes reported the PDF as stale (nothing rewritten, freshness check failed, ribbon shown). Such a run keeps its link and compile id now. The compiler measures freshness against a sentinel file touched before the run instead of a two-second clock slack. Also makes the e2e ports configurable (E2E_PORT, E2E_MOCK_PORT, E2E_AUTH_PORT) so two checkouts can run the suites side by side.

Checks: server typecheck, compile-stale unit test (new case), e2e 17-feedback-round1 11/11 with a new unchanged-typeset case.