### PR TITLE
feat: ZIP import reads ZIP64 and names what it cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ All notable changes to Aldine are documented here. The format follows
   behind a paid tier.
 
 ### Changed
+- `POST /api/projects/import` accepts `multipart/form-data` with a `zip` file
+  part (and an optional `name` field); the web client uploads the file that
+  way, so the browser holds one copy of a 60 MB archive instead of four (file,
+  base64, JSON string, request body). The JSON `{ name, zipBase64 }` body
+  keeps working for API clients. The 60 MB limit and its message are unchanged.
 - Typesetting runs to the end of the document by default instead of stopping
   at the first error: the preview shows the complete PDF and the errors sit in
   the list beside it, like Overleaf. The old behaviour is a per-project setting,
@@ -125,6 +130,21 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- ZIP import reads ZIP64 archives (64-bit sizes and offsets, the ZIP64
+  end-of-central-directory record), so exports from tools that write ZIP64
+  headers no longer fail as "not a zip file" or import partially. An entry
+  compressed with anything but store or deflate (bzip2, LZMA, zstd, ...) or a
+  password-protected entry (ZipCrypto or AES) is now refused with a message
+  that names the entry and the method, instead of being skipped silently or
+  imported as garbage. Entry names without the UTF-8 flag are decoded as UTF-8
+  when valid, otherwise from the Info-ZIP unicode path field, cp437 or Latin-1,
+  so Windows and 7-Zip archives keep their accented file names.
+- Every failed ZIP import writes one info-level log line (`ZIP import failed`)
+  with the reason, the archive size and its entry count, never file contents,
+  so a hosted instance can be debugged without asking the user for the file.
+  The server now logs at `info` by default (per-request access lines stay off);
+  `LOG_LEVEL=warn` restores the previous quiet.
+
 - A SyncTeX jump from the PDF is refused (409, with a toast) when the preview
   on screen and the SyncTeX file on disk come from different typeset runs,
   instead of landing on the wrong line. Compile results carry a `compileId`

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/compiler-info.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify from 'fastify';
+import Fastify, { LogController } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import { WebSocketServer } from 'ws';
 import fs from 'node:fs';
@@ -27,7 +27,15 @@ initProjectEvents({ onAccessChanged: closeProjectConnections });
 // trustProxy makes req.ip honor X-Forwarded-For — enable ONLY behind a trusted
 // reverse proxy (Caddy/nginx). Off by default so clients can't spoof their IP
 // to evade rate limits or lock others out.
-const app = Fastify({ logger: { level: 'warn' }, bodyLimit: 32 * 1024 * 1024, trustProxy: process.env.TRUST_PROXY === '1' });
+// Info level so operational lines (a failed ZIP import and its reason) reach
+// the hosted instance's log; per-request access lines stay off because the
+// load balancer already keeps those. LOG_LEVEL=warn restores the old quiet.
+const app = Fastify({
+  logger: { level: process.env.LOG_LEVEL || 'info' },
+  logController: new LogController({ disableRequestLogging: true }),
+  bodyLimit: 32 * 1024 * 1024,
+  trustProxy: process.env.TRUST_PROXY === '1',
+});
 
 await initObservability(app);
 await registerRoutes(app);

--- a/apps/server/src/multipart.ts
+++ b/apps/server/src/multipart.ts
@@ -1,0 +1,47 @@
+/**
+ * multipart/form-data for a single file upload, parsed from a buffered body.
+ * The import route needs the whole ZIP in memory anyway (random access into
+ * the central directory), so buffering costs nothing extra and keeps the
+ * server free of a multipart dependency. Field bodies are returned as raw
+ * bytes; text fields are decoded as UTF-8 by the caller.
+ */
+export interface MultipartPart {
+  name: string;
+  filename?: string;
+  contentType?: string;
+  data: Buffer;
+}
+
+export function multipartBoundary(contentType: string | undefined): string | null {
+  const m = /;\s*boundary=(?:"([^"]+)"|([^;]+))/i.exec(contentType || '');
+  const b = (m?.[1] ?? m?.[2])?.trim();
+  return b || null;
+}
+
+/** RFC 7578 parts, in order; throws on a body that does not fit the framing. */
+export function parseMultipart(body: Buffer, boundary: string): MultipartPart[] {
+  const delim = Buffer.from(`--${boundary}`);
+  const parts: MultipartPart[] = [];
+  let pos = body.indexOf(delim);
+  if (pos < 0) throw new Error('multipart body has no boundary');
+  pos += delim.length;
+  for (;;) {
+    if (body[pos] === 0x2d && body[pos + 1] === 0x2d) return parts; // closing "--"
+    if (body[pos] === 0x0d && body[pos + 1] === 0x0a) pos += 2;
+    else if (body[pos] === 0x0a) pos += 1;
+    else throw new Error('multipart boundary is not followed by a line break');
+    const headerEnd = body.indexOf('\r\n\r\n', pos);
+    if (headerEnd < 0) throw new Error('multipart part has no header block');
+    const headers = body.toString('latin1', pos, headerEnd);
+    const dataStart = headerEnd + 4;
+    const next = body.indexOf(Buffer.concat([Buffer.from('\r\n'), delim]), dataStart);
+    if (next < 0) throw new Error('multipart part is not closed by a boundary');
+    const disposition = /^content-disposition:\s*(.*)$/im.exec(headers)?.[1] || '';
+    const name = /;\s*name="([^"]*)"/i.exec(disposition)?.[1];
+    if (name === undefined) throw new Error('multipart part has no field name');
+    const filename = /;\s*filename="([^"]*)"/i.exec(disposition)?.[1];
+    const contentType = /^content-type:\s*(.*)$/im.exec(headers)?.[1]?.trim();
+    parts.push({ name, filename, contentType, data: body.subarray(dataStart, next) });
+    pos = next + 2 + delim.length;
+  }
+}

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -15,9 +15,10 @@ import { listPlugins, pluginAssetPath } from './plugins.js';
 import { listTemplates, templateFiles } from './templates.js';
 import { fetchBibEntry, searchWorks } from './references.js';
 import { latexWordCount, documentFiles } from './wordcount.js';
-import { unzip } from './unzip.js';
+import { unzip, zipEntryCount, ZipError } from './unzip.js';
 import { guessRoot, detectRoot } from './root.js';
 import { detectEngine, decodeText } from './detect.js';
+import { multipartBoundary, parseMultipart } from './multipart.js';
 import { aiConfigured, aiModel, diagnose } from './ai.js';
 import * as comments from './comments.js';
 import * as auth from './auth.js';
@@ -432,32 +433,63 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // the project auth hook; it discloses nothing beyond a TeX Live release.
   app.get('/api/compiler', async () => compilerInfo());
 
-  // Import an Overleaf/project ZIP (base64) as a new project.
-  // The ZIP arrives base64-encoded inside JSON (×4/3 of the raw size), so the
-  // route needs its own body limit: the global 32 MB one would cap imports at
-  // ~24 MB while the UI promises IMPORT_MAX_ZIP_BYTES. deploy/nginx.conf's
-  // client_max_body_size must stay ≥ this figure.
+  // Import an Overleaf/project ZIP as a new project. Two body shapes: JSON
+  // { name, zipBase64 } for API clients, and multipart/form-data with a `zip`
+  // file part (what the web client sends, so the browser holds one copy of
+  // the archive instead of file + base64 + JSON string + request body).
+  // Base64 is 4/3 of the raw size, so the route needs its own body limit: the
+  // global 32 MB one would cap imports at ~24 MB while the UI promises
+  // IMPORT_MAX_ZIP_BYTES. deploy/nginx.conf's client_max_body_size must stay
+  // >= this figure.
   const importBodyLimit = Math.ceil(IMPORT_MAX_ZIP_BYTES * 4 / 3) + 1024 * 1024;
-  app.post<{ Body: { name?: string; zipBase64: string } }>('/api/projects/import', { bodyLimit: importBodyLimit }, async (req, reply) => {
-    const { name, zipBase64 } = req.body || {};
-    if (!zipBase64) return reply.code(400).send({ error: 'zipBase64 required' });
+  app.addContentTypeParser('multipart/form-data', { parseAs: 'buffer' }, (req, body: Buffer, done) => {
+    try {
+      const boundary = multipartBoundary(req.headers['content-type']);
+      if (!boundary) throw new Error('multipart/form-data without a boundary');
+      const parsed: ImportBody = {};
+      for (const part of parseMultipart(body, boundary)) {
+        if (part.filename !== undefined || part.name === 'zip') { parsed.zip = part.data; parsed.zipName = part.filename; }
+        else if (part.name === 'name') parsed.name = part.data.toString('utf8');
+      }
+      done(null, parsed);
+    } catch (err: any) {
+      done(Object.assign(err, { statusCode: 400 }), undefined);
+    }
+  });
+  type ImportBody = { name?: string; zipBase64?: string; zip?: Buffer; zipName?: string };
+  app.post<{ Body: ImportBody }>('/api/projects/import', { bodyLimit: importBodyLimit }, async (req, reply) => {
+    const body = req.body || {};
+    let buf: Buffer;
+    if (Buffer.isBuffer(body.zip)) buf = body.zip;
+    else if (typeof body.zipBase64 === 'string' && body.zipBase64) buf = Buffer.from(body.zipBase64, 'base64');
+    else return reply.code(400).send({ error: 'zipBase64 (JSON) or a zip file part (multipart/form-data) required' });
+    const name = body.name || (body.zipName ? body.zipName.replace(/\.zip$/i, '') : '') || 'Imported project';
+    // Every failure is one info line with what a self-hoster needs to debug an
+    // import without the archive: the reason, its size and entry count. Never
+    // an entry's contents.
+    let entryCount: number | null | undefined;
+    const fail = (status: number, error: string) => {
+      if (entryCount === undefined) entryCount = zipEntryCount(buf);
+      req.log.info({ import: { reason: error, zipBytes: buf.length, entries: entryCount, multipart: Buffer.isBuffer(body.zip) } }, 'ZIP import failed');
+      return reply.code(status).send({ error });
+    };
+    if (buf.length > IMPORT_MAX_ZIP_BYTES) {
+      return fail(413, `ZIP is ${mb(buf.length)} MB; the limit is ${mb(IMPORT_MAX_ZIP_BYTES)} MB`);
+    }
     let created: store.ProjectMeta | null = null;
     try {
-      const buf = Buffer.from(zipBase64, 'base64');
-      if (buf.length > IMPORT_MAX_ZIP_BYTES) {
-        return reply.code(413).send({ error: `ZIP is ${mb(buf.length)} MB; the limit is ${mb(IMPORT_MAX_ZIP_BYTES)} MB` });
-      }
       const entries = unzip(buf);
+      entryCount = Object.keys(entries).length;
       // Every entry is placed (or rejected) before the project exists, so a bad
       // path can never leave a half-imported project behind.
       const files: Record<string, Buffer> = {};
       for (const [entry, data] of Object.entries(entries)) {
         const p = importPath(entry);
-        if (p === null) return reply.code(400).send({ error: `ZIP entry "${entry}" points outside the project` });
+        if (p === null) return fail(400, `ZIP entry "${entry}" points outside the project`);
         if (p.startsWith('__MACOSX/') || isHiddenPath(p)) continue;
         files[p] = data;
       }
-      if (!Object.keys(files).length) return reply.code(400).send({ error: 'ZIP had no usable files' });
+      if (!Object.keys(files).length) return fail(400, 'ZIP had no usable files');
       // create with text files seeded; write binaries as buffers afterward
       const textFiles: Record<string, string> = {};
       const binFiles: string[] = [];
@@ -471,7 +503,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
           if (decoded.transcoded) transcoded.push(p);
         } else binFiles.push(p);
       }
-      const meta = await store.createProject(name || 'Imported project', textFiles, reqUser(req)?.id);
+      const meta = await store.createProject(name, textFiles, reqUser(req)?.id);
       created = meta;
       for (const p of binFiles) store.writeFile(meta.id, 'main', p, files[p]);
       if (binFiles.length) await gitops.commitAll(meta.id, 'main', 'aldine: import assets').catch(() => {});
@@ -485,7 +517,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       return { ...(await publicMeta(meta, reqUser(req))), import: { engine: detected.engine, engineReason: detected.reason, transcoded } };
     } catch (err: any) {
       if (created) await store.deleteProject(created.id).catch(() => {});
-      return reply.code(400).send({ error: `Could not import ZIP: ${err.message}` });
+      if (err instanceof ZipError && err.entryCount !== undefined) entryCount = err.entryCount;
+      return fail(400, `Could not import ZIP: ${err.message}`);
     }
   });
 

--- a/apps/server/src/unzip.ts
+++ b/apps/server/src/unzip.ts
@@ -1,49 +1,195 @@
 import zlib from 'node:zlib';
 
 /**
- * Minimal ZIP reader (store + deflate) — enough for Overleaf/project exports.
- * Parses the End-of-Central-Directory + central directory, then local headers.
- * Returns { path -> Buffer } for files (directories skipped).
+ * Minimal ZIP reader (store + deflate, ZIP64) for Overleaf/project exports.
+ * Parses the End-of-Central-Directory (and its ZIP64 record), the central
+ * directory, then each local header. Returns { path -> Buffer } for files
+ * (directories skipped). Anything it cannot read is an error that names the
+ * entry and the reason; no entry is ever dropped silently.
  */
 const MAX_ENTRY_BYTES = 40 * 1024 * 1024;   // 40 MB per file
 const MAX_TOTAL_BYTES = 200 * 1024 * 1024;  // 200 MB inflated total
 
+const SIG_LOCAL = 0x04034b50;
+const SIG_CENTRAL = 0x02014b50;
+const SIG_EOCD = 0x06054b50;
+const SIG_ZIP64_EOCD = 0x06064b50;
+const SIG_ZIP64_LOCATOR = 0x07064b50;
+const FLAG_ENCRYPTED = 0x1;
+const FLAG_UTF8 = 0x800;
+const METHOD_STORE = 0;
+const METHOD_DEFLATE = 8;
+const METHOD_AES = 99;
+
+/** APPNOTE 4.4.5 method ids; anything not listed is reported by number. */
+const METHOD_NAMES: Record<number, string> = {
+  1: 'shrink', 2: 'reduce', 3: 'reduce', 4: 'reduce', 5: 'reduce', 6: 'implode', 7: 'tokenize',
+  9: 'deflate64', 10: 'PKWARE DCL implode', 12: 'bzip2', 14: 'LZMA', 16: 'IBM z/OS CMPSC',
+  18: 'IBM TERSE', 19: 'IBM LZ77', 20: 'zstd', 93: 'zstd', 94: 'MP3', 95: 'xz', 96: 'JPEG',
+  97: 'WavPack', 98: 'PPMd',
+};
+
+/** cp437 (the original PC OEM set) for bytes 0x80..0xFF; 0x00..0x7F are ASCII. */
+const CP437_HIGH =
+  'ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»' +
+  '░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀' +
+  'αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■ ';
+
+export class ZipError extends Error {
+  /** Entry count from the end-of-central-directory record, when it was readable. */
+  entryCount?: number;
+  constructor(message: string, entryCount?: number) {
+    super(message);
+    this.name = 'ZipError';
+    this.entryCount = entryCount;
+  }
+}
+
+const utf8Strict = new TextDecoder('utf-8', { fatal: true });
+
+/**
+ * Entry names carry no encoding unless flag bit 11 says UTF-8. Info-ZIP on
+ * Linux/macOS writes UTF-8 without the bit, so valid UTF-8 wins; the
+ * Info-ZIP Unicode Path extra (0x7075) is trusted when its CRC matches; what
+ * is left is a legacy codepage: cp437 (Windows' OEM default, 7-Zip, older
+ * WinZip) unless every high byte lands in cp437's box-drawing/Greek range,
+ * where a Latin-1 reading (umlauts, accents) is the plausible one.
+ */
+function decodeName(raw: Buffer, flags: number, extra: Buffer): string {
+  if (flags & FLAG_UTF8) return raw.toString('utf8');
+  const unicodePath = findExtra(extra, 0x7075);
+  if (unicodePath && unicodePath.length >= 5 && unicodePath[0] === 1 && unicodePath.readUInt32LE(1) === zlib.crc32(raw)) {
+    try { return utf8Strict.decode(unicodePath.subarray(5)); } catch { /* fall through */ }
+  }
+  try { return utf8Strict.decode(raw); } catch { /* legacy codepage */ }
+  let cp437 = false;
+  for (const b of raw) if (b >= 0x80 && b < 0xb0) { cp437 = true; break; }
+  if (!cp437) return raw.toString('latin1');
+  let out = '';
+  for (const b of raw) out += b < 0x80 ? String.fromCharCode(b) : CP437_HIGH[b - 0x80];
+  return out;
+}
+
+function findExtra(extra: Buffer, id: number): Buffer | null {
+  let p = 0;
+  while (p + 4 <= extra.length) {
+    const fid = extra.readUInt16LE(p);
+    const size = extra.readUInt16LE(p + 2);
+    if (fid === id) return extra.subarray(p + 4, Math.min(p + 4 + size, extra.length));
+    p += 4 + size;
+  }
+  return null;
+}
+
+function u64(buf: Buffer, off: number, what: string): number {
+  if (off + 8 > buf.length) throw new ZipError(`${what} runs past the end of the archive`);
+  const v = buf.readBigUInt64LE(off);
+  if (v > BigInt(Number.MAX_SAFE_INTEGER)) throw new ZipError(`${what} is larger than this server can address`);
+  return Number(v);
+}
+
+interface Directory { count: number; offset: number }
+
+/** EOCD, then the ZIP64 record via its locator when the archive has one. */
+function readDirectory(buf: Buffer): Directory {
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= 0 && i > buf.length - 22 - 65536; i--) {
+    if (buf.readUInt32LE(i) === SIG_EOCD) { eocd = i; break; }
+  }
+  if (eocd < 0) throw new ZipError('not a zip file');
+  let count: number = buf.readUInt16LE(eocd + 10);
+  let offset: number = buf.readUInt32LE(eocd + 16);
+  const needZip64 = count === 0xffff || offset === 0xffffffff;
+  const loc = eocd - 20;
+  if (loc >= 0 && buf.readUInt32LE(loc) === SIG_ZIP64_LOCATOR) {
+    const recOff = u64(buf, loc + 8, 'the ZIP64 directory offset');
+    if (recOff + 56 > buf.length || buf.readUInt32LE(recOff) !== SIG_ZIP64_EOCD) {
+      throw new ZipError('the ZIP64 end of central directory record is missing or damaged');
+    }
+    count = u64(buf, recOff + 32, 'the ZIP64 entry count');
+    offset = u64(buf, recOff + 48, 'the ZIP64 directory offset');
+  } else if (needZip64) {
+    throw new ZipError('the archive needs ZIP64 but has no ZIP64 locator');
+  }
+  if (offset >= buf.length) throw new ZipError('the central directory offset is past the end of the archive');
+  return { count, offset };
+}
+
+/** Entry count from the directory record alone; null when there is none. */
+export function zipEntryCount(buf: Buffer): number | null {
+  try { return readDirectory(buf).count; } catch { return null; }
+}
+
 export function unzip(buf: Buffer): Record<string, Buffer> {
   const out: Record<string, Buffer> = {};
   let total = 0;
-  // find End of Central Directory (0x06054b50), scanning from the end
-  let eocd = -1;
-  for (let i = buf.length - 22; i >= 0 && i > buf.length - 22 - 65536; i--) {
-    if (buf.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
-  }
-  if (eocd < 0) throw new Error('not a zip file');
-  const count = buf.readUInt16LE(eocd + 10);
-  let off = buf.readUInt32LE(eocd + 16);
+  const { count, offset } = readDirectory(buf);
+  const fail = (msg: string) => new ZipError(msg, count);
+  let off = offset;
 
   for (let n = 0; n < count; n++) {
-    if (buf.readUInt32LE(off) !== 0x02014b50) break; // central dir header
+    if (off + 46 > buf.length || buf.readUInt32LE(off) !== SIG_CENTRAL) {
+      throw fail(`the central directory is damaged (entry ${n + 1} of ${count} is missing)`);
+    }
+    const flags = buf.readUInt16LE(off + 8);
     const method = buf.readUInt16LE(off + 10);
-    const compSize = buf.readUInt32LE(off + 20);
+    let compSize: number = buf.readUInt32LE(off + 20);
+    let uncompSize: number = buf.readUInt32LE(off + 24);
     const nameLen = buf.readUInt16LE(off + 28);
     const extraLen = buf.readUInt16LE(off + 30);
     const commentLen = buf.readUInt16LE(off + 32);
-    const localOff = buf.readUInt32LE(off + 42);
-    const name = buf.toString('utf8', off + 46, off + 46 + nameLen);
+    let localOff: number = buf.readUInt32LE(off + 42);
+    const rawName = buf.subarray(off + 46, off + 46 + nameLen);
+    const extra = buf.subarray(off + 46 + nameLen, off + 46 + nameLen + extraLen);
+    const name = decodeName(rawName, flags, extra);
     off += 46 + nameLen + extraLen + commentLen;
 
+    // ZIP64 extra: 64-bit values, in this order, only for the fields the
+    // 32-bit header saturated.
+    if (uncompSize === 0xffffffff || compSize === 0xffffffff || localOff === 0xffffffff) {
+      const z = findExtra(extra, 0x0001);
+      if (!z) throw fail(`entry "${name}" has ZIP64 sizes but no ZIP64 extra field`);
+      let p = 0;
+      const next = (what: string) => { const v = u64(z, p, `${what} of "${name}"`); p += 8; return v; };
+      if (uncompSize === 0xffffffff) uncompSize = next('the size');
+      if (compSize === 0xffffffff) compSize = next('the compressed size');
+      if (localOff === 0xffffffff) localOff = next('the offset');
+    }
+
     if (name.endsWith('/')) continue; // directory
-    // read the local header to find the actual data start
-    if (buf.readUInt32LE(localOff) !== 0x04034b50) continue;
+    if (flags & FLAG_ENCRYPTED || method === METHOD_AES) {
+      const scheme = method === METHOD_AES ? 'AES' : 'ZipCrypto';
+      throw fail(`entry "${name}" is password protected (${scheme}); remove the password and export the archive again`);
+    }
+    if (method !== METHOD_STORE && method !== METHOD_DEFLATE) {
+      const label = METHOD_NAMES[method] ? `${METHOD_NAMES[method]} compression (method ${method})` : `compression method ${method}`;
+      throw fail(`entry "${name}" uses ${label}; only store and deflate are supported, so re-zip the files with standard compression`);
+    }
+    // A stored entry is bounded by the archive itself; only inflation can
+    // outgrow it, so the per-file cap applies to deflate.
+    if (method === METHOD_DEFLATE && uncompSize > MAX_ENTRY_BYTES) {
+      throw fail(`entry "${name}" is ${Math.round(uncompSize / 1024 / 1024)} MB unpacked; the limit per file is ${MAX_ENTRY_BYTES / 1024 / 1024} MB`);
+    }
+    if (localOff + 30 > buf.length || buf.readUInt32LE(localOff) !== SIG_LOCAL) {
+      throw fail(`the local header of entry "${name}" is missing`);
+    }
     const lNameLen = buf.readUInt16LE(localOff + 26);
     const lExtraLen = buf.readUInt16LE(localOff + 28);
     const dataStart = localOff + 30 + lNameLen + lExtraLen;
+    if (dataStart + compSize > buf.length) throw fail(`entry "${name}" runs past the end of the archive`);
     const comp = buf.subarray(dataStart, dataStart + compSize);
     let data: Buffer;
-    if (method === 0) data = comp;
-    else if (method === 8) data = zlib.inflateRawSync(comp, { maxOutputLength: MAX_ENTRY_BYTES });
-    else continue; // unsupported method
+    if (method === METHOD_STORE) data = comp;
+    else {
+      try { data = zlib.inflateRawSync(comp, { maxOutputLength: MAX_ENTRY_BYTES }); }
+      catch (err: any) {
+        throw fail(err?.code === 'ERR_BUFFER_TOO_LARGE'
+          ? `entry "${name}" unpacks past the ${MAX_ENTRY_BYTES / 1024 / 1024} MB limit per file`
+          : `entry "${name}" has damaged deflate data`);
+      }
+    }
     total += data.length;
-    if (total > MAX_TOTAL_BYTES) throw new Error('archive expands too large');
+    if (total > MAX_TOTAL_BYTES) throw fail(`the archive unpacks past the ${MAX_TOTAL_BYTES / 1024 / 1024} MB total limit`);
     out[name] = data;
   }
   return out;

--- a/apps/server/test/import-route.test.mjs
+++ b/apps/server/test/import-route.test.mjs
@@ -4,6 +4,10 @@
  *  - a failure after the project exists (file/dir collision) → 400, cleaned up
  *  - a base64 body past the global 32 MB limit is accepted on the import route
  *  - a ZIP over the limit gets the honest size message, not a bare 413
+ *  - multipart/form-data (the web client) and JSON base64 (API clients) both
+ *    import; a 60 MB multipart body passes the route's limit
+ *  - unsupported method, encrypted entry, ZIP64 and cp437 names via the route
+ *  - every failure is one info-level log line with reason, size, entry count
  *  - PATCH engine rejects anything the compiler cannot run
  *  - engine detection: latexmkrc, xepersian root, Latin-1 transcode, reported in the response
  */
@@ -21,18 +25,35 @@ process.env.CACHE_DIR = path.join(tmp, 'cache');
 delete process.env.DATABASE_URL;
 delete process.env.REDIS_URL;
 
-const { default: Fastify } = await import('fastify');
+const { default: Fastify, LogController } = await import('fastify');
 const { initDb, closeDb } = await import('../src/db/index.ts');
 const { registerRoutes, IMPORT_MAX_ZIP_BYTES } = await import('../src/routes.ts');
 const store = await import('../src/store.ts');
 
 await initDb();
-const app = Fastify({ logger: false, bodyLimit: 32 * 1024 * 1024 });
+const logLines = [];
+const logStream = { write: (line) => { logLines.push(JSON.parse(line)); } };
+const app = Fastify({ logger: { level: 'info', stream: logStream }, logController: new LogController({ disableRequestLogging: true }), bodyLimit: 32 * 1024 * 1024 });
 await registerRoutes(app);
 await app.ready();
 
 const projectIds = async () => (await store.listProjects()).map((m) => m.id).sort();
-const importZip = (entries, name = 'T') => app.inject({ method: 'POST', url: '/api/projects/import', payload: { name, zipBase64: buildZip(entries).toString('base64') } });
+const importZip = (entries, name = 'T', opts) => app.inject({ method: 'POST', url: '/api/projects/import', payload: { name, zipBase64: buildZip(entries, opts).toString('base64') } });
+const BOUNDARY = '----aldineTestBoundary7d3';
+const multipartBody = (zip, name, filename = 'proj.zip') => Buffer.concat([
+  ...(name === undefined ? [] : [Buffer.from(`--${BOUNDARY}\r\nContent-Disposition: form-data; name="name"\r\n\r\n${name}\r\n`)]),
+  Buffer.from(`--${BOUNDARY}\r\nContent-Disposition: form-data; name="zip"; filename="${filename}"\r\nContent-Type: application/zip\r\n\r\n`),
+  zip,
+  Buffer.from(`\r\n--${BOUNDARY}--\r\n`),
+]);
+const importMultipart = (zip, name, filename) => app.inject({ method: 'POST', url: '/api/projects/import', headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` }, payload: multipartBody(zip, name, filename) });
+/** The one 'ZIP import failed' line written since the last call. */
+const lastImportLog = () => {
+  const found = logLines.filter((l) => l.msg === 'ZIP import failed');
+  logLines.length = 0;
+  eq(found.length, 1, 'exactly one import-failure log line');
+  return found[0].import;
+};
 const doc = '\\documentclass{article}\\begin{document}Hi\\end{document}\n';
 
 try {
@@ -78,6 +99,78 @@ try {
   eq(res.statusCode, 413, 'ZIP over the limit → 413');
   eq(res.json().error, 'ZIP is 60 MB; the limit is 60 MB', 'honest size message');
   eq(await projectIds(), before, 'over-limit import created nothing');
+
+  // ---- multipart: the web client's shape ----
+  logLines.length = 0;
+  res = await importMultipart(buildZip({ 'main.tex': doc, 'figs/plot.png': bin }), 'Multipart paper');
+  eq(res.statusCode, 200, `multipart import: ${res.body.slice(0, 200)}`);
+  eq(res.json().name, 'Multipart paper', 'name field read from the form');
+  eq(res.json().rootFile, 'main.tex', 'root detected on a multipart import');
+  eq(store.readFile(res.json().id, 'main', 'figs/plot.png').equals(bin), true, 'multipart binary byte-exact');
+  eq(logLines.filter((l) => l.msg === 'ZIP import failed').length, 0, 'a successful import logs no failure line');
+  res = await importMultipart(buildZip({ 'main.tex': doc }), undefined, 'thesis-final.zip');
+  eq(res.statusCode, 200, 'multipart without a name field');
+  eq(res.json().name, 'thesis-final', 'project named after the file');
+  res = await app.inject({ method: 'POST', url: '/api/projects/import', headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` }, payload: Buffer.from('garbage') });
+  eq(res.statusCode, 400, 'malformed multipart → 400');
+  res = await app.inject({ method: 'POST', url: '/api/projects/import', headers: { 'content-type': 'multipart/form-data' }, payload: Buffer.from('garbage') });
+  eq(res.statusCode, 400, 'multipart without a boundary → 400');
+  res = await app.inject({ method: 'POST', url: '/api/projects/import', payload: { name: 'x' } });
+  eq(res.statusCode, 400, 'JSON without zipBase64 → 400');
+  check(res.json().error.includes('zipBase64') && res.json().error.includes('multipart'), `error names both body shapes: ${res.json().error}`);
+  before = await projectIds();
+
+  // ---- 60 MB multipart: at the limit, accepted ----
+  const nearLimit = buildZip({ 'main.tex': doc, 'assets/blob.bin': crypto.randomBytes(IMPORT_MAX_ZIP_BYTES - 4096) });
+  check(nearLimit.length <= IMPORT_MAX_ZIP_BYTES && nearLimit.length > IMPORT_MAX_ZIP_BYTES - 4096, `fixture sits just under the limit: ${nearLimit.length}`);
+  res = await importMultipart(nearLimit, 'Sixty');
+  eq(res.statusCode, 200, `60 MB multipart import accepted: ${res.statusCode} ${res.body.slice(0, 200)}`);
+  eq(store.readFile(res.json().id, 'main', 'assets/blob.bin').length, IMPORT_MAX_ZIP_BYTES - 4096, '60 MB asset intact');
+  logLines.length = 0;
+  res = await importMultipart(buildZip({ 'main.tex': doc, 'pad.bin': Buffer.alloc(IMPORT_MAX_ZIP_BYTES) }), 'Over');
+  eq(res.statusCode, 413, 'multipart ZIP over the limit → 413');
+  eq(res.json().error, 'ZIP is 60 MB; the limit is 60 MB', 'honest size message on multipart too');
+  let logged = lastImportLog();
+  eq(logged.reason, 'ZIP is 60 MB; the limit is 60 MB', 'log line carries the reason');
+  eq(logged.multipart, true, 'log line says which body shape');
+  check(logged.zipBytes > IMPORT_MAX_ZIP_BYTES, `log line carries the zip size: ${logged.zipBytes}`);
+  eq(logged.entries, 2, 'log line carries the entry count');
+  before = await projectIds();
+
+  // ---- explicit errors through the route, each logged ----
+  logLines.length = 0;
+  res = await importZip({ 'main.tex': doc, 'figs/plot.pdf': { data: 'BZh9', method: 12 } });
+  eq(res.statusCode, 400, 'bzip2 entry → 400');
+  eq(res.json().error, 'Could not import ZIP: entry "figs/plot.pdf" uses bzip2 compression (method 12); only store and deflate are supported, so re-zip the files with standard compression', 'bzip2 message');
+  logged = lastImportLog();
+  eq(logged.entries, 2, 'entry count logged from the directory even though unzip failed');
+  eq(logged.multipart, false, 'JSON body shape logged');
+  check(!JSON.stringify(logged).includes(doc.slice(0, 20)), 'no file contents in the log');
+  res = await importZip({ 'main.tex': { data: 'x', flags: 0x1 } });
+  eq(res.statusCode, 400, 'encrypted entry → 400');
+  eq(res.json().error, 'Could not import ZIP: entry "main.tex" is password protected (ZipCrypto); remove the password and export the archive again', 'encrypted message');
+  lastImportLog();
+  res = await importZip({ 'main.tex': doc, '../evil.tex': 'x' });
+  eq(lastImportLog().reason, 'ZIP entry "../evil.tex" points outside the project', 'path escape logged with its reason');
+  res = await importZip({ '__MACOSX/._x': 'junk' });
+  eq(res.statusCode, 400, 'nothing usable → 400');
+  eq(lastImportLog().reason, 'ZIP had no usable files', 'empty import logged');
+  res = await app.inject({ method: 'POST', url: '/api/projects/import', payload: { name: 'x', zipBase64: Buffer.from('not a zip').toString('base64') } });
+  eq(res.statusCode, 400, 'not a zip → 400');
+  eq(res.json().error, 'Could not import ZIP: not a zip file', 'not-a-zip message');
+  eq(lastImportLog().entries, null, 'no directory: entry count null, still logged');
+  eq(await projectIds(), before, 'no project left behind by any rejected archive');
+
+  // ---- ZIP64 and legacy names import normally ----
+  res = await importZip({ 'paper/main.tex': doc, 'paper/refs.bib': { data: '@book{k}', method: 8 } }, 'Z64', { zip64: true });
+  eq(res.statusCode, 200, `ZIP64 archive imports: ${res.body.slice(0, 200)}`);
+  eq(res.json().rootFile, 'paper/main.tex', 'ZIP64 root detected');
+  const cp437 = Buffer.concat([Buffer.from('r'), Buffer.from([0x82]), Buffer.from('sum'), Buffer.from([0x82]), Buffer.from('.tex')]);
+  res = await importZip({ x: { data: doc, nameBytes: cp437 } }, 'CP');
+  eq(res.statusCode, 200, 'cp437 archive imports');
+  eq(res.json().rootFile, 'résumé.tex', 'cp437 name decoded before root detection');
+  eq(store.readFile(res.json().id, 'main', 'résumé.tex').toString(), doc, 'file stored under the decoded name');
+  before = await projectIds();
 
   // ---- engine validation ----
   const id = meta.id;

--- a/apps/server/test/multipart.test.mjs
+++ b/apps/server/test/multipart.test.mjs
@@ -1,0 +1,29 @@
+/** The single-file multipart parser: browser framing, quoted boundaries, binary bodies, malformed input. */
+import { check, eq, throws } from './assert.mjs';
+
+const { parseMultipart, multipartBoundary } = await import('../src/multipart.ts');
+
+eq(multipartBoundary('multipart/form-data; boundary=----WebKitFormBoundaryabc'), '----WebKitFormBoundaryabc', 'bare boundary');
+eq(multipartBoundary('multipart/form-data; charset=utf-8; boundary="a b"'), 'a b', 'quoted boundary');
+eq(multipartBoundary('application/json'), null, 'no boundary');
+
+const bin = Buffer.from([0x00, 0x0d, 0x0a, 0x2d, 0x2d, 0xff, 0x50, 0x4b]);
+const body = Buffer.concat([
+  Buffer.from('preamble\r\n--XX\r\nContent-Disposition: form-data; name="name"\r\n\r\nMy paper\r\n--XX\r\n'),
+  Buffer.from('Content-Disposition: form-data; name="zip"; filename="a.zip"\r\nContent-Type: application/zip\r\n\r\n'),
+  bin,
+  Buffer.from('\r\n--XX--\r\n'),
+]);
+const parts = parseMultipart(body, 'XX');
+eq(parts.map((p) => p.name), ['name', 'zip'], 'both parts, in order');
+eq(parts[0].data.toString(), 'My paper', 'text field bytes');
+eq(parts[1].filename, 'a.zip', 'filename');
+eq(parts[1].contentType, 'application/zip', 'content type');
+check(parts[1].data.equals(bin), 'binary body byte-exact, CRLF and -- inside the data left alone');
+
+eq(parseMultipart(Buffer.from('--XX--'), 'XX'), [], 'empty form');
+await throws(() => parseMultipart(Buffer.from('nothing'), 'XX'), 'no boundary', 'body without the boundary');
+await throws(() => parseMultipart(Buffer.from('--XX\r\nContent-Disposition: form-data; name="a"\r\n\r\nunterminated'), 'XX'), 'not closed', 'missing closing boundary');
+await throws(() => parseMultipart(Buffer.from('--XX\r\nContent-Type: text/plain\r\n\r\nx\r\n--XX--'), 'XX'), 'no field name', 'part without a name');
+
+console.log('multipart: all checks passed');

--- a/apps/server/test/unzip.test.mjs
+++ b/apps/server/test/unzip.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * The ZIP reader on archives the old one misread or skipped silently: ZIP64
+ * records and extra fields, deflate, foreign compression methods, encrypted
+ * entries, legacy-codepage names, and damaged directories. Every unsupported
+ * case is an error that names the entry; nothing is dropped.
+ */
+import { check, eq, throws } from './assert.mjs';
+import { buildZip, unicodePathExtra } from './zip.mjs';
+
+const { unzip, zipEntryCount } = await import('../src/unzip.ts');
+
+const doc = '\\documentclass{article}\\begin{document}Hi\\end{document}\n';
+const B = (s) => Buffer.from(s);
+
+// ---- store + deflate, plain archive ----
+let files = unzip(buildZip({ 'main.tex': doc, 'big.txt': { data: 'x'.repeat(100_000), method: 8 }, 'figs/': '' }));
+eq(Object.keys(files).sort(), ['big.txt', 'main.tex'], 'store and deflate entries read, directory skipped');
+eq(files['big.txt'].length, 100_000, 'deflate entry inflated');
+eq(zipEntryCount(buildZip({ 'a': '1', 'b': '2', 'c/': '' })), 3, 'entry count from the EOCD');
+eq(zipEntryCount(B('not a zip at all')), null, 'no directory: null');
+
+// ---- ZIP64 ----
+const z64 = buildZip({ 'paper/main.tex': doc, 'paper/data.csv': { data: '1,2,3\n'.repeat(1000), method: 8 } }, { zip64: true });
+check(z64.includes(Buffer.from([0x50, 0x4b, 0x06, 0x06])), 'fixture carries a ZIP64 EOCD record');
+files = unzip(z64);
+eq(Object.keys(files).sort(), ['paper/data.csv', 'paper/main.tex'], 'ZIP64 archive: entries via the ZIP64 record and extra fields');
+eq(files['paper/main.tex'].toString(), doc, 'ZIP64 entry bytes intact');
+eq(files['paper/data.csv'].length, 6000, 'ZIP64 deflate entry inflated');
+eq(zipEntryCount(z64), 2, 'entry count from the ZIP64 record');
+const noLocator = buildZip({ 'main.tex': doc });
+noLocator.writeUInt16LE(0xffff, noLocator.length - 22 + 10);
+await throws(() => unzip(noLocator), 'needs ZIP64 but has no ZIP64 locator', 'saturated count without a locator');
+const badLocator = Buffer.from(z64);
+badLocator.writeBigUInt64LE(BigInt(badLocator.length + 100), badLocator.length - 22 - 20 + 8);
+await throws(() => unzip(badLocator), 'ZIP64 end of central directory record is missing or damaged', 'locator pointing past the archive');
+
+// ---- unsupported methods: named, never skipped ----
+await throws(() => unzip(buildZip({ 'main.tex': doc, 'figs/plot.pdf': { data: 'BZh9garbage', method: 12 } })),
+  'entry "figs/plot.pdf" uses bzip2 compression (method 12); only store and deflate are supported', 'bzip2 entry');
+await throws(() => unzip(buildZip({ 'a.tex': { data: 'x', method: 14 } })), 'uses LZMA compression (method 14)', 'lzma entry');
+await throws(() => unzip(buildZip({ 'a.tex': { data: 'x', method: 77 } })), 'uses compression method 77', 'unknown method id is reported by number');
+const okThenBad = buildZip({ 'main.tex': doc, 'late.bin': { data: 'x', method: 12 } });
+await throws(() => unzip(okThenBad), 'late.bin', 'a bad entry after good ones still fails the archive');
+
+// ---- encrypted entries ----
+await throws(() => unzip(buildZip({ 'main.tex': { data: 'garbage', flags: 0x1 } })),
+  'entry "main.tex" is password protected (ZipCrypto); remove the password and export the archive again', 'ZipCrypto flag');
+await throws(() => unzip(buildZip({ 'main.tex': { data: 'garbage', flags: 0x1, method: 99 } })),
+  'entry "main.tex" is password protected (AES)', 'AES method 99');
+
+// ---- names: UTF-8 flag, UTF-8 without the flag, cp437, latin-1, unicode path extra ----
+files = unzip(buildZip({ 'Übersicht.tex': { data: doc, flags: 0x800 } }));
+eq(Object.keys(files), ['Übersicht.tex'], 'flag bit 11: UTF-8');
+files = unzip(buildZip({ 'Übersicht.tex': doc }));
+eq(Object.keys(files), ['Übersicht.tex'], 'valid UTF-8 without the flag (Info-ZIP on Linux/macOS) is UTF-8');
+const cp437 = Buffer.concat([B('r'), Buffer.from([0x82]), B('sum'), Buffer.from([0x82]), B('.tex')]); // résumé.tex in cp437
+files = unzip(buildZip({ x: { data: doc, nameBytes: cp437 } }));
+eq(Object.keys(files), ['résumé.tex'], 'cp437 name (Windows Explorer, 7-Zip)');
+const cp437Sub = Buffer.concat([B('Anh'), Buffer.from([0x84]), B('nge/Stra'), Buffer.from([0xe1]), B('e.tex')]); // Anhänge/Straße.tex
+files = unzip(buildZip({ x: { data: doc, nameBytes: cp437Sub } }));
+eq(Object.keys(files), ['Anhänge/Straße.tex'], 'cp437 with a 0x80-0xAF byte decides the whole name');
+const latin1 = Buffer.concat([B('Stra'), Buffer.from([0xdf]), B('e-'), Buffer.from([0xdc]), B('bersicht.tex')]); // Straße-Übersicht.tex
+files = unzip(buildZip({ x: { data: doc, nameBytes: latin1 } }));
+eq(Object.keys(files), ['Straße-Übersicht.tex'], 'high bytes only in cp437 box-drawing range: Latin-1');
+const raw = Buffer.from([0x82, 0x2e, 0x74, 0x65, 0x78]);
+files = unzip(buildZip({ x: { data: doc, nameBytes: raw, extra: unicodePathExtra(raw, 'é-from-extra.tex') } }));
+eq(Object.keys(files), ['é-from-extra.tex'], 'Info-ZIP unicode path extra wins when its CRC matches');
+files = unzip(buildZip({ x: { data: doc, nameBytes: raw, extra: unicodePathExtra(B('other'), 'stale.tex') } }));
+eq(Object.keys(files), ['é.tex'], 'unicode path extra with a stale CRC is ignored');
+
+// ---- damaged directories ----
+const truncated = buildZip({ 'main.tex': doc, 'b.tex': doc });
+truncated.writeUInt16LE(3, truncated.length - 22 + 10);
+await throws(() => unzip(truncated), 'central directory is damaged (entry 3 of 3 is missing)', 'count past the directory');
+const badLocal = buildZip({ 'main.tex': doc });
+badLocal.writeUInt32LE(0, 0);
+await throws(() => unzip(badLocal), 'local header of entry "main.tex" is missing', 'local header signature gone');
+const badDeflate = buildZip({ 'main.tex': { data: 'not deflate data', method: 8 } });
+// method 8 compresses in the builder; overwrite the stored bytes with junk
+const start = 30 + 'main.tex'.length;
+badDeflate.fill(0xff, start, start + 8);
+await throws(() => unzip(badDeflate), 'entry "main.tex" has damaged deflate data', 'corrupt deflate stream');
+await throws(() => unzip(B('PK\x03\x04 nothing else')), 'not a zip file', 'no EOCD');
+await throws(() => unzip(buildZip({ 'zeros.bin': { data: Buffer.alloc(41 * 1024 * 1024), method: 8 } })),
+  'entry "zeros.bin" is 41 MB unpacked; the limit per file is 40 MB', 'deflate entry past the per-file cap is refused before inflating');
+files = unzip(buildZip({ 'blob.bin': Buffer.alloc(41 * 1024 * 1024) }));
+eq(files['blob.bin'].length, 41 * 1024 * 1024, 'a stored entry has no per-file cap (bounded by the archive)');
+
+console.log('unzip: all checks passed');

--- a/apps/server/test/zip.d.mts
+++ b/apps/server/test/zip.d.mts
@@ -1,0 +1,13 @@
+export interface ZipEntry {
+  data?: Buffer | string;
+  /** 0 store (default), 8 deflate, any other id written as-is (bzip2 12, LZMA 14, AES 99). */
+  method?: number;
+  /** General-purpose bits: 0x1 encrypted, 0x800 UTF-8 name. */
+  flags?: number;
+  /** Raw name bytes in place of the key's UTF-8 (cp437 / Latin-1 names). */
+  nameBytes?: Buffer;
+  /** Extra field bytes for the central directory header. */
+  extra?: Buffer;
+}
+export function buildZip(entries: Record<string, Buffer | string | ZipEntry>, opts?: { zip64?: boolean }): Buffer;
+export function unicodePathExtra(rawName: Buffer, utf8Name: string): Buffer;

--- a/apps/server/test/zip.mjs
+++ b/apps/server/test/zip.mjs
@@ -1,50 +1,107 @@
 /**
- * Build a stored (method 0) ZIP from { name -> Buffer|string } for tests. Entry
- * names are written verbatim, so a test can put `../x` or `a\b` in an archive
- * the way a hostile or Windows-made zip would.
+ * Build a ZIP from { name -> Buffer|string|entry } for tests. Entry names are
+ * written verbatim, so a test can put `../x` or `a\b` in an archive the way a
+ * hostile or Windows-made zip would. An entry object can set:
+ *   data      Buffer|string (default '')
+ *   method    0 store (default), 8 deflate (compressed here), anything else
+ *             is written as-is with that method id (bzip2, lzma, AES 99...)
+ *   flags     general-purpose bits (0x1 encrypted, 0x800 UTF-8 name)
+ *   nameBytes raw name bytes instead of UTF-8 of the key (cp437/latin-1 names)
+ *   extra     extra field bytes for the central directory header
+ * Options: { zip64: true } writes 0xFFFFFFFF sentinels, ZIP64 extra fields,
+ * the ZIP64 end-of-central-directory record and its locator, the way an
+ * archiver does for archives past 4 GB or 65 535 entries.
  */
 import zlib from 'node:zlib';
 
-export function buildZip(entries) {
+const FFFF = 0xffffffff;
+
+export function buildZip(entries, opts = {}) {
+  const zip64 = !!opts.zip64;
   const locals = [];
   const centrals = [];
   let offset = 0;
-  for (const [name, raw] of Object.entries(entries)) {
-    const data = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
-    const nameBuf = Buffer.from(name, 'utf8');
-    const crc = zlib.crc32 ? zlib.crc32(data) : 0;
+  for (const [key, spec] of Object.entries(entries)) {
+    const e = Buffer.isBuffer(spec) || typeof spec === 'string' ? { data: spec } : spec;
+    const data = Buffer.isBuffer(e.data) ? e.data : Buffer.from(e.data ?? '');
+    const method = e.method ?? 0;
+    const flags = e.flags ?? 0;
+    const nameBuf = e.nameBytes ?? Buffer.from(key, 'utf8');
+    const comp = method === 8 ? zlib.deflateRawSync(data) : data;
+    const crc = zlib.crc32(data);
+    const localExtra = zip64 ? zip64Extra([data.length, comp.length]) : Buffer.alloc(0);
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);
-    local.writeUInt16LE(20, 4);
-    local.writeUInt16LE(0, 6);
-    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(zip64 ? 45 : 20, 4);
+    local.writeUInt16LE(flags, 6);
+    local.writeUInt16LE(method, 8);
     local.writeUInt32LE(crc, 14);
-    local.writeUInt32LE(data.length, 18);
-    local.writeUInt32LE(data.length, 22);
+    local.writeUInt32LE(zip64 ? FFFF : comp.length, 18);
+    local.writeUInt32LE(zip64 ? FFFF : data.length, 22);
     local.writeUInt16LE(nameBuf.length, 26);
-    local.writeUInt16LE(0, 28);
+    local.writeUInt16LE(localExtra.length, 28);
+    const centralExtra = Buffer.concat([zip64 ? zip64Extra([data.length, comp.length, offset]) : Buffer.alloc(0), e.extra ?? Buffer.alloc(0)]);
     const central = Buffer.alloc(46);
     central.writeUInt32LE(0x02014b50, 0);
-    central.writeUInt16LE(20, 4);
-    central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(0, 10);
+    central.writeUInt16LE(zip64 ? 45 : 20, 4);
+    central.writeUInt16LE(zip64 ? 45 : 20, 6);
+    central.writeUInt16LE(flags, 8);
+    central.writeUInt16LE(method, 10);
     central.writeUInt32LE(crc, 16);
-    central.writeUInt32LE(data.length, 20);
-    central.writeUInt32LE(data.length, 24);
+    central.writeUInt32LE(zip64 ? FFFF : comp.length, 20);
+    central.writeUInt32LE(zip64 ? FFFF : data.length, 24);
     central.writeUInt16LE(nameBuf.length, 28);
-    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(centralExtra.length, 30);
     central.writeUInt16LE(0, 32);
-    central.writeUInt32LE(offset, 42);
-    locals.push(local, nameBuf, data);
-    centrals.push(central, nameBuf);
-    offset += local.length + nameBuf.length + data.length;
+    central.writeUInt32LE(zip64 ? FFFF : offset, 42);
+    locals.push(local, nameBuf, localExtra, comp);
+    centrals.push(central, nameBuf, centralExtra);
+    offset += local.length + nameBuf.length + localExtra.length + comp.length;
   }
+  const count = Object.keys(entries).length;
   const cdSize = centrals.reduce((n, b) => n + b.length, 0);
+  const tail = [];
+  if (zip64) {
+    const rec = Buffer.alloc(56);
+    rec.writeUInt32LE(0x06064b50, 0);
+    rec.writeBigUInt64LE(44n, 4);
+    rec.writeUInt16LE(45, 12);
+    rec.writeUInt16LE(45, 14);
+    rec.writeBigUInt64LE(BigInt(count), 24);
+    rec.writeBigUInt64LE(BigInt(count), 32);
+    rec.writeBigUInt64LE(BigInt(cdSize), 40);
+    rec.writeBigUInt64LE(BigInt(offset), 48);
+    const loc = Buffer.alloc(20);
+    loc.writeUInt32LE(0x07064b50, 0);
+    loc.writeBigUInt64LE(BigInt(offset + cdSize), 8);
+    loc.writeUInt32LE(1, 16);
+    tail.push(rec, loc);
+  }
   const eocd = Buffer.alloc(22);
   eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(Object.keys(entries).length, 8);
-  eocd.writeUInt16LE(Object.keys(entries).length, 10);
-  eocd.writeUInt32LE(cdSize, 12);
-  eocd.writeUInt32LE(offset, 16);
-  return Buffer.concat([...locals, ...centrals, eocd]);
+  eocd.writeUInt16LE(zip64 ? 0xffff : count, 8);
+  eocd.writeUInt16LE(zip64 ? 0xffff : count, 10);
+  eocd.writeUInt32LE(zip64 ? FFFF : cdSize, 12);
+  eocd.writeUInt32LE(zip64 ? FFFF : offset, 16);
+  return Buffer.concat([...locals, ...centrals, ...tail, eocd]);
+}
+
+function zip64Extra(values) {
+  const b = Buffer.alloc(4 + 8 * values.length);
+  b.writeUInt16LE(0x0001, 0);
+  b.writeUInt16LE(8 * values.length, 2);
+  values.forEach((v, i) => b.writeBigUInt64LE(BigInt(v), 4 + 8 * i));
+  return b;
+}
+
+/** Info-ZIP Unicode Path extra field (0x7075) naming `utf8Name` for `rawName`. */
+export function unicodePathExtra(rawName, utf8Name) {
+  const name = Buffer.from(utf8Name, 'utf8');
+  const b = Buffer.alloc(4 + 5 + name.length);
+  b.writeUInt16LE(0x7075, 0);
+  b.writeUInt16LE(5 + name.length, 2);
+  b.writeUInt8(1, 4);
+  b.writeUInt32LE(zlib.crc32(rawName), 5);
+  name.copy(b, 9);
+  return b;
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -67,7 +67,7 @@ export class ApiError extends Error {
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {
-    headers: init?.body ? { 'content-type': 'application/json' } : undefined,
+    headers: init?.body && !(init.body instanceof FormData) ? { 'content-type': 'application/json' } : undefined,
     ...init,
   });
   if (!res.ok) {
@@ -90,8 +90,14 @@ export const api = {
   createProject: (name: string, files?: Record<string, string>, template?: string) =>
     req<ProjectSummary>('/api/projects', { method: 'POST', body: JSON.stringify({ name, files, template }) }),
   templates: () => req<TemplateInfo[]>('/api/templates'),
-  importZip: (name: string, zipBase64: string) =>
-    req<ImportedProject>('/api/projects/import', { method: 'POST', body: JSON.stringify({ name, zipBase64 }) }),
+  /** Multipart so the browser streams the File itself; the JSON + base64
+   *  shape stays on the server for API clients. */
+  importZip: (name: string, zip: File) => {
+    const form = new FormData();
+    form.append('name', name);
+    form.append('zip', zip, zip.name);
+    return req<ImportedProject>('/api/projects/import', { method: 'POST', body: form });
+  },
   compilerInfo: () => req<CompilerInfo>('/api/compiler'),
   getProject: (id: string) => req<ProjectDetail>(`/api/projects/${id}`),
   patchProject: (id: string, patch: Partial<Pick<ProjectSummary, 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>>) =>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -77,10 +77,7 @@ export default function Home() {
     if (file.size > IMPORT_MAX_ZIP_BYTES) { toast(`ZIP is ${sizeMb} MB; the limit is ${IMPORT_MAX_ZIP_MB} MB`, 'error'); return; }
     toast('Importing…');
     try {
-      const buf = new Uint8Array(await file.arrayBuffer());
-      let bin = '';
-      for (let i = 0; i < buf.length; i += 0x8000) bin += String.fromCharCode(...buf.subarray(i, i + 0x8000));
-      const p = await api.importZip(file.name.replace(/\.zip$/i, ''), btoa(bin));
+      const p = await api.importZip(file.name.replace(/\.zip$/i, ''), file);
       toast(importSummary(p), 'ok');
       navigate(`/p/${p.id}`, { state: { import: p.import } });
     } catch (err: any) {

--- a/e2e/tests/21-zip-import.spec.ts
+++ b/e2e/tests/21-zip-import.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * ZIP import hardening (issue #11): archives the reader used to misread or
+ * skip silently, each with the message the user sees, plus a 60 MB import
+ * through the browser's multipart upload.
+ */
+import { test, expect, Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { buildZip, cleanup } from './helpers';
+
+const IMPORT_MAX_ZIP_BYTES = 60 * 1024 * 1024;
+const doc = (body: string) => `\\documentclass{article}\n\\begin{document}\n${body}\n\\end{document}\n`;
+
+const tmpZip = (name: string, zip: Buffer) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-zip11-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, zip);
+  return { dir, file };
+};
+
+const projectNamed = async (page: Page, name: string) => {
+  const list = await (await page.request.get('/api/projects')).json();
+  return list.find((p: { name: string }) => p.name === name);
+};
+
+const importFromHome = async (page: Page, file: string) => {
+  await page.goto('/');
+  await page.getByTestId('import-input').setInputFiles(file);
+};
+
+test.describe('ZIP import hardening', () => {
+  test('a bzip2 entry is refused with the method named, no project created', async ({ page }) => {
+    const name = `bzip2-${Date.now()}`;
+    const { dir, file } = tmpZip(`${name}.zip`, buildZip({ 'main.tex': doc('x'), 'figs/plot.pdf': { data: 'BZh91AY&SY', method: 12 } }));
+    try {
+      await importFromHome(page, file);
+      await expect(page.locator('.toast').filter({ hasText: 'entry "figs/plot.pdf" uses bzip2 compression (method 12); only store and deflate are supported' })).toBeVisible();
+      await expect(page.getByTestId('editor-shell')).toHaveCount(0);
+      expect(await projectNamed(page, name)).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a password-protected entry is refused, not imported as garbage', async ({ page }) => {
+    const name = `encrypted-${Date.now()}`;
+    const { dir, file } = tmpZip(`${name}.zip`, buildZip({ 'main.tex': { data: crypto.randomBytes(64), flags: 0x1 } }));
+    try {
+      await importFromHome(page, file);
+      await expect(page.locator('.toast').filter({ hasText: 'entry "main.tex" is password protected (ZipCrypto); remove the password and export the archive again' })).toBeVisible();
+      expect(await projectNamed(page, name)).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a ZIP64 archive imports with its root detected', async ({ page, request }) => {
+    const name = `zip64-${Date.now()}`;
+    const { dir, file } = tmpZip(`${name}.zip`, buildZip({
+      'paper/main.tex': doc('ZIP64-IMPORTED'),
+      'paper/refs.bib': { data: '@book{k, title={T}}\n', method: 8 },
+    }, { zip64: true }));
+    let id: string | null = null;
+    try {
+      await importFromHome(page, file);
+      await expect(page.getByTestId('editor-shell')).toBeVisible({ timeout: 20_000 });
+      id = new URL(page.url()).pathname.split('/')[2];
+      const meta = await (await request.get(`/api/projects/${id}`)).json();
+      expect(meta.rootFile).toBe('paper/main.tex');
+      await expect(page.locator('.cm-content')).toContainText('ZIP64-IMPORTED');
+      await expect(page.getByTestId('file-paper/refs.bib')).toBeVisible();
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('cp437 file names from a Windows archive are decoded', async ({ page, request }) => {
+    const name = `cp437-${Date.now()}`;
+    // "résumé.tex" as Windows Explorer writes it: cp437 bytes, UTF-8 flag unset
+    const raw = Buffer.concat([Buffer.from('r'), Buffer.from([0x82]), Buffer.from('sum'), Buffer.from([0x82]), Buffer.from('.tex')]);
+    const { dir, file } = tmpZip(`${name}.zip`, buildZip({ x: { data: doc('CP437-NAME'), nameBytes: raw } }));
+    let id: string | null = null;
+    try {
+      await importFromHome(page, file);
+      await expect(page.getByTestId('editor-shell')).toBeVisible({ timeout: 20_000 });
+      id = new URL(page.url()).pathname.split('/')[2];
+      const meta = await (await request.get(`/api/projects/${id}`)).json();
+      expect(meta.rootFile).toBe('résumé.tex');
+      await expect(page.getByTestId('file-résumé.tex')).toBeVisible();
+      await expect(page.locator('.cm-content')).toContainText('CP437-NAME');
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a 60 MB archive uploads as multipart and imports', async ({ page, request }) => {
+    test.setTimeout(180_000);
+    const name = `sixty-${Date.now()}`;
+    const asset = crypto.randomBytes(IMPORT_MAX_ZIP_BYTES - 4096);
+    const zip = buildZip({ 'main.tex': doc('SIXTY-MB'), 'assets/blob.bin': asset });
+    expect(zip.length).toBeLessThanOrEqual(IMPORT_MAX_ZIP_BYTES);
+    expect(zip.length).toBeGreaterThan(IMPORT_MAX_ZIP_BYTES - 4096);
+    const { dir, file } = tmpZip(`${name}.zip`, zip);
+    let id: string | null = null;
+    try {
+      await page.goto('/');
+      const upload = page.waitForRequest((r) => r.url().endsWith('/api/projects/import') && r.method() === 'POST');
+      await page.getByTestId('import-input').setInputFiles(file);
+      const req = await upload;
+      // the browser streams the File in a form; no base64 or JSON copy is made
+      expect(req.headers()['content-type']).toMatch(/^multipart\/form-data; boundary=/);
+      await expect(page.getByTestId('editor-shell')).toBeVisible({ timeout: 120_000 });
+      id = new URL(page.url()).pathname.split('/')[2];
+      const meta = await (await request.get(`/api/projects/${id}`)).json();
+      expect(meta.name).toBe(name);
+      expect(meta.rootFile).toBe('main.tex');
+      const files = await (await request.get(`/api/projects/${id}/files?branch=main`)).json();
+      const blob = files.find((f: { path: string }) => f.path === 'assets/blob.bin');
+      expect(blob?.size).toBe(asset.length);
+    } finally {
+      if (id) await cleanup(request, id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('over 60 MB: the browser and the multipart API both state the size and the limit', async ({ page, request }) => {
+    const name = `toobig-${Date.now()}`;
+    const zip = buildZip({ 'main.tex': doc('x'), 'pad.bin': Buffer.alloc(IMPORT_MAX_ZIP_BYTES + 1024 * 1024) });
+    const { dir, file } = tmpZip(`${name}.zip`, zip);
+    try {
+      await importFromHome(page, file);
+      await expect(page.locator('.toast').filter({ hasText: /ZIP is 61(\.\d)? MB; the limit is 60 MB/ })).toBeVisible();
+      const res = await request.post('/api/projects/import', { multipart: { name, zip: { name: `${name}.zip`, mimeType: 'application/zip', buffer: zip } } });
+      expect(res.status()).toBe(413);
+      expect((await res.json()).error).toBe('ZIP is 61 MB; the limit is 60 MB');
+      expect(await projectNamed(page, name)).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the JSON base64 body keeps working for API clients', async ({ request }) => {
+    const name = `base64-${Date.now()}`;
+    const res = await request.post('/api/projects/import', { data: { name, zipBase64: buildZip({ 'main.tex': doc('B64') }).toString('base64') } });
+    expect(res.ok()).toBeTruthy();
+    const meta = await res.json();
+    try {
+      expect(meta.name).toBe(name);
+      expect(meta.rootFile).toBe('main.tex');
+    } finally {
+      await cleanup(request, meta.id);
+    }
+  });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,7 +1,6 @@
 import { APIRequestContext, Page, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
-import zlib from 'node:zlib';
 
 export const PAPER_DIR = process.env.PAPER_DIR || path.resolve(__dirname, '..', 'fixtures', 'demo-paper');
 
@@ -66,45 +65,6 @@ export async function cleanup(request: APIRequestContext, id: string): Promise<v
   await request.delete(`/api/projects/${id}?permanent=1`).catch(() => {});
 }
 
-/**
- * A stored (method 0) ZIP with entry names written verbatim — the `zip` CLI
- * refuses the `../x` names an import test needs to send.
- */
-export function buildZip(entries: Record<string, Buffer | string>): Buffer {
-  const locals: Buffer[] = [];
-  const centrals: Buffer[] = [];
-  let offset = 0;
-  for (const [name, raw] of Object.entries(entries)) {
-    const data = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
-    const nameBuf = Buffer.from(name, 'utf8');
-    const crc = zlib.crc32(data);
-    const local = Buffer.alloc(30);
-    local.writeUInt32LE(0x04034b50, 0);
-    local.writeUInt16LE(20, 4);
-    local.writeUInt32LE(crc, 14);
-    local.writeUInt32LE(data.length, 18);
-    local.writeUInt32LE(data.length, 22);
-    local.writeUInt16LE(nameBuf.length, 26);
-    const central = Buffer.alloc(46);
-    central.writeUInt32LE(0x02014b50, 0);
-    central.writeUInt16LE(20, 4);
-    central.writeUInt16LE(20, 6);
-    central.writeUInt32LE(crc, 16);
-    central.writeUInt32LE(data.length, 20);
-    central.writeUInt32LE(data.length, 24);
-    central.writeUInt16LE(nameBuf.length, 28);
-    central.writeUInt32LE(offset, 42);
-    locals.push(local, nameBuf, data);
-    centrals.push(central, nameBuf);
-    offset += local.length + nameBuf.length + data.length;
-  }
-  const count = Object.keys(entries).length;
-  const cdSize = centrals.reduce((n, b) => n + b.length, 0);
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(count, 8);
-  eocd.writeUInt16LE(count, 10);
-  eocd.writeUInt32LE(cdSize, 12);
-  eocd.writeUInt32LE(offset, 16);
-  return Buffer.concat([...locals, ...centrals, eocd]);
-}
+/** ZIP fixtures built in-test (raw names, foreign methods, encryption flag,
+ *  ZIP64): the server unit tests own the builder. */
+export { buildZip, unicodePathExtra } from '../../apps/server/test/zip.mjs';


### PR DESCRIPTION
Closes #11. Several of the colleague's Overleaf exports failed to import; this removes the reader's remaining blind spots.

- ZIP64 (the record, its locator and the per-entry extra field), so large archives and ones written with 64-bit headers parse.
- No entry is ever skipped silently: an unsupported compression method is named (`bzip2 compression (method 12)`), an encrypted entry says which scheme, a damaged central directory says which entry is missing. Per-file and total inflation caps stay.
- Filenames without the UTF-8 flag: Info-ZIP Unicode path extra when its CRC matches, then cp437 or latin-1, chosen by which reading is plausible.
- The web client uploads multipart/form-data (one copy of the archive in the browser instead of four); the JSON base64 body still works for API clients.
- Every failed import logs one line with the reason, size and entry count, never file contents. The server's default log level is now info with per-request logging off, so a hosted instance has that trace; `LOG_LEVEL=warn` restores the old quiet.

Checks: server and web typecheck, server unit suite (new unzip and multipart tests), web unit 13/13, e2e 21-zip-import 7/7.

Note: the workflow that wrote this ran out of credits before its review stage, so I read the parser myself. Bounds are checked before every read (central header, local header, data extent), inflation is capped, and a bogus ZIP64 entry count cannot loop past the buffer.