### PR TITLE
feat: project compiler settings and engine detection on import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ e2e needs the compiler on :4020 **with the e2e data dir**:
 compiler on the default `.data` makes every compile test fail while looking
 healthy. `ALDINE_URL=http://localhost:8080 npm run test:e2e` targets a running
 compose stack instead. Two `07-features` tests need full TeX Live (BasicTeX
-lacks packages); everything else passes locally.
+lacks packages); everything else passes locally. Two checkouts side by side
+(`reuseExistingServer` would otherwise test the other tree's server):
+`E2E_PORT=3101 E2E_MOCK_PORT=4920 E2E_AUTH_PORT=3201 COMPILER_URL=http://localhost:4021 npm run test:e2e`.
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,6 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
-### Changed
-- Typesetting runs to the end of the document by default instead of stopping
-  at the first error: the preview shows the complete PDF and the errors sit in
-  the list beside it, like Overleaf. The old behaviour is a per-project setting,
-  "Stop on first error" (log dialog and command palette, `stopOnFirstError` in
-  `PATCH /api/projects/:id`); with it on, a failing run keeps the previous PDF
-  on screen as before.
-
-### Fixed
-- A SyncTeX jump from the PDF is refused (409, with a toast) when the preview
-  on screen and the SyncTeX file on disk come from different typeset runs,
-  instead of landing on the wrong line. Compile results carry a `compileId`
-  that the lookup sends back.
-
 ### Added
 - Blank projects: a "Blank" tile leads the template grid and creates a project
   with no files; `POST /api/projects` with `template: "blank"` (or `files: {}`)
@@ -47,22 +33,74 @@ All notable changes to Aldine are documented here. The format follows
 - The New project dialog only posts a template id the server listed; on a
   server without a templates directory the pick stays empty and Create seeds
   the default article, with the Blank tile still there to choose.
+- Project settings dialog (toolbar "Settings", command palette) with a
+  Compiler section: main document, compiler (pdfLaTeX, XeLaTeX, LuaLaTeX),
+  the connected compiler's TeX Live release and scheme ("2026, full"), "Stop
+  on first error" and "Auto-typeset". The preview-header engine picker and
+  the log dialog's checkbox stay as shortcuts to the same settings. The
+  project name is editable there too. (#7)
+- Engine detection on ZIP import: a `latexmkrc` in the archive (`$pdf_mode`
+  4 or 5, or a `$pdflatex`/`$xelatex`/`$lualatex` line), a `% !TEX program`
+  line, or a root file using fontspec, unicode-math, polyglossia, xepersian,
+  bidi or luacode sets the project to XeLaTeX or LuaLaTeX; the import toast
+  says which and why, and the settings panel repeats the reason. A
+  `$pdflatex` line that only passes flags to pdflatex (the Overleaf
+  `-shell-escape` idiom), or an rc that assigns all three engine commands,
+  chooses nothing, so the root file still decides.
+  Sources that are not UTF-8 are transcoded to UTF-8: Windows-1252 (a
+  superset of Latin-1, so Word-era quotes and dashes survive), or Latin-9 /
+  Mac Roman when the inputenc option names them; the option is switched to
+  `utf8` and the file is named in the toast. A UTF-8 file with a stray byte
+  is left as it was, multibyte characters intact. Overleaf exports that need
+  XeLaTeX now typeset on first open. (#7)
+- The compiler reports its TeX Live release and scheme at `GET /health`
+  (`texlive: { release, scheme }`; "unknown" outside the image), and the
+  server exposes it, cached, at `GET /api/compiler`. Switching between
+  several TeX Live versions (`ALDINE_COMPILERS`) is not part of this change;
+  the panel displays the one compiler the server is connected to.
+- The e2e suites take `E2E_PORT`, `E2E_MOCK_PORT` and `E2E_AUTH_PORT` so two
+  checkouts can run side by side (see AGENTS.md).
 - AWS deployment: an optional staging service on the same load balancer
   (`staging_domain_name`), with its own filesystem, log group and certificate,
   so a feature branch can be tried at a real URL before it reaches prod. The
   deploy and rollback workflows take a `target` input (production or staging).
 
-### Security
-- The minimal `docker-compose.yml` carries the compiler sandbox again: an
-  `internal: true` network with no route to the internet, `cap_drop: [ALL]`,
-  `no-new-privileges`, and memory/PID bounds. The 0.3.0 split had left all of it
-  in `docker-compose.full.yml` while SECURITY.md and the README went on
-  promising it, so quick-start instances were compiling untrusted LaTeX in a
-  container with full egress and every capability. The README quick start is the
-  same file, verbatim, including the `name: aldine` line that fixes the volume
-  names.
+- Download PDF button in the preview toolbar — saves the compiled PDF named
+  after the project.
+- Public-demo hardening: `ALDINE_PROTECTED_PROJECTS` serves listed projects
+  read-only (HTTP and collab socket) so a showcase paper survives a
+  world-writable demo, and `ALDINE_COMPILE_PER_MIN` caps each visitor's
+  typesets per minute. The demo stack enables the cap by default.
+- Search and AI discoverability for aldine.dev: `robots.txt` (all crawlers
+  welcome, AI crawlers included), `sitemap.xml`, a canonical URL, JSON-LD
+  software metadata, and a curated `llms.txt` overview for LLMs and agents.
+  The page title now says what people search for: "open-source Overleaf
+  alternative".
+- `AGENTS.md` at the repo root (the cross-tool agent-guidance standard);
+  `CLAUDE.md` now imports it instead of carrying its own copy.
+
+- An About dialog, from the home screen and the command palette, naming the
+  licence and linking to the source, stamped with the version and the commit
+  the bundle was built from. AGPL section 13 requires a network instance to
+  offer its users the corresponding source, and every public deployment had
+  been serving a UI that mentioned neither.
+- [`CLA.md`](CLA.md) and a signing workflow: contributors keep their copyright
+  and grant the right to distribute, including under different licence terms
+  later, so the project keeps the option of a commercially licensed edition.
+- [`TRADEMARK.md`](TRADEMARK.md): the AGPL covers the code, not the name. Run
+  and rebrand freely; don't ship a modified Aldine under the Aldine name.
+- The README states plainly that a hosted service is planned, that the
+  self-hosted edition stays AGPL, and that no feature that works today moves
+  behind a paid tier.
 
 ### Changed
+- Typesetting runs to the end of the document by default instead of stopping
+  at the first error: the preview shows the complete PDF and the errors sit in
+  the list beside it, like Overleaf. The old behaviour is a per-project setting,
+  "Stop on first error" (log dialog and command palette, `stopOnFirstError` in
+  `PATCH /api/projects/:id`); with it on, a failing run keeps the previous PDF
+  on screen as before.
+
 - The compiler image defaults to full TeX Live (`TEXLIVE_SCHEME=full`): every
   script and language compiles out of the box. The `medium` scheme stays for
   constrained hosts and now includes the publisher classes and the Arabic/Persian,
@@ -81,37 +119,17 @@ All notable changes to Aldine are documented here. The format follows
   `MAX_CONCURRENT_COMPILES` through from `.env` instead of hardcoding the
   timeout.
 
-### Added
-- Download PDF button in the preview toolbar — saves the compiled PDF named
-  after the project.
-- Public-demo hardening: `ALDINE_PROTECTED_PROJECTS` serves listed projects
-  read-only (HTTP and collab socket) so a showcase paper survives a
-  world-writable demo, and `ALDINE_COMPILE_PER_MIN` caps each visitor's
-  typesets per minute. The demo stack enables the cap by default.
-- Search and AI discoverability for aldine.dev: `robots.txt` (all crawlers
-  welcome, AI crawlers included), `sitemap.xml`, a canonical URL, JSON-LD
-  software metadata, and a curated `llms.txt` overview for LLMs and agents.
-  The page title now says what people search for: "open-source Overleaf
-  alternative".
-- `AGENTS.md` at the repo root (the cross-tool agent-guidance standard);
-  `CLAUDE.md` now imports it instead of carrying its own copy.
-
-### Added
-- An About dialog, from the home screen and the command palette, naming the
-  licence and linking to the source, stamped with the version and the commit
-  the bundle was built from. AGPL section 13 requires a network instance to
-  offer its users the corresponding source, and every public deployment had
-  been serving a UI that mentioned neither.
-- [`CLA.md`](CLA.md) and a signing workflow: contributors keep their copyright
-  and grant the right to distribute, including under different licence terms
-  later, so the project keeps the option of a commercially licensed edition.
-- [`TRADEMARK.md`](TRADEMARK.md): the AGPL covers the code, not the name. Run
-  and rebrand freely; don't ship a modified Aldine under the Aldine name.
-- The README states plainly that a hosted service is planned, that the
-  self-hosted edition stays AGPL, and that no feature that works today moves
-  behind a paid tier.
+- App instances send `noindex`: an Aldine box holds private documents, and
+  the public face for search engines is aldine.dev. This covers the demo and
+  every self-hosted install; remove the tag in `apps/web/index.html` if you
+  want your instance indexed.
 
 ### Fixed
+- A SyncTeX jump from the PDF is refused (409, with a toast) when the preview
+  on screen and the SyncTeX file on disk come from different typeset runs,
+  instead of landing on the wrong line. Compile results carry a `compileId`
+  that the lookup sends back.
+
 - Importing a ZIP larger than about 24 MB no longer fails with a bare
   "Payload Too Large": the import route now accepts the 60 MB the dialog
   promises (the ZIP travels base64-encoded inside JSON, so the global 32 MB
@@ -172,24 +190,6 @@ All notable changes to Aldine are documented here. The format follows
   the demo answers no TLS handshake at all until the window rolls over. The
   wipe now drops the data volumes by name and leaves `aldine_caddy-data` alone.
 
-### Changed
-- App instances send `noindex`: an Aldine box holds private documents, and
-  the public face for search engines is aldine.dev. This covers the demo and
-  every self-hosted install; remove the tag in `apps/web/index.html` if you
-  want your instance indexed.
-
-### Security
-- Accepting a review suggestion now applies to the live collaborative
-  document on the server. The old client-side path read the disk copy,
-  string-replaced, and wrote the whole file back — silently destroying every
-  collaborator's not-yet-autosaved edits, and failing with a misleading
-  "commented text has changed" toast whenever the target text was younger
-  than the autosave debounce.
-- Renaming a file flushes pending collaborative edits to disk first. The
-  rename endpoint evicted the live document before moving the file, so
-  keystrokes from the last few seconds were silently lost.
-
-### Fixed
 - Renaming the typeset root keeps it the root (the setting follows the new
   name; deleting the root already re-derived it). Renaming a missing file now
   returns 404 instead of 500, and a rename conflict from the command palette
@@ -232,7 +232,6 @@ All notable changes to Aldine are documented here. The format follows
   row, menu hover, primary button) use a fill that carries white text at
   4.5:1.
 
-### Fixed
 - The word count now covers the whole document (the root file plus everything
   it `\input`s/`\include`s), keeping the open file's share live while typing.
   It used to count only the open file, which for a multi-file project meant
@@ -296,6 +295,26 @@ All notable changes to Aldine are documented here. The format follows
   described resizing a server type that is no longer the default.
 - The landing page announced "Typeset in 0.4s" a paragraph above "about two
   seconds"; the README says ~2s, so the page does now too.
+
+### Security
+- The minimal `docker-compose.yml` carries the compiler sandbox again: an
+  `internal: true` network with no route to the internet, `cap_drop: [ALL]`,
+  `no-new-privileges`, and memory/PID bounds. The 0.3.0 split had left all of it
+  in `docker-compose.full.yml` while SECURITY.md and the README went on
+  promising it, so quick-start instances were compiling untrusted LaTeX in a
+  container with full egress and every capability. The README quick start is the
+  same file, verbatim, including the `name: aldine` line that fixes the volume
+  names.
+
+- Accepting a review suggestion now applies to the live collaborative
+  document on the server. The old client-side path read the disk copy,
+  string-replaced, and wrote the whole file back — silently destroying every
+  collaborator's not-yet-autosaved edits, and failing with a misleading
+  "commented text has changed" toast whenever the target text was younger
+  than the autosave debounce.
+- Renaming a file flushes pending collaborative edits to disk first. The
+  rename endpoint evicted the live document before moving the file, so
+  keystrokes from the last few seconds were silently lost.
 
 ## [0.3.0] — 2026-08-03
 

--- a/apps/compiler/Dockerfile
+++ b/apps/compiler/Dockerfile
@@ -57,6 +57,10 @@ RUN tlmgr conf texmf shell_escape p
 
 WORKDIR /srv
 COPY server.js .
+# server.js reports the scheme at GET /health; the ARG must be re-declared
+# after FROM to be visible in this stage.
+ARG TEXLIVE_SCHEME
+RUN echo "${TEXLIVE_SCHEME}" > /srv/texlive-scheme
 
 ENV PORT=4020 \
     DATA_DIR=/data \

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -5,7 +5,7 @@
  * Contract:
  *   POST /compile  { projectDir, rootFile, engine? }  ->
  *     { ok, pdf: <path in OUT_DIR>, log, errors: [{file,line,message,type}], durationMs }
- *   GET  /health   -> { ok: true }
+ *   GET  /health   -> { ok: true, texlive: { release: '2026' | 'unknown', scheme: 'full' | 'medium' | 'unknown' } }
  *
  * The compiler shares the projects volume (read) and an output cache volume
  * (write) with the app server, so no file transfer is needed.
@@ -24,6 +24,9 @@ const TIMEOUT_MS = Number(process.env.COMPILE_TIMEOUT_MS || 120_000);
 // Aux/PDF output lives inside the project tree (relative path) so TeX path
 // restrictions (openout_any=p) never apply and incremental caches persist.
 const OUT_SUBDIR = '.aldine-out';
+// The Dockerfile writes the build arg TEXLIVE_SCHEME here; a checkout running
+// server.js directly has no such file and reports "unknown".
+const SCHEME_FILE = process.env.TEXLIVE_SCHEME_FILE || path.join(__dirname, 'texlive-scheme');
 
 function json(res, code, body) {
   const buf = Buffer.from(JSON.stringify(body));
@@ -92,6 +95,28 @@ function run(cmd, args, opts, timeoutMs) {
       resolve({ code: -2, out: String(err), timedOut: false });
     });
   });
+}
+
+/**
+ * TeX Live release and scheme, resolved once at startup. The release comes
+ * from kpsewhich (the TEXMFDIST path carries the year), falling back to tlmgr;
+ * the scheme from SCHEME_FILE. Neither is worth failing startup over: a host
+ * without TeX Live still answers /health, just with "unknown".
+ */
+const texlive = { release: 'unknown', scheme: 'unknown' };
+async function probeTexLive() {
+  try {
+    const scheme = fs.readFileSync(SCHEME_FILE, 'utf8').trim();
+    if (/^[a-z]+$/.test(scheme)) texlive.scheme = scheme;
+  } catch { /* not built from the Dockerfile */ }
+  const year = (text) => (text.match(/\b(20\d\d)\b/) || [])[1];
+  const dist = await run('kpsewhich', ['-var-value=TEXMFDIST'], {}, 10_000);
+  let release = dist.code === 0 ? year(dist.out) : undefined;
+  if (!release) {
+    const tl = await run('tlmgr', ['--version'], {}, 10_000);
+    release = tl.code === 0 ? year(tl.out) : undefined;
+  }
+  if (release) texlive.release = release;
 }
 
 // Bound concurrent latexmk runs so a burst can't OOM the container.
@@ -265,7 +290,7 @@ async function synctex(body) {
 }
 
 const server = http.createServer(async (req, res) => {
-  if (req.method === 'GET' && req.url === '/health') return json(res, 200, { ok: true });
+  if (req.method === 'GET' && req.url === '/health') return json(res, 200, { ok: true, texlive });
   if (req.method === 'POST' && (req.url === '/compile' || req.url === '/synctex')) {
     let raw = '';
     req.on('data', (d) => { raw += d; });
@@ -283,4 +308,6 @@ const server = http.createServer(async (req, res) => {
   json(res, 404, { ok: false, error: 'not found' });
 });
 
-server.listen(PORT, () => console.log(`[compiler] listening on :${PORT}, data=${DATA_DIR}`));
+probeTexLive().finally(() => {
+  server.listen(PORT, () => console.log(`[compiler] listening on :${PORT}, data=${DATA_DIR}, texlive=${texlive.release} (${texlive.scheme})`));
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/compiler-info.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -68,6 +68,43 @@ export function forgetPdfUrls(projectId: string, branch?: string): void {
   for (const key of lastSynctexId.keys()) if (key.startsWith(`${projectId}::`)) lastSynctexId.delete(key);
 }
 
+export interface CompilerInfo {
+  /** The compiler answered /health. */
+  ok: boolean;
+  /** TeX Live release year ("2026") and scheme ("full" | "medium"); "unknown"
+   *  when the compiler predates the report or runs outside the image. */
+  texlive: { release: string; scheme: string };
+}
+
+const UNKNOWN_TEXLIVE = { release: 'unknown', scheme: 'unknown' };
+// A reachable compiler's TeX Live does not change while it runs; an
+// unreachable one is retried soon so the settings panel recovers with it.
+const COMPILER_INFO_TTL_MS = 5 * 60_000;
+const COMPILER_INFO_RETRY_MS = 5_000;
+let compilerInfoCache: { until: number; value: CompilerInfo } | null = null;
+let compilerInfoInflight: Promise<CompilerInfo> | null = null;
+
+/** Release and scheme of the connected compiler's TeX Live, cached. */
+export function compilerInfo(): Promise<CompilerInfo> {
+  const now = Date.now();
+  if (compilerInfoCache && compilerInfoCache.until > now) return Promise.resolve(compilerInfoCache.value);
+  if (compilerInfoInflight) return compilerInfoInflight;
+  compilerInfoInflight = (async () => {
+    let value: CompilerInfo;
+    try {
+      const res = await fetch(`${config.compilerUrl}/health`, { signal: AbortSignal.timeout(5_000) });
+      const raw = (await res.json()) as { ok?: boolean; texlive?: { release?: unknown; scheme?: unknown } };
+      const str = (v: unknown) => (typeof v === 'string' && v ? v : 'unknown');
+      value = { ok: !!raw.ok, texlive: { release: str(raw.texlive?.release), scheme: str(raw.texlive?.scheme) } };
+    } catch {
+      value = { ok: false, texlive: UNKNOWN_TEXLIVE };
+    }
+    compilerInfoCache = { until: Date.now() + (value.ok ? COMPILER_INFO_TTL_MS : COMPILER_INFO_RETRY_MS), value };
+    return value;
+  })().finally(() => { compilerInfoInflight = null; });
+  return compilerInfoInflight;
+}
+
 export function compileProject(projectId: string, branch: string): Promise<CompileResult> {
   const key = `${projectId}::${branch}`;
   const prev = compileChain.get(key) || Promise.resolve();

--- a/apps/server/src/detect.ts
+++ b/apps/server/src/detect.ts
@@ -1,0 +1,146 @@
+/**
+ * Engine detection and text decoding for imported archives. Overleaf exports
+ * that need XeLaTeX or LuaLaTeX fail silently under pdflatex, so the import
+ * picks the engine the project asks for: an explicit build setting first
+ * (latexmkrc, then a magic comment), the root file's package list last.
+ */
+export type Engine = 'pdf' | 'xelatex' | 'lualatex';
+
+export interface EngineDetection {
+  engine: Engine;
+  /** Where the choice came from, for the import toast; null when nothing asked for a non-default engine. */
+  reason: string | null;
+}
+
+// Only the head of the root is scanned: a preamble past this is not one a
+// person wrote, and the 200 MB archive bound must stay cheap to honour.
+const SNIFF_BYTES = 256 * 1024;
+
+/** \usepackage or \RequirePackage naming any of the packages, outside a comment (an escaped \% opens none). */
+const packageRe = (names: string[]) =>
+  new RegExp(`^(?:[^%\\\\\\n]|\\\\.)*\\\\(?:usepackage|RequirePackage)\\s*(?:\\[[^\\]]*\\]\\s*)?\\{[^}]*\\b(${names.join('|')})\\b[^}]*\\}`, 'm');
+const LUA_PACKAGES = ['luacode', 'luatexbase', 'luaotfload', 'lualatex-math', 'luatextra', 'luamplib'];
+// fontspec and unicode-math run on both engines; XeLaTeX is the one Overleaf
+// picks for them and the one bidi/xepersian require outright.
+const XE_PACKAGES = ['fontspec', 'unicode-math', 'polyglossia', 'xepersian', 'bidi', 'xeCJK', 'xltxtra', 'xunicode'];
+const LUA_RE = packageRe(LUA_PACKAGES);
+const XE_RE = packageRe(XE_PACKAGES);
+// "% !TEX program = xelatex" (TeXShop/TeXworks/VS Code), "TS-program" is the TeXShop spelling.
+const MAGIC_RE = /^%\s*!\s*TEX\s+(?:TS-)?program\s*=\s*(\w+)/im;
+
+function engineFromProgram(name: string): Engine | null {
+  const n = name.toLowerCase();
+  if (n === 'xelatex' || n === 'xetex') return 'xelatex';
+  if (n === 'lualatex' || n === 'luatex' || n === 'luahbtex') return 'lualatex';
+  if (n === 'pdflatex' || n === 'latex' || n === 'pdftex') return 'pdf';
+  return null;
+}
+
+/**
+ * latexmk's own precedence, reduced: $pdf_mode selects the engine (4 = xelatex,
+ * 5 = lualatex, 1 = pdflatex); without it, a $pdflatex command naming xelatex
+ * or lualatex (the pre-4.51 idiom); without either, a bare $xelatex or
+ * $lualatex assignment is the only remaining hint, and only when it stands
+ * alone: an rc that assigns both (the idiom that hands -shell-escape to
+ * whichever engine runs) chooses none, like a $pdflatex line that names
+ * pdflatex, so the root file still decides. Lines after `#` are comments.
+ */
+export function engineFromLatexmkrc(text: string): Engine | null {
+  const code = text.split('\n').map((l) => l.replace(/#.*$/, '')).join('\n');
+  const mode = code.match(/\$pdf_mode\s*=\s*['"]?(\d)/);
+  if (mode) {
+    if (mode[1] === '4') return 'xelatex';
+    if (mode[1] === '5') return 'lualatex';
+    if (mode[1] === '1') return 'pdf';
+  }
+  const cmd = code.match(/\$pdflatex\s*=\s*['"]\s*(\S+)/);
+  if (cmd) {
+    const e = engineFromProgram(cmd[1].split('/').pop()!);
+    if (e && e !== 'pdf') return e;
+  }
+  const hasLua = /\$lualatex\s*=/.test(code);
+  const hasXe = /\$xelatex\s*=/.test(code);
+  if (hasLua && hasXe) return null;
+  if (hasLua) return 'lualatex';
+  if (hasXe) return 'xelatex';
+  return null;
+}
+
+/** Engine the root file's preamble requires, or null when pdflatex would do. */
+export function engineFromSource(text: string): { engine: Engine; reason: string } | null {
+  const magic = text.match(MAGIC_RE);
+  if (magic) {
+    const e = engineFromProgram(magic[1]);
+    if (e) return { engine: e, reason: `the "!TEX program" line in the main document` };
+  }
+  const lua = text.match(LUA_RE);
+  if (lua) return { engine: 'lualatex', reason: `the ${lua[1]} package in the main document` };
+  const xe = text.match(XE_RE);
+  if (xe) return { engine: 'xelatex', reason: `the ${xe[1]} package in the main document` };
+  return null;
+}
+
+/**
+ * The engine an imported archive should typeset with. `files` are the placed
+ * entries (project-relative paths), `root` the detected main document.
+ * A latexmkrc beside the root wins over one elsewhere.
+ */
+export function detectEngine(files: Record<string, Buffer>, root: string | undefined): EngineDetection {
+  const rootDir = root && root.includes('/') ? root.slice(0, root.lastIndexOf('/') + 1) : '';
+  const rcs = Object.keys(files)
+    .filter((p) => /(^|\/)\.?latexmkrc$/i.test(p))
+    .sort((a, b) => Number(!a.startsWith(rootDir)) - Number(!b.startsWith(rootDir)) || a.split('/').length - b.split('/').length || a.localeCompare(b));
+  for (const rc of rcs) {
+    const engine = engineFromLatexmkrc(files[rc].toString('utf8'));
+    if (engine) return { engine, reason: engine === 'pdf' ? null : `${rc} in the archive` };
+  }
+  if (root && files[root]) {
+    const head = files[root].toString('utf8', 0, Math.min(files[root].length, SNIFF_BYTES));
+    const found = engineFromSource(head);
+    if (found) return found;
+  }
+  return { engine: 'pdf', reason: null };
+}
+
+const utf8Strict = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
+
+// Node decodes the windows-1252 label as Latin-1, so the C1 range (the curly
+// quotes, dashes, ellipsis and euro sign of Windows exports) is mapped here.
+const CP1252_C1 = '\u20AC\u0081\u201A\u0192\u201E\u2026\u2020\u2021\u02C6\u2030\u0160\u2039\u0152\u008D\u017D\u008F'
+  + '\u0090\u2018\u2019\u201C\u201D\u2022\u2013\u2014\u02DC\u2122\u0161\u203A\u0153\u009D\u017E\u0178';
+const decodeCp1252 = (data: Buffer) => data.toString('latin1').replace(/[\x80-\x9f]/g, (c) => CP1252_C1[c.charCodeAt(0) - 0x80]);
+
+const INPUTENC_RE = /(\\usepackage\s*\[)([^\]]*)(\]\s*\{inputenc\})/g;
+/** inputenc options the transcode understands; each is replaced by utf8 afterwards. */
+const LEGACY_OPTION_RE = /\b(latin1|latin9|ansinew|cp1252|applemac)\b/g;
+// Windows-1252 is a superset of Latin-1 for every printable byte, so a
+// [latin1] file decodes through it too; the other two differ and need their own.
+const DECODER_FOR_OPTION: Record<string, string> = { latin9: 'iso-8859-15', applemac: 'macintosh' };
+
+/**
+ * Decode an imported text file. Bytes that are not UTF-8 are read as
+ * Windows-1252 (Latin-1 plus the Windows punctuation of Word-era exports), or
+ * as Latin-9 / Mac Roman when the file's inputenc option says so, and that
+ * option is switched to utf8 so the transcoded file still compiles. A UTF-8
+ * file with a stray byte is not transcoded: the multibyte characters it does
+ * have are kept and the bad byte becomes U+FFFD, as before. Returns whether a
+ * transcode happened.
+ */
+export function decodeText(data: Buffer): { text: string; transcoded: boolean } {
+  try {
+    return { text: utf8Strict.decode(data), transcoded: false };
+  } catch {
+    const lenient = data.toString('utf8');
+    const valid = (lenient.match(/[^\x00-\x7f\ufffd]/g) ?? []).length;
+    const bad = (lenient.match(/\ufffd/g) ?? []).length;
+    if (valid >= bad) return { text: lenient, transcoded: false };
+    let text = decodeCp1252(data);
+    const option = Array.from(text.matchAll(INPUTENC_RE)).flatMap((m) => m[2].match(LEGACY_OPTION_RE) ?? []).find((o) => DECODER_FOR_OPTION[o]);
+    if (option) text = new TextDecoder(DECODER_FOR_OPTION[option]).decode(data);
+    text = text.replace(INPUTENC_RE, (m, open, opts, close) => {
+      const swapped = opts.replace(LEGACY_OPTION_RE, 'utf8');
+      return swapped === opts ? m : `${open}${swapped}${close}`;
+    });
+    return { text, transcoded: true };
+  }
+}

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -5,7 +5,7 @@ import crypto from 'node:crypto';
 import * as store from './store.js';
 import * as gitops from './gitops.js';
 import * as zotero from './zotero.js';
-import { compileProject, synctexLookup, forgetPdfUrls } from './compile.js';
+import { compileProject, synctexLookup, forgetPdfUrls, compilerInfo } from './compile.js';
 import * as usage from './usage.js';
 import * as github from './github.js';
 import { flushBranchDocs, refreshBranchDocsFromDisk, evictDoc, scheduleCommit, closeProjectConnections, bumpContentVersion, contentVersion, applySuggestionToDoc, protectedProjects } from './collab.js';
@@ -17,6 +17,7 @@ import { fetchBibEntry, searchWorks } from './references.js';
 import { latexWordCount, documentFiles } from './wordcount.js';
 import { unzip } from './unzip.js';
 import { guessRoot, detectRoot } from './root.js';
+import { detectEngine, decodeText } from './detect.js';
 import { aiConfigured, aiModel, diagnose } from './ai.js';
 import * as comments from './comments.js';
 import * as auth from './auth.js';
@@ -427,6 +428,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
 
   app.get('/api/templates', async () => listTemplates());
 
+  // What the connected compiler runs. Not project-scoped, so it is not behind
+  // the project auth hook; it discloses nothing beyond a TeX Live release.
+  app.get('/api/compiler', async () => compilerInfo());
+
   // Import an Overleaf/project ZIP (base64) as a new project.
   // The ZIP arrives base64-encoded inside JSON (×4/3 of the raw size), so the
   // route needs its own body limit: the global 32 MB one would cap imports at
@@ -456,19 +461,28 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       // create with text files seeded; write binaries as buffers afterward
       const textFiles: Record<string, string> = {};
       const binFiles: string[] = [];
+      const transcoded: string[] = [];
       for (const [p, data] of Object.entries(files)) {
         // treat as text only if the extension says so AND there's no NUL byte in the head
         const looksBinary = data.subarray(0, 8000).includes(0);
-        if (isTextFile(p) && !looksBinary) textFiles[p] = data.toString('utf8');
-        else binFiles.push(p);
+        if (isTextFile(p) && !looksBinary) {
+          const decoded = decodeText(data);
+          textFiles[p] = decoded.text;
+          if (decoded.transcoded) transcoded.push(p);
+        } else binFiles.push(p);
       }
       const meta = await store.createProject(name || 'Imported project', textFiles, reqUser(req)?.id);
       created = meta;
       for (const p of binFiles) store.writeFile(meta.id, 'main', p, files[p]);
       if (binFiles.length) await gitops.commitAll(meta.id, 'main', 'aldine: import assets').catch(() => {});
       const root = guessRoot(files);
-      if (root) { meta.rootFile = root; await store.writeMeta(meta); }
-      return publicMeta(meta, reqUser(req));
+      // Detection reads the archive bytes, not the transcoded text: the package
+      // names it looks for are ASCII either way, and the latexmkrc is never transcoded.
+      const detected = detectEngine(files, root);
+      if (root) meta.rootFile = root;
+      meta.engine = detected.engine;
+      await store.writeMeta(meta);
+      return { ...(await publicMeta(meta, reqUser(req))), import: { engine: detected.engine, engineReason: detected.reason, transcoded } };
     } catch (err: any) {
       if (created) await store.deleteProject(created.id).catch(() => {});
       return reply.code(400).send({ error: `Could not import ZIP: ${err.message}` });

--- a/apps/server/test/compiler-info.test.mjs
+++ b/apps/server/test/compiler-info.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * GET /api/compiler: the compiler's own /health reports TeX Live release and
+ * scheme (probed from the real server.js), the app caches a good answer and
+ * retries an unreachable compiler, and a compiler that predates the report
+ * comes back as "unknown" rather than an error.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { check, eq } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-compiler-info-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+const freePort = () => new Promise((resolve) => {
+  const s = net.createServer();
+  s.listen(0, '127.0.0.1', () => { const { port } = s.address(); s.close(() => resolve(port)); });
+});
+
+// ---- the real compiler script ----
+const here = path.dirname(fileURLToPath(import.meta.url));
+const compilerJs = path.resolve(here, '../../compiler/server.js');
+const schemeFile = path.join(tmp, 'texlive-scheme');
+fs.writeFileSync(schemeFile, 'medium\n');
+const compilerPort = await freePort();
+const child = spawn(process.execPath, [compilerJs], { env: { ...process.env, PORT: String(compilerPort), DATA_DIR: path.join(tmp, 'data'), TEXLIVE_SCHEME_FILE: schemeFile }, stdio: ['ignore', 'pipe', 'inherit'] });
+await new Promise((resolve, reject) => {
+  child.stdout.on('data', (d) => { if (String(d).includes('listening')) resolve(); });
+  child.on('exit', (code) => reject(new Error(`compiler exited early: ${code}`)));
+  setTimeout(() => reject(new Error('compiler did not start')), 20_000);
+});
+
+// ---- a mock compiler that predates the report, counting requests ----
+let mockHits = 0;
+const mock = http.createServer((req, res) => {
+  mockHits++;
+  const buf = Buffer.from(JSON.stringify({ ok: true }));
+  res.writeHead(200, { 'content-type': 'application/json', 'content-length': buf.length });
+  res.end(buf);
+});
+await new Promise((r) => mock.listen(0, '127.0.0.1', r));
+const deadPort = await freePort();
+process.env.COMPILER_URL = `http://127.0.0.1:${deadPort}`;
+
+const { default: Fastify } = await import('fastify');
+const { initDb, closeDb } = await import('../src/db/index.ts');
+const { registerRoutes } = await import('../src/routes.ts');
+const { config } = await import('../src/config.ts');
+
+await initDb();
+const app = Fastify({ logger: false });
+await registerRoutes(app);
+await app.ready();
+const info = async () => (await app.inject({ method: 'GET', url: '/api/compiler' })).json();
+
+try {
+  const health = await (await fetch(`http://127.0.0.1:${compilerPort}/health`)).json();
+  eq(health.ok, true, 'real compiler answers /health');
+  eq(health.texlive.scheme, 'medium', 'scheme comes from the file the Dockerfile writes');
+  check(/^(20\d\d|unknown)$/.test(health.texlive.release), `release is a year or "unknown": ${health.texlive.release}`);
+
+  // unreachable compiler: honest, not an error
+  let r = await info();
+  eq(r, { ok: false, texlive: { release: 'unknown', scheme: 'unknown' } }, 'unreachable compiler reports ok:false with unknowns');
+
+  // a compiler without the report, after the retry window
+  config.compilerUrl = `http://127.0.0.1:${mock.address().port}`;
+  await new Promise((res) => setTimeout(res, 5_200));
+  r = await info();
+  eq(r, { ok: true, texlive: { release: 'unknown', scheme: 'unknown' } }, 'a /health without texlive maps to unknown');
+  eq(mockHits, 1, 'one probe');
+  await info();
+  await info();
+  eq(mockHits, 1, 'a good answer is cached: two more calls, no more probes');
+
+  // the cache holds even when the compiler goes away
+  config.compilerUrl = `http://127.0.0.1:${deadPort}`;
+  eq((await info()).ok, true, 'cached answer survives the compiler going away');
+
+  // fresh process view of the real compiler through the app: exercised via a
+  // direct probe above; here only the shape contract matters.
+  const real = await (await fetch(`http://127.0.0.1:${compilerPort}/health`)).json();
+  eq(Object.keys(real.texlive).sort(), ['release', 'scheme'], 'health carries exactly release and scheme');
+
+  console.log('compiler info: all checks passed');
+} finally {
+  child.kill();
+  mock.close();
+  await app.close();
+  await closeDb();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+process.exit(0);

--- a/apps/server/test/detect.test.mjs
+++ b/apps/server/test/detect.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * Engine detection on import: latexmkrc settings in latexmk's own precedence,
+ * magic comments, the packages that need XeLaTeX or LuaLaTeX, and the
+ * Latin-1 transcode that keeps an inputenc'd file compiling.
+ */
+import { check, eq } from './assert.mjs';
+
+const { detectEngine, engineFromLatexmkrc, engineFromSource, decodeText } = await import('../src/detect.ts');
+
+const B = (s) => Buffer.from(s);
+const doc = (preamble = '') => `\\documentclass{article}\n${preamble}\\begin{document}\nHello\n\\end{document}\n`;
+
+// ---- latexmkrc ----
+eq(engineFromLatexmkrc('$pdf_mode = 4;'), 'xelatex', '$pdf_mode 4');
+eq(engineFromLatexmkrc('$pdf_mode = 5;'), 'lualatex', '$pdf_mode 5');
+eq(engineFromLatexmkrc('$pdf_mode = 1;'), 'pdf', '$pdf_mode 1 is an explicit pdflatex');
+eq(engineFromLatexmkrc('$pdf_mode = "4";'), 'xelatex', 'quoted value');
+eq(engineFromLatexmkrc("$pdflatex = 'xelatex -synctex=1 %O %S';"), 'xelatex', 'pre-4.51 idiom: $pdflatex names xelatex');
+eq(engineFromLatexmkrc("$pdflatex = 'lualatex %O %S';"), 'lualatex', '$pdflatex names lualatex');
+eq(engineFromLatexmkrc("$pdflatex = '/usr/bin/xelatex %O %S';"), 'xelatex', 'absolute command path');
+eq(engineFromLatexmkrc("$pdflatex = 'pdflatex -shell-escape %O %S';"), null, '$pdflatex naming pdflatex only passes flags: no choice');
+eq(engineFromLatexmkrc("$xelatex = 'xelatex -interaction=nonstopmode %O %S';"), 'xelatex', 'a bare $xelatex assignment is the last hint');
+eq(engineFromLatexmkrc("$lualatex = 'lualatex %O %S';"), 'lualatex', 'a bare $lualatex assignment');
+eq(engineFromLatexmkrc("$pdf_mode = 5;\n$xelatex = 'xelatex %O %S';"), 'lualatex', '$pdf_mode wins over a command assignment');
+const allThree = "$pdflatex = 'pdflatex -shell-escape %O %S';\n$xelatex = 'xelatex -shell-escape %O %S';\n$lualatex = 'lualatex -shell-escape %O %S';";
+eq(engineFromLatexmkrc(allThree), null, 'flags handed to all three engines choose none');
+eq(engineFromLatexmkrc("$xelatex = 'xelatex %O %S';\n$lualatex = 'lualatex %O %S';"), null, 'both bare assignments together are no hint either');
+eq(engineFromLatexmkrc("$pdf_mode = 4;\n" + allThree), 'xelatex', '$pdf_mode still decides beside all three');
+eq(engineFromLatexmkrc("$pdflatex = 'xelatex %O %S';\n$lualatex = 'lualatex %O %S';"), 'xelatex', 'a $pdflatex naming xelatex beats a bare $lualatex');
+eq(engineFromLatexmkrc('# $pdf_mode = 4;\n$bibtex_use = 2;'), null, 'commented-out setting is ignored');
+eq(engineFromLatexmkrc('$bibtex_use = 2;'), null, 'no engine setting at all');
+
+// ---- source sniffing ----
+eq(engineFromSource(doc('\\usepackage{fontspec}\n')), { engine: 'xelatex', reason: 'the fontspec package in the main document' }, 'fontspec');
+eq(engineFromSource(doc('\\usepackage[math-style=ISO]{unicode-math}\n')).engine, 'xelatex', 'unicode-math with options');
+eq(engineFromSource(doc('\\usepackage{polyglossia}\n')).engine, 'xelatex', 'polyglossia');
+eq(engineFromSource(doc('\\usepackage{xepersian}\n')).engine, 'xelatex', 'xepersian');
+eq(engineFromSource(doc('\\usepackage[RTLdocument]{bidi}\n')).engine, 'xelatex', 'bidi');
+eq(engineFromSource(doc('\\usepackage{amsmath,fontspec,graphicx}\n')).engine, 'xelatex', 'fontspec inside a package list');
+eq(engineFromSource(doc('\\usepackage{luacode}\n')), { engine: 'lualatex', reason: 'the luacode package in the main document' }, 'luacode');
+eq(engineFromSource(doc('\\usepackage{fontspec}\n\\usepackage{luacode}\n')).engine, 'lualatex', 'luacode beats fontspec: fontspec runs on both engines, luacode on one');
+eq(engineFromSource('% !TEX program = lualatex\n' + doc('\\usepackage{fontspec}\n')).engine, 'lualatex', 'magic comment wins over packages');
+eq(engineFromSource('% !TEX TS-program = xelatex\n' + doc()).engine, 'xelatex', 'TeXShop spelling');
+eq(engineFromSource('%!TEX program = pdflatex\n' + doc('\\usepackage{fontspec}\n')).engine, 'pdf', 'magic comment can pin pdflatex explicitly');
+eq(engineFromSource(doc('% \\usepackage{fontspec}\n')), null, 'commented-out package is not a hint');
+eq(engineFromSource(doc('\\usepackage{fontspecial}\n')), null, 'no partial matches');
+eq(engineFromSource(doc('\\usepackage{graphicx}\n')), null, 'plain preamble: nothing');
+eq(engineFromSource(doc('\\newcommand{\\pct}{\\%}\\usepackage{fontspec}\n')).engine, 'xelatex', 'an escaped \\% earlier on the line does not hide the package');
+eq(engineFromSource(doc('\\newcommand{\\pct}{\\%} % \\usepackage{fontspec}\n')), null, 'a real comment after an escaped \\% still hides it');
+
+// ---- archive-level precedence ----
+const files = { 'latexmkrc': B('$pdf_mode = 4;'), 'main.tex': B(doc('\\usepackage{luacode}\n')) };
+eq(detectEngine(files, 'main.tex'), { engine: 'xelatex', reason: 'latexmkrc in the archive' }, 'latexmkrc beats the package sniff');
+eq(detectEngine({ '.latexmkrc': B('$pdf_mode = 5;'), 'main.tex': B(doc()) }, 'main.tex').engine, 'lualatex', 'dotfile spelling');
+eq(detectEngine({ 'paper/latexmkrc': B('$pdf_mode = 4;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'latexmkrc beside a nested root');
+eq(detectEngine({ 'latexmkrc': B('$pdf_mode = 5;'), 'paper/latexmkrc': B('$pdf_mode = 4;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'the latexmkrc beside the root wins over the top-level one');
+eq(detectEngine({ 'latexmkrc': B('$bibtex_use = 2;'), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'silent latexmkrc falls through to the root');
+eq(detectEngine({ 'latexmkrc': B("$pdflatex = 'pdflatex -synctex=1 %O %S';"), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'a flags-only $pdflatex line does not override a root that needs XeLaTeX');
+eq(detectEngine({ 'latexmkrc': B(allThree), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'an rc that flags all three engines leaves the root to decide');
+eq(detectEngine({ 'latexmkrc': B(allThree), 'main.tex': B(doc()) }, 'main.tex'), { engine: 'pdf', reason: null }, 'and a plain root under it stays on pdflatex');
+eq(detectEngine({ 'latexmkrc': B('$pdf_mode = 1;'), 'main.tex': B(doc('\\usepackage{fontspec}\n')) }, 'main.tex'), { engine: 'pdf', reason: null }, 'explicit $pdf_mode 1 overrides the sniff, with no reason to report');
+eq(detectEngine({ 'main.tex': B(doc()) }, 'main.tex'), { engine: 'pdf', reason: null }, 'default');
+eq(detectEngine({ 'chapter.tex': B('\\usepackage{fontspec}') }, undefined), { engine: 'pdf', reason: null }, 'no root: nothing to sniff');
+eq(detectEngine({ 'main.tex': B('%'.repeat(300 * 1024) + '\n' + doc('\\usepackage{fontspec}\n')) }, 'main.tex').engine, 'pdf', 'a preamble past the scan window is not seen');
+
+// ---- decoding ----
+eq(decodeText(B('caf\u00e9')), { text: 'café', transcoded: false }, 'valid UTF-8 passes through');
+const latin1 = Buffer.from([0x63, 0x61, 0x66, 0xe9]); // "café" in Latin-1
+eq(decodeText(latin1), { text: 'café', transcoded: true }, 'Latin-1 bytes are transcoded');
+const inputenc = Buffer.concat([B('\\usepackage[latin1]{inputenc}\n\\usepackage[T1]{fontenc}\ncaf'), Buffer.from([0xe9])]);
+eq(decodeText(inputenc).text, '\\usepackage[latin1]{inputenc}\n\\usepackage[T1]{fontenc}\ncafé'.replace('[latin1]', '[utf8]'), 'a transcoded file gets its inputenc switched to utf8');
+eq(decodeText(Buffer.concat([B('\\usepackage[utf8]{inputenc} '), Buffer.from([0xe9])])).text, '\\usepackage[utf8]{inputenc} é', 'an inputenc already on utf8 is left alone');
+eq(decodeText(B('\\usepackage[latin1]{inputenc}\ncaf\u00e9')).text, '\\usepackage[latin1]{inputenc}\ncafé', 'valid UTF-8 keeps its inputenc line untouched, even a wrong one');
+check(!decodeText(B('')).transcoded, 'empty file is not a transcode');
+eq(decodeText(Buffer.from([0xef, 0xbb, 0xbf, 0x41])), { text: '\ufeffA', transcoded: false }, 'a UTF-8 BOM is kept, so a valid file round-trips byte for byte');
+const mixed = Buffer.concat([B('Z\u00fcrich und K\u00f6ln, '), Buffer.from([0xe9]), B(' fin')]);
+eq(decodeText(mixed), { text: 'Z\u00fcrich und K\u00f6ln, \ufffd fin', transcoded: false }, 'a UTF-8 file with one stray byte keeps its multibyte characters');
+const cp1252 = Buffer.concat([B('\\usepackage[ansinew]{inputenc}\nI'), Buffer.from([0x92]), B('m '), Buffer.from([0x93]), B('quoted'), Buffer.from([0x94]), B(' '), Buffer.from([0x96, 0x80])]);
+eq(decodeText(cp1252), { text: '\\usepackage[utf8]{inputenc}\nI\u2019m \u201cquoted\u201d \u2013\u20ac', transcoded: true }, 'Windows-1252 punctuation survives and inputenc follows');
+eq(decodeText(Buffer.from([0x49, 0x92, 0x6d])).text, 'I\u2019m', 'no inputenc: Windows-1252 is the default for the C1 range');
+eq(decodeText(Buffer.concat([B('\\usepackage[latin9]{inputenc} '), Buffer.from([0xa4])])).text, '\\usepackage[utf8]{inputenc} \u20ac', 'latin9 decodes its euro sign');
+eq(decodeText(Buffer.concat([B('\\usepackage[applemac]{inputenc} caf'), Buffer.from([0x8e])])).text, '\\usepackage[utf8]{inputenc} caf\u00e9', 'applemac decodes as Mac Roman');
+
+console.log('detect: all checks passed');

--- a/apps/server/test/import-route.test.mjs
+++ b/apps/server/test/import-route.test.mjs
@@ -5,6 +5,7 @@
  *  - a base64 body past the global 32 MB limit is accepted on the import route
  *  - a ZIP over the limit gets the honest size message, not a bare 413
  *  - PATCH engine rejects anything the compiler cannot run
+ *  - engine detection: latexmkrc, xepersian root, Latin-1 transcode, reported in the response
  */
 import fs from 'node:fs';
 import os from 'node:os';
@@ -92,6 +93,30 @@ try {
   res = await app.inject({ method: 'PATCH', url: `/api/projects/${id}`, payload: { name: 'Renamed' } });
   eq(res.statusCode, 200, 'PATCH without engine still works');
   eq((await store.readMeta(id)).engine, 'xelatex', 'engine untouched by a name-only patch');
+
+  // ---- engine detection on import ----
+  res = await importZip({ 'latexmkrc': '$pdf_mode = 4;\n', 'main.tex': doc });
+  eq(res.statusCode, 200, 'latexmkrc archive imports');
+  eq(res.json().engine, 'xelatex', 'engine set from latexmkrc');
+  eq(res.json().import, { engine: 'xelatex', engineReason: 'latexmkrc in the archive', transcoded: [] }, 'response says why');
+  eq((await store.readMeta(res.json().id)).engine, 'xelatex', 'engine persisted in meta');
+
+  const persian = '\\documentclass{article}\n\\usepackage{xepersian}\n\\begin{document}\nسلام\n\\end{document}\n';
+  res = await importZip({ 'main.tex': persian, 'refs.bib': '' });
+  eq(res.json().engine, 'xelatex', 'xepersian root selects XeLaTeX');
+  eq(res.json().import.engineReason, 'the xepersian package in the main document', 'reason names the package');
+
+  res = await importZip({ 'main.tex': doc });
+  eq(res.json().engine, 'pdf', 'plain archive stays on pdflatex');
+  eq(res.json().import, { engine: 'pdf', engineReason: null, transcoded: [] }, 'nothing to explain');
+
+  const latin1Doc = Buffer.concat([Buffer.from('\\documentclass{article}\n\\usepackage[latin1]{inputenc}\n\\begin{document}\ncaf'), Buffer.from([0xe9]), Buffer.from('\n\\end{document}\n')]);
+  res = await importZip({ 'main.tex': latin1Doc, 'notes.txt': 'plain ascii' });
+  eq(res.statusCode, 200, 'Latin-1 archive imports');
+  eq(res.json().import.transcoded, ['main.tex'], 'the transcoded file is named');
+  const text = store.readFile(res.json().id, 'main', 'main.tex').toString('utf8');
+  check(text.includes('café'), `file is UTF-8 on disk: ${JSON.stringify(text)}`);
+  check(text.includes('[utf8]{inputenc}'), 'inputenc switched to utf8 with the transcode');
 
   console.log('import route: all checks passed');
 } finally {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -79,6 +79,11 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 export interface TemplateInfo { id: string; name: string; description?: string; icon?: string }
+/** What /api/projects/import decided while placing the archive. */
+export interface ImportedProject extends ProjectSummary {
+  import: { engine: string; engineReason: string | null; transcoded: string[] };
+}
+export interface CompilerInfo { ok: boolean; texlive: { release: string; scheme: string } }
 
 export const api = {
   listProjects: () => req<ProjectSummary[]>('/api/projects'),
@@ -86,7 +91,8 @@ export const api = {
     req<ProjectSummary>('/api/projects', { method: 'POST', body: JSON.stringify({ name, files, template }) }),
   templates: () => req<TemplateInfo[]>('/api/templates'),
   importZip: (name: string, zipBase64: string) =>
-    req<ProjectSummary>('/api/projects/import', { method: 'POST', body: JSON.stringify({ name, zipBase64 }) }),
+    req<ImportedProject>('/api/projects/import', { method: 'POST', body: JSON.stringify({ name, zipBase64 }) }),
+  compilerInfo: () => req<CompilerInfo>('/api/compiler'),
   getProject: (id: string) => req<ProjectDetail>(`/api/projects/${id}`),
   patchProject: (id: string, patch: Partial<Pick<ProjectSummary, 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>>) =>
     req<ProjectSummary>(`/api/projects/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -236,8 +236,11 @@
 .gh-repo__badge { font-size: 10px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-3); border: 1px solid var(--hairline); border-radius: 999px; padding: 1px 7px; flex-shrink: 0; }
 .gh-repo__meta { font-size: 11.5px; color: var(--text-3); flex-shrink: 0; }
 
-.settings__row { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--hairline); font-size: 13.5px; }
+.settings__row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--hairline); font-size: 13.5px; }
 .settings__label { color: var(--text-2); }
+.settings__control { flex: 0 0 62%; width: auto; }
+.settings__control--check { display: flex; align-items: center; gap: 8px; }
+.settings__hint { color: var(--text-3); font-size: 12px; line-height: 1.3; }
 .user-chip__name { background: transparent; border: 0; padding: 0; cursor: pointer; color: var(--text); font: inherit; font-weight: 600; }
 .user-chip__name:hover { color: var(--accent); text-decoration: underline; }
 .login__oauth { width: 100%; justify-content: center; gap: 8px; height: 34px; margin-bottom: 10px; }

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -179,7 +179,7 @@ export default function FileTree({ files, active, rootFile, projectId, branch, o
 
       {menu && (
         <div className="menu" style={{ left: menu.x, top: menu.y, position: 'fixed' }} onClick={(e) => e.stopPropagation()}>
-          <button className="menu__item" onClick={() => { onSetRoot(menu.path); setMenu(null); }}>Set as typeset root</button>
+          <button className="menu__item" onClick={() => { onSetRoot(menu.path); setMenu(null); }}>Set as main document</button>
           <button className="menu__item" onClick={() => {
             const to = window.prompt('Rename to', menu.path);
             if (to && to !== menu.path) onRename(menu.path, to);

--- a/apps/web/src/components/ProjectSettings.tsx
+++ b/apps/web/src/components/ProjectSettings.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react';
+import { api, CompilerInfo, ProjectSummary, TreeEntry } from '../api';
+import Modal from './Modal';
+import { ENGINES, texliveLabel } from '../util/engines';
+
+interface Props {
+  project: Pick<ProjectSummary, 'id' | 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>;
+  files: TreeEntry[];
+  /** The auto-typeset switch lives in localStorage, not in the project. */
+  autoTypeset: boolean;
+  /** Shown under the compiler picker right after an import: where the choice came from. */
+  importNote?: string;
+  onClose(): void;
+  onRename(name: string): Promise<void>;
+  onSetRoot(path: string): Promise<void>;
+  onSetEngine(engine: string): Promise<void>;
+  onSetStopOnFirstError(on: boolean): Promise<void>;
+  onToggleAutoTypeset(): void;
+}
+
+/**
+ * The permanent home of the project's compile options (the preview header's
+ * engine picker and the log dialog's stop-on-error box are shortcuts to the
+ * same state). Every change saves on its own; there is no Save button.
+ */
+export default function ProjectSettings({ project, files, autoTypeset, importNote, onClose, onRename, onSetRoot, onSetEngine, onSetStopOnFirstError, onToggleAutoTypeset }: Props) {
+  const [name, setName] = useState(project.name);
+  const [compiler, setCompiler] = useState<CompilerInfo | null>(null);
+  useEffect(() => {
+    let live = true;
+    api.compilerInfo()
+      .then((info) => { if (live) setCompiler(info); })
+      .catch(() => { if (live) setCompiler({ ok: false, texlive: { release: 'unknown', scheme: 'unknown' } }); });
+    return () => { live = false; };
+  }, []);
+
+  const texFiles = files.filter((f) => f.type === 'file' && /\.tex$/i.test(f.path)).map((f) => f.path);
+  // A root that is not in the tree (deleted on this branch, or not a .tex
+  // file) must still be selectable, or the select would show the wrong file.
+  const rootOptions = texFiles.includes(project.rootFile) ? texFiles : [project.rootFile, ...texFiles];
+  const engine = ENGINES.some((e) => e.id === project.engine) ? project.engine : 'pdf';
+
+  // Escape unmounts the dialog without a blur, so the close path commits too;
+  // the ref keeps blur-then-close from sending the same rename twice.
+  const committed = useRef(project.name);
+  const commitName = () => {
+    const next = name.trim();
+    if (!next || next === committed.current) { setName(committed.current); return; }
+    committed.current = next;
+    onRename(next).catch(() => { committed.current = project.name; setName(project.name); });
+  };
+  const close = () => { commitName(); onClose(); };
+
+  return (
+    <Modal onClose={close} label="Project settings" testId="project-settings" width={520}>
+      <div>
+        <h2>Project settings</h2>
+        <p className="modal__sub">Changes save as you make them.</p>
+
+        <div className="settings__row">
+          <label className="settings__label" htmlFor="settings-name">Name</label>
+          <input
+            id="settings-name"
+            className="input settings__control"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={commitName}
+            onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+            data-testid="settings-name"
+          />
+        </div>
+
+        <section data-testid="compiler-settings">
+          <div className="menu__label" style={{ margin: '18px 0 4px', padding: 0 }}>Compiler</div>
+
+          <div className="settings__row">
+            <label className="settings__label" htmlFor="settings-root-file">Main document</label>
+            <select
+              id="settings-root-file"
+              className="input settings__control"
+              value={project.rootFile}
+              onChange={(e) => onSetRoot(e.target.value)}
+              data-testid="settings-root-file"
+            >
+              {rootOptions.map((p) => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+
+          <div className="settings__row">
+            <label className="settings__label" htmlFor="settings-engine">Compiler</label>
+            <select
+              id="settings-engine"
+              className="input settings__control"
+              value={engine}
+              onChange={(e) => onSetEngine(e.target.value)}
+              data-testid="settings-engine"
+            >
+              {ENGINES.map((e) => <option key={e.id} value={e.id}>{e.label}</option>)}
+            </select>
+          </div>
+          {importNote && (
+            <div className="settings__row">
+              <span className="settings__label" />
+              <span className="settings__hint" data-testid="settings-engine-note">{importNote}</span>
+            </div>
+          )}
+
+          <div className="settings__row">
+            <span className="settings__label">TeX Live</span>
+            <span data-testid="settings-texlive" title="Release and scheme of the compiler this server talks to">{texliveLabel(compiler)}</span>
+          </div>
+
+          <div className="settings__row">
+            <label className="settings__label" htmlFor="settings-stop-on-error">Stop on first error</label>
+            <span className="settings__control settings__control--check">
+              <input
+                id="settings-stop-on-error"
+                type="checkbox"
+                checked={!!project.stopOnFirstError}
+                onChange={(e) => onSetStopOnFirstError(e.target.checked)}
+                data-testid="settings-stop-on-error"
+              />
+              <span className="settings__hint">{project.stopOnFirstError ? 'The run stops at the first error and keeps the previous PDF' : 'The run continues to the end and lists the errors beside the PDF'}</span>
+            </span>
+          </div>
+
+          <div className="settings__row">
+            <label className="settings__label" htmlFor="settings-auto-typeset">Auto-typeset</label>
+            <span className="settings__control settings__control--check">
+              <input
+                id="settings-auto-typeset"
+                type="checkbox"
+                checked={autoTypeset}
+                onChange={onToggleAutoTypeset}
+                data-testid="settings-auto-typeset"
+              />
+              <span className="settings__hint">{autoTypeset ? 'Typesets shortly after you stop typing, on this browser' : 'Typeset by hand only, on this browser'}</span>
+            </span>
+          </div>
+        </section>
+
+        <div className="modal__row">
+          <button className="btn" onClick={close} data-testid="settings-close">Close</button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { api, ApiError, CompileResult, ProjectDetail, TreeEntry, Comment, localUser } from '../api';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { api, ApiError, CompileResult, ImportedProject, ProjectDetail, TreeEntry, Comment, localUser } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
 import ShareModal from '../components/ShareModal';
@@ -25,15 +25,10 @@ import Modal from '../components/Modal';
 import FormatToolbar from '../components/FormatToolbar';
 import { toggleTheme } from '../theme';
 import { shortcut } from '../platform';
+import ProjectSettings from '../components/ProjectSettings';
+import { ENGINES } from '../util/engines';
 
 type CompileStatus = 'idle' | 'compiling' | 'ok' | 'error';
-
-/** The engines the server accepts (PATCH rejects anything else with 400). */
-const ENGINES: Array<{ id: string; label: string }> = [
-  { id: 'pdf', label: 'pdfLaTeX' },
-  { id: 'xelatex', label: 'XeLaTeX' },
-  { id: 'lualatex', label: 'LuaLaTeX' },
-];
 
 /** A text field that is not the code editor (whose own keymap owns Mod-j). */
 function inTextField(target: EventTarget | null): boolean {
@@ -48,6 +43,9 @@ export default function Editor() {
   const [params, setParams] = useSearchParams();
   const branch = params.get('branch') || 'main';
   const navigate = useNavigate();
+  // Home hands the import result over in history state so the settings
+  // panel can say where the compiler choice came from.
+  const imported = (useLocation().state as { import?: ImportedProject['import'] } | null)?.import;
   const toast = useToast();
 
   const [project, setProject] = useState<ProjectDetail | null>(null);
@@ -79,6 +77,7 @@ export default function Editor() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const { authEnabled } = useAuth();
   const [spellcheck, setSpellcheck] = useState(() => localStorage.getItem('aldine.spellcheck') === '1');
@@ -223,18 +222,33 @@ export default function Editor() {
     setCompile({ status: 'idle', result: null });
   };
 
-  const renameProject = async (el: HTMLElement, name: string) => {
-    if (!project || !name.trim() || name === project.name) return;
+  const saveName = useCallback(async (name: string) => {
     try {
       const p = await api.patchProject(id, { name: name.trim() });
       setProject((prev) => (prev ? { ...prev, name: p.name } : prev));
     } catch (err: any) {
-      // The name lives in a contentEditable React doesn't control, so a
-      // rejected rename would otherwise leave the refused text on screen.
-      el.textContent = project.name;
       toast(`Could not rename: ${err.message}`, 'error');
+      throw err;
     }
+  }, [id, toast]);
+
+  const renameProject = async (el: HTMLElement, name: string) => {
+    if (!project || !name.trim() || name === project.name) return;
+    // The name lives in a contentEditable React doesn't control, so a
+    // rejected rename would otherwise leave the refused text on screen.
+    await saveName(name).catch(() => { el.textContent = project.name; });
   };
+
+  const setRootFile = useCallback(async (path: string) => {
+    if (!project || path === project.rootFile) return;
+    try {
+      await api.patchProject(id, { rootFile: path });
+      await loadProject();
+      toast(`Main document is now ${path}`, 'ok');
+    } catch (err: any) {
+      toast(`Could not change the main document: ${err.message}`, 'error');
+    }
+  }, [id, project, loadProject, toast]);
 
   const setStopOnFirstError = useCallback(async (on: boolean) => {
     if (!project || on === !!project.stopOnFirstError) return;
@@ -445,6 +459,7 @@ export default function Editor() {
       { id: 'stop-on-error', group: 'Action', title: project?.stopOnFirstError ? 'Stop on first error: on' : 'Stop on first error: off', run: () => setStopOnFirstError(!project?.stopOnFirstError) },
       { id: 'spell', group: 'Action', title: spellcheck ? 'Turn spellcheck off' : 'Turn spellcheck on', run: () => setSpellcheck((s) => { localStorage.setItem('aldine.spellcheck', s ? '0' : '1'); return !s; }) },
       { id: 'theme', group: 'View', title: 'Toggle light/dark theme', run: () => { toggleTheme(); } },
+      { id: 'settings', group: 'View', title: 'Project settings: compiler, main document, TeX Live', run: () => setSettingsOpen(true) },
       { id: 'about', group: 'View', title: 'About Aldine and its source code', run: () => setAboutOpen(true) },
       ...(visualEnabled
         ? [{ id: 'mode', group: 'View', title: mode === 'visual' ? 'Switch to Source editing' : 'Switch to Visual editing', run: () => switchMode(mode === 'visual' ? 'source' : 'visual') }]
@@ -546,6 +561,7 @@ export default function Editor() {
         {authEnabled && project.isOwner && (
           <button className="btn" onClick={() => setShareOpen(true)} data-testid="share-project" title="Invite collaborators or share by link">Share</button>
         )}
+        <button className="btn" onClick={() => setSettingsOpen(true)} data-testid="project-settings-open" title="Project settings: compiler, main document, TeX Live">Settings</button>
         <button className="btn" onClick={startComment} data-testid="add-comment" title="Comment on the selected text">Comment</button>
         <Presence users={users} />
         <div className="toolbar__group">
@@ -618,11 +634,7 @@ export default function Editor() {
                     toast(/already exists/i.test(err?.message) ? `"${to}" already exists` : `Could not rename: ${err.message}`, 'error');
                   }
                 }}
-                onSetRoot={async (path) => {
-                  await api.patchProject(id, { rootFile: path });
-                  await loadProject();
-                  toast(`Typeset root is now ${path}`, 'ok');
-                }}
+                onSetRoot={setRootFile}
               />
             )}
             {tab === 'history' && <HistoryPanel projectId={id} branch={branch} />}
@@ -849,6 +861,21 @@ export default function Editor() {
       )}
 
       {aboutOpen && <About onClose={() => setAboutOpen(false)} />}
+
+      {settingsOpen && (
+        <ProjectSettings
+          project={project}
+          files={files}
+          autoTypeset={auto}
+          importNote={imported && imported.engineReason && imported.engine === project.engine ? `Set on import because of ${imported.engineReason}` : undefined}
+          onClose={() => setSettingsOpen(false)}
+          onRename={saveName}
+          onSetRoot={setRootFile}
+          onSetEngine={setEngine}
+          onSetStopOnFirstError={setStopOnFirstError}
+          onToggleAutoTypeset={toggleAuto}
+        />
+      )}
 
       {shareOpen && (
         <ShareModal

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import Onboarding from '../components/Onboarding';
 import About from '../components/About';
 import { friendlyDate } from '../util/dates';
 import { pickTemplate, templateToPost } from '../util/templates';
+import { importSummary } from '../util/engines';
 
 /** Mirrors IMPORT_MAX_ZIP_BYTES in apps/server/src/routes.ts — the server
  *  enforces it; this pre-flight only spares the upload. */
@@ -80,7 +81,8 @@ export default function Home() {
       let bin = '';
       for (let i = 0; i < buf.length; i += 0x8000) bin += String.fromCharCode(...buf.subarray(i, i + 0x8000));
       const p = await api.importZip(file.name.replace(/\.zip$/i, ''), btoa(bin));
-      navigate(`/p/${p.id}`);
+      toast(importSummary(p), 'ok');
+      navigate(`/p/${p.id}`, { state: { import: p.import } });
     } catch (err: any) {
       // A 413 without the route's own text comes from a proxy or body limit
       // below what the app allows — the size is the only number worth stating.

--- a/apps/web/src/util/__tests__/engines.test.ts
+++ b/apps/web/src/util/__tests__/engines.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { engineLabel, importSummary, texliveLabel } from '../engines';
+
+describe('texliveLabel', () => {
+  it('shows release and scheme from a current compiler', () => {
+    expect(texliveLabel({ ok: true, texlive: { release: '2026', scheme: 'full' } })).toBe('2026, full');
+  });
+  it('is honest about a compiler that predates the report', () => {
+    expect(texliveLabel({ ok: true, texlive: { release: 'unknown', scheme: 'unknown' } })).toBe('Not reported by this compiler');
+  });
+  it('shows what it has when only one half is known', () => {
+    expect(texliveLabel({ ok: true, texlive: { release: '2026', scheme: 'unknown' } })).toBe('2026');
+    expect(texliveLabel({ ok: true, texlive: { release: 'unknown', scheme: 'medium' } })).toBe('unknown release, medium');
+  });
+  it('distinguishes unreachable from not yet loaded', () => {
+    expect(texliveLabel({ ok: false, texlive: { release: 'unknown', scheme: 'unknown' } })).toBe('Compiler not reachable');
+    expect(texliveLabel(null)).toBe('Checking the compiler');
+  });
+});
+
+describe('importSummary', () => {
+  it('names the detected engine and its source', () => {
+    expect(importSummary({ name: 'thesis', import: { engine: 'xelatex', engineReason: 'latexmkrc in the archive', transcoded: [] } }))
+      .toBe('Imported thesis: XeLaTeX (latexmkrc in the archive)');
+  });
+  it('states the default when nothing asked for another engine', () => {
+    expect(importSummary({ name: 'notes', import: { engine: 'pdf', engineReason: null, transcoded: [] } }))
+      .toBe('Imported notes: pdfLaTeX');
+  });
+  it('names transcoded files without guessing their encoding', () => {
+    expect(importSummary({ name: 'old', import: { engine: 'pdf', engineReason: null, transcoded: ['main.tex'] } }))
+      .toBe('Imported old: pdfLaTeX. main.tex was not UTF-8 and has been transcoded');
+    expect(importSummary({ name: 'old', import: { engine: 'pdf', engineReason: null, transcoded: ['a.tex', 'b.tex'] } }))
+      .toContain('2 files were not UTF-8 and have been transcoded');
+  });
+  it('falls back to the id for an engine it does not know', () => {
+    expect(engineLabel('tectonic')).toBe('tectonic');
+  });
+});

--- a/apps/web/src/util/engines.ts
+++ b/apps/web/src/util/engines.ts
@@ -1,0 +1,38 @@
+import type { CompilerInfo, ImportedProject } from '../api';
+
+/** The engines the server accepts (PATCH rejects anything else with 400). */
+export const ENGINES: Array<{ id: string; label: string }> = [
+  { id: 'pdf', label: 'pdfLaTeX' },
+  { id: 'xelatex', label: 'XeLaTeX' },
+  { id: 'lualatex', label: 'LuaLaTeX' },
+];
+
+export function engineLabel(id: string): string {
+  return ENGINES.find((e) => e.id === id)?.label ?? id;
+}
+
+/** "2026, full" for the settings panel; honest wording when the compiler
+ *  is older than the report or not reachable at all. */
+export function texliveLabel(info: CompilerInfo | null): string {
+  if (!info) return 'Checking the compiler';
+  if (!info.ok) return 'Compiler not reachable';
+  const { release, scheme } = info.texlive;
+  if (release === 'unknown' && scheme === 'unknown') return 'Not reported by this compiler';
+  if (scheme === 'unknown') return release;
+  if (release === 'unknown') return `unknown release, ${scheme}`;
+  return `${release}, ${scheme}`;
+}
+
+/** The import toast: which compiler the project got and, briefly, why, plus
+ *  any files transcoded to UTF-8. The server names only the files, not the
+ *  encoding each was read as (Windows-1252, Latin-9 or Mac Roman), so the
+ *  wording stays neutral. It lives a few seconds under the loading editor,
+ *  so the settings panel repeats the reason at length. */
+export function importSummary(p: Pick<ImportedProject, 'name' | 'import'>): string {
+  const { engine, engineReason, transcoded } = p.import;
+  const compiler = engineReason ? `${engineLabel(engine)} (${engineReason})` : engineLabel(engine);
+  const enc = transcoded.length === 0 ? '' : transcoded.length === 1
+    ? `. ${transcoded[0]} was not UTF-8 and has been transcoded`
+    : `. ${transcoded.length} files were not UTF-8 and have been transcoded`;
+  return `Imported ${p.name}: ${compiler}${enc}`;
+}

--- a/e2e/fixtures/import-latexmkrc/latexmkrc
+++ b/e2e/fixtures/import-latexmkrc/latexmkrc
@@ -1,0 +1,3 @@
+# Overleaf-style build settings: $pdf_mode 4 selects XeLaTeX.
+$pdf_mode = 4;
+$bibtex_use = 2;

--- a/e2e/fixtures/import-latexmkrc/main.tex
+++ b/e2e/fixtures/import-latexmkrc/main.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\title{Built by latexmkrc}
+\begin{document}
+\maketitle
+LATEXMKRC-BODY: this document names no engine itself; the latexmkrc beside it asks for XeLaTeX.
+\end{document}

--- a/e2e/fixtures/import-xepersian/main.tex
+++ b/e2e/fixtures/import-xepersian/main.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{xepersian}
+\settextfont{Amiri}
+\begin{document}
+\section{مقدمه}
+این یک سند فارسی است که فقط با زی‌لاتک قابل تایپ است.
+\end{document}

--- a/e2e/tests/27-compiler-settings.spec.ts
+++ b/e2e/tests/27-compiler-settings.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '../fixtures';
+import { createProject, openProject, cleanup, buildZip, expectTypesetOk } from './helpers';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+const FIXTURES = path.resolve(__dirname, '..', 'fixtures');
+
+async function meta(request: import('@playwright/test').APIRequestContext, id: string) {
+  return (await request.get(`/api/projects/${id}`)).json();
+}
+
+/** Zip a fixture directory (flat, text files) into a temp file for the import input. */
+function zipFixture(name: string, extra: Record<string, Buffer | string> = {}): { dir: string; file: string; stem: string } {
+  const src = path.join(FIXTURES, name);
+  const entries: Record<string, Buffer | string> = { ...extra };
+  for (const f of fs.readdirSync(src)) entries[f] = fs.readFileSync(path.join(src, f));
+  const stem = `${name}-${Date.now()}`;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-engine-'));
+  const file = path.join(dir, `${stem}.zip`);
+  fs.writeFileSync(file, buildZip(entries));
+  return { dir, file, stem };
+}
+
+/** Import through the Home input and assert the import toast (it lives 3.4 s,
+ *  so it is checked before the editor finishes loading), then return the id. */
+async function importFile(page: import('@playwright/test').Page, file: string, stem: string, toastText: string): Promise<string> {
+  await page.goto('/');
+  await page.getByTestId('import-input').setInputFiles(file);
+  await expect(page.locator('.toast').filter({ hasText: `Imported ${stem}` })).toContainText(toastText, { timeout: 20_000 });
+  await expect(page.getByTestId('editor-shell')).toBeVisible({ timeout: 20_000 });
+  return new URL(page.url()).pathname.split('/')[2];
+}
+
+test.describe('engine detection on import', () => {
+  test('a latexmkrc with $pdf_mode 4 selects XeLaTeX and the import typesets with it', async ({ page, request }) => {
+    const { dir, file, stem } = zipFixture('import-latexmkrc');
+    let id: string | null = null;
+    try {
+      id = await importFile(page, file, stem, 'XeLaTeX (latexmkrc in the archive)');
+      expect((await meta(request, id)).engine).toBe('xelatex');
+      await expect(page.getByTestId('engine-select')).toHaveValue('xelatex');
+      // auto-typeset is on by default: the first build runs without any click
+      await expectTypesetOk(page);
+      await page.getByTestId('view-log').click();
+      await expect(page.getByTestId('log-view')).toContainText('XeTeX');
+      await page.keyboard.press('Escape');
+      // the panel is the permanent home and agrees
+      await page.getByTestId('project-settings-open').click();
+      await expect(page.getByTestId('compiler-settings')).toBeVisible();
+      await expect(page.getByTestId('settings-engine')).toHaveValue('xelatex');
+      await expect(page.getByTestId('settings-engine-note')).toHaveText('Set on import because of latexmkrc in the archive');
+      await expect(page.getByTestId('settings-root-file')).toHaveValue('main.tex');
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a root using xepersian selects XeLaTeX', async ({ page, request }) => {
+    // BasicTeX has no xepersian; the detection is the point, not the build
+    await page.addInitScript(() => window.localStorage.setItem('aldine.autoTypeset', '0'));
+    const { dir, file, stem } = zipFixture('import-xepersian');
+    let id: string | null = null;
+    try {
+      id = await importFile(page, file, stem, 'XeLaTeX (the xepersian package in the main document)');
+      expect((await meta(request, id)).engine).toBe('xelatex');
+      await expect(page.getByTestId('engine-select')).toHaveValue('xelatex');
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a Latin-1 source is transcoded to UTF-8 and its inputenc follows', async ({ page, request }) => {
+    await page.addInitScript(() => window.localStorage.setItem('aldine.autoTypeset', '0'));
+    const latin1 = Buffer.concat([
+      Buffer.from('\\documentclass{article}\n\\usepackage[latin1]{inputenc}\n\\begin{document}\nLATIN1-BODY caf'),
+      Buffer.from([0xe9]),
+      Buffer.from('\n\\end{document}\n'),
+    ]);
+    const stem = `latin1-${Date.now()}`;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-latin1-'));
+    const file = path.join(dir, `${stem}.zip`);
+    fs.writeFileSync(file, buildZip({ 'main.tex': latin1 }));
+    let id: string | null = null;
+    try {
+      id = await importFile(page, file, stem, 'main.tex was not UTF-8 and has been transcoded');
+      await expect(page.locator('.cm-content')).toContainText('LATIN1-BODY café');
+      await expect(page.locator('.cm-content')).toContainText('[utf8]{inputenc}');
+      expect((await meta(request, id)).engine).toBe('pdf');
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+test.describe('compiler settings panel', () => {
+  test('every compile option lives in the panel and persists', async ({ page, request }) => {
+    await page.addInitScript(() => window.localStorage.setItem('aldine.autoTypeset', '0'));
+    const id = await createProject(request, 'Compiler Settings');
+    try {
+      const doc = '\\documentclass{article}\\begin{document}Second root\\end{document}\n';
+      expect((await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'other.tex', content: doc } })).ok()).toBeTruthy();
+      await openProject(page, id);
+
+      await page.getByTestId('project-settings-open').click();
+      const panel = page.getByTestId('compiler-settings');
+      await expect(panel).toBeVisible();
+      await expect(page.getByTestId('settings-texlive')).not.toHaveText('Checking the compiler');
+      const texlive = (await page.getByTestId('settings-texlive').textContent()) || '';
+      // a current compiler image says "2026, full"; the local script says what it can
+      expect(texlive).toMatch(/^(20\d\d, (full|medium)|20\d\d|Not reported by this compiler)$/);
+
+      await page.getByTestId('settings-engine').selectOption('lualatex');
+      await expect.poll(async () => (await meta(request, id)).engine).toBe('lualatex');
+      await expect(page.getByTestId('engine-select')).toHaveValue('lualatex');
+
+      await page.getByTestId('settings-stop-on-error').check();
+      await expect.poll(async () => (await meta(request, id)).stopOnFirstError).toBe(true);
+      await expect(page.locator('.toast').filter({ hasText: 'stops at the first error' })).toBeVisible();
+
+      await expect(page.getByTestId('settings-auto-typeset')).not.toBeChecked();
+      await page.getByTestId('settings-auto-typeset').check();
+      await expect.poll(() => page.evaluate(() => window.localStorage.getItem('aldine.autoTypeset'))).toBe('1');
+      await expect(page.getByTestId('auto-toggle')).toHaveClass(/auto-toggle--on/);
+
+      await page.getByTestId('settings-root-file').selectOption('other.tex');
+      await expect.poll(async () => (await meta(request, id)).rootFile).toBe('other.tex');
+      await expect(page.locator('.toast').filter({ hasText: 'Main document is now other.tex' })).toBeVisible();
+
+      await page.getByTestId('settings-name').fill('Renamed via settings');
+      await page.getByTestId('settings-name').press('Enter');
+      await expect.poll(async () => (await meta(request, id)).name).toBe('Renamed via settings');
+      await expect(page.getByTestId('project-name')).toHaveText('Renamed via settings');
+
+      // Escape closes the dialog without a blur: the typed name must still land
+      await page.getByTestId('settings-name').fill('Renamed on Escape');
+      await page.keyboard.press('Escape');
+      await expect(page.getByTestId('project-settings')).toHaveCount(0);
+      await expect.poll(async () => (await meta(request, id)).name).toBe('Renamed on Escape');
+      await expect(page.getByTestId('project-name')).toHaveText('Renamed on Escape');
+
+      await page.getByTestId('project-settings-open').click();
+      await page.getByTestId('settings-close').click();
+      await expect(page.getByTestId('project-settings')).toHaveCount(0);
+
+      // the project options are meta and survive a reload; auto-typeset is
+      // browser state, and the init script above turns it off again on reload
+      await page.reload();
+      await expect(page.getByTestId('editor-shell')).toBeVisible();
+      await page.keyboard.press(`${mod}+k`);
+      await page.getByTestId('palette-input').fill('Project settings');
+      await page.getByTestId('palette-item-settings').click();
+      await expect(page.getByTestId('settings-engine')).toHaveValue('lualatex');
+      await expect(page.getByTestId('settings-stop-on-error')).toBeChecked();
+      await expect(page.getByTestId('settings-auto-typeset')).not.toBeChecked();
+      await expect(page.getByTestId('settings-root-file')).toHaveValue('other.tex');
+    } finally { await cleanup(request, id); }
+  });
+
+  test('GET /api/compiler reports the connected compiler', async ({ request }) => {
+    const res = await request.get('/api/compiler');
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.texlive.release).toMatch(/^(20\d\d|unknown)$/);
+    expect(body.texlive.scheme).toMatch(/^(full|medium|unknown)$/);
+  });
+});


### PR DESCRIPTION
Closes #7 (except multi-version TeX Live switching, which needs one compiler image per version and stays out of scope).

- A Compiler section in project settings: main document, engine, the TeX Live release and scheme the compiler reports at `/health`, stop on first error, auto-typeset. The preview-header engine picker stays as the shortcut.
- Importing an archive detects the engine from `latexmkrc` (`$pdf_mode`, engine commands) and from what the root file loads (fontspec, polyglossia, xepersian, bidi, luacode), transcodes non-UTF-8 sources, and the import toast names what was detected. This is what made several Overleaf exports fail to compile.
- The compiler reports its TeX Live release and scheme; the server caches it at `GET /api/compiler`.

Checks: server and web typecheck, server unit suite (new detect and compiler-info tests), web unit 21/21, e2e 27-compiler-settings 5/5, plus 01-home, 13-visual, 17-feedback-round1 green in the review pass.

Known gap: a `latexmkrc` that sets two flag-only engine commands (`$pdflatex` and `$xelatex` with -shell-escape) still picks XeLaTeX instead of falling back to the root file sniff.