### PR TITLE
feat: venue template gallery from the classes the compiler has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
       # edition. Same command checks both.
       - name: Third-party notices and licence gate
         run: npm run notices:check
+      # A starter file whose licence nobody recorded is one nobody can safely
+      # copy into a paper, and the gallery shows a licence on every tile.
+      - name: Template licence gate
+        run: npm run templates:check
+      - name: Server unit tests
+        run: npm run test:unit -w apps/server
 
   compose:
     name: docker compose config is valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,27 @@ All notable changes to Aldine are documented here. The format follows
   self-hosted edition stays AGPL, and that no feature that works today moves
   behind a paid tier.
 
+- Template gallery: the New project dialog groups templates by category
+  (Journals, Conferences, Theses, Slides, General), has a search box, and shows
+  each template's licence. Beside the four templates in `templates/`, the
+  gallery now offers a template per venue class installed in the compiler image
+  (fifteen on the full TeX Live image: Elsevier, IEEE Transactions and
+  conference, ACM, REVTeX, Springer LNCS, JMLR, AMS, MNRAS, APA 7, ACS, AIAA,
+  ASCE, ASME conference and SPIE): the compiler
+  answers `GET /catalog` with the classes it actually
+  has, their licence from `tlmgr`, and the class's own sample document when the
+  image ships one; where it does not, Aldine generates a skeleton with the
+  title block, abstract, a section and the class's usual bibliography style. No
+  publisher file is vendored into the repo, and an image without those classes
+  (or an older compiler) simply shows the four folder templates.
+- Every template folder carries a `LICENSE` file, and `template.json` carries
+  `license`, `licenseUrl` and `source` (upstream URL and version). `npm run
+  templates:check` fails on a template missing either, and CI runs it.
+- AWS deployment: an optional staging service on the same load balancer
+  (`staging_domain_name`), with its own filesystem, log group and certificate,
+  so a feature branch can be tried at a real URL before it reaches prod. The
+  deploy and rollback workflows take a `target` input (production or staging).
+
 ### Changed
 - `POST /api/projects/import` accepts `multipart/form-data` with a `zip` file
   part (and an optional `name` field); the web client uploads the file that
@@ -105,6 +126,7 @@ All notable changes to Aldine are documented here. The format follows
   "Stop on first error" (log dialog and command palette, `stopOnFirstError` in
   `PATCH /api/projects/:id`); with it on, a failing run keeps the previous PDF
   on screen as before.
+
 
 - The compiler image defaults to full TeX Live (`TEXLIVE_SCHEME=full`): every
   script and language compiles out of the box. The `medium` scheme stays for
@@ -150,6 +172,12 @@ All notable changes to Aldine are documented here. The format follows
   user cannot open, and identical error rows are listed once.
 - A failed typeset always says why: a run whose logs parse to no error at all
   falls back to latexmk's own summary rather than an unexplained "Failed".
+- Templates are read as bytes instead of UTF-8 text, so a template carrying a
+  logo, a figure or any other binary file reaches the new project intact.
+- A SyncTeX jump from the PDF is refused (409, with a toast) when the preview
+  on screen and the SyncTeX file on disk come from different typeset runs,
+  instead of landing on the wrong line. Compile results carry a `compileId`
+  that the lookup sends back.
 - ZIP import reads ZIP64 archives (64-bit sizes and offsets, the ZIP64
   end-of-central-directory record), so exports from tools that write ZIP64
   headers no longer fail as "not a zip file" or import partially. An entry
@@ -337,6 +365,15 @@ All notable changes to Aldine are documented here. The format follows
   seconds"; the README says ~2s, so the page does now too.
 
 ### Security
+- The minimal `docker-compose.yml` carries the compiler sandbox again: an
+  `internal: true` network with no route to the internet, `cap_drop: [ALL]`,
+  `no-new-privileges`, and memory/PID bounds. The 0.3.0 split had left all of it
+  in `docker-compose.full.yml` while SECURITY.md and the README went on
+  promising it, so quick-start instances were compiling untrusted LaTeX in a
+  container with full egress and every capability. The README quick start is the
+  same file, verbatim, including the `name: aldine` line that fixes the volume
+  names.
+
 - The minimal `docker-compose.yml` carries the compiler sandbox again: an
   `internal: true` network with no route to the internet, `cap_drop: [ALL]`,
   `no-new-privileges`, and memory/PID bounds. The 0.3.0 split had left all of it

--- a/README.md
+++ b/README.md
@@ -363,10 +363,14 @@ Copyright (C) 2026 Tobias Rahloff.
 
 [AGPL-3.0](LICENSE): self-host freely; if you offer a modified Aldine as a
 service, share your changes. Third-party plugins interact with Aldine over its
-plugin API and may use any license. `templates/iac-paper/iac.cls` is LPPL-1.3c,
-the customary license for a LaTeX class file. Overleaf is a trademark of its
-owners; Aldine is an independent project, not affiliated with or endorsed by
-Overleaf.
+plugin API and may use any license. Each folder under `templates/` carries its
+own `LICENSE` and states it in `template.json` (the gallery shows it on the
+tile): the generic templates are MIT, and `templates/iac-paper` is LPPL-1.3c,
+the customary license for a LaTeX class file. Venue templates are generated
+from the classes installed in the compiler image, with the license `tlmgr`
+reports; no publisher file is stored in this repository. Overleaf is a
+trademark of its owners; Aldine is an independent project, not affiliated with
+or endorsed by Overleaf.
 
 Two things stated plainly, because finding them out later feels like a
 bait-and-switch. **A hosted Aldine service is planned**, and contributions are

--- a/apps/compiler/Dockerfile
+++ b/apps/compiler/Dockerfile
@@ -56,12 +56,11 @@ RUN biber --version
 RUN tlmgr conf texmf shell_escape p
 
 WORKDIR /srv
-COPY server.js .
+COPY server.js catalog.js ./
 # server.js reports the scheme at GET /health; the ARG must be re-declared
 # after FROM to be visible in this stage.
 ARG TEXLIVE_SCHEME
 RUN echo "${TEXLIVE_SCHEME}" > /srv/texlive-scheme
-
 ENV PORT=4020 \
     DATA_DIR=/data \
     openin_any=p \

--- a/apps/compiler/catalog.js
+++ b/apps/compiler/catalog.js
@@ -1,0 +1,220 @@
+/**
+ * Venue catalog — which publisher classes this TeX Live installation actually
+ * carries, so the app can offer a template per venue without vendoring a single
+ * publisher file into the repo.
+ *
+ * Only the allowlist below is probed: an arbitrary kpsewhich sweep would expose
+ * every class on the image, most of which nobody submits a paper to.
+ * A scheme-basic install has almost none of them — an empty list is a normal
+ * answer, never an error.
+ */
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * id      — stable venue key; the app's template metadata is keyed by it, so it
+ *           must not change when the image ships a newer, differently named file
+ *           (aastex631.cls → aastex7.cls).
+ * files   — candidates in preference order; the first one installed wins.
+ * pkg     — TeX Live package name, for the license and upstream URL.
+ */
+const VENUES = [
+  { id: 'elsarticle', pkg: 'elsarticle', files: ['elsarticle.cls'] },
+  { id: 'ieeetran', pkg: 'ieeetran', files: ['IEEEtran.cls'] },
+  { id: 'ieeeconf', pkg: 'ieeeconf', files: ['IEEEconf.cls'] },
+  { id: 'acmart', pkg: 'acmart', files: ['acmart.cls'] },
+  { id: 'revtex', pkg: 'revtex', files: ['revtex4-2.cls', 'revtex4-1.cls'] },
+  { id: 'agujournal', pkg: 'agujournal', files: ['agujournal2019.cls', 'agujournal.cls'] },
+  { id: 'copernicus', pkg: 'copernicus', files: ['copernicus.cls'] },
+  { id: 'llncs', pkg: 'llncs', files: ['llncs.cls'] },
+  { id: 'svjour3', pkg: 'svjour3', files: ['svjour3.cls'] },
+  { id: 'mdpi', pkg: 'mdpi', files: ['mdpi.cls'] },
+  { id: 'jmlr', pkg: 'jmlr', files: ['jmlr.cls'] },
+  { id: 'amsart', pkg: 'amscls', files: ['amsart.cls'] },
+  { id: 'siamart', pkg: 'siamart', files: ['siamart220329.cls', 'siamart190516.cls', 'siamart.cls'] },
+  { id: 'jfm', pkg: 'jfm', files: ['jfm.cls'] },
+  { id: 'aastex', pkg: 'aastex', files: ['aastex631.cls', 'aastex63.cls'] },
+  { id: 'mnras', pkg: 'mnras', files: ['mnras.cls'] },
+  { id: 'apa7', pkg: 'apa7', files: ['apa7.cls'] },
+  { id: 'achemso', pkg: 'achemso', files: ['achemso.cls'] },
+  { id: 'aiaa', pkg: 'aiaa', files: ['aiaa-tc.cls'] },
+  { id: 'ascelike', pkg: 'ascelike', files: ['ascelike.cls'] },
+  { id: 'asmeconf', pkg: 'asmeconf', files: ['asmeconf.cls'] },
+  { id: 'spie', pkg: 'spie', files: ['spie.cls'] },
+  // Conference kits ship as style files loaded on top of article.
+  { id: 'neurips', pkg: 'neurips', files: ['neurips_2025.sty', 'neurips_2024.sty', 'neurips_2023.sty', 'neurips_2022.sty'] },
+  { id: 'iclr', pkg: 'iclr', files: ['iclr2025_conference.sty', 'iclr2024_conference.sty', 'iclr2023_conference.sty'] },
+  { id: 'acl', pkg: 'acl', files: ['acl.sty', 'acl_natbib.sty', 'acl2023.sty'] },
+  { id: 'aaai', pkg: 'aaai', files: ['aaai25.sty', 'aaai24.sty', 'aaai.sty'] },
+  { id: 'usenix', pkg: 'usenix', files: ['usenix2019_v3.sty', 'usenix.sty'] },
+  { id: 'cvpr', pkg: 'cvpr', files: ['cvpr.sty', 'cvpr_eso.sty'] },
+];
+
+/** A sample bigger than this is a manual, not a starting point. */
+const MAX_SAMPLE_BYTES = 100 * 1024;
+const PROBE_TIMEOUT_MS = 30_000;
+
+function run(cmd, args, timeoutMs = PROBE_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch {
+      return resolve({ ok: false, out: '' });
+    }
+    let out = '';
+    let done = false;
+    const finish = (ok) => { if (!done) { done = true; resolve({ ok, out }); } };
+    const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* gone */ } finish(false); }, timeoutMs);
+    child.stdout.on('data', (d) => { out += d.toString('utf8'); });
+    child.on('error', () => { clearTimeout(timer); finish(false); });
+    child.on('close', () => { clearTimeout(timer); finish(true); });
+  });
+}
+
+/**
+ * kpsewhich prints one line per argument — the resolved path, or empty when the
+ * file is not installed — so the answers line up with the queries positionally.
+ */
+async function locate(files) {
+  if (!files.length) return {};
+  const { ok, out } = await run('kpsewhich', files);
+  if (!ok) return {};
+  const lines = out.split('\n');
+  const found = {};
+  files.forEach((f, i) => {
+    const p = (lines[i] || '').trim();
+    if (p && fs.existsSync(p)) found[f] = p;
+  });
+  return found;
+}
+
+/** One tlmgr call for the whole image: package → { license, version, home }. */
+async function packageData() {
+  const { ok, out } = await run('tlmgr', ['info', '--only-installed', '--data', 'name,cat-license,cat-version,cat-contact-home']);
+  if (!ok) return {};
+  const byPkg = {};
+  for (const line of out.split('\n')) {
+    const [name, license, version, home] = line.split(',');
+    if (!name) continue;
+    byPkg[name.trim()] = {
+      license: (license || '').trim() || null,
+      version: (version || '').trim() || null,
+      source: (home || '').trim() || null,
+    };
+  }
+  return byPkg;
+}
+
+/**
+ * texmf-dist/tex/latex/<pkg>/x.cls → texmf-dist/doc/latex/<pkg>/. The last
+ * "tex" segment is the tree root, so replacing it by name (not by string
+ * search) survives paths that contain "tex" elsewhere, which every TeX Live
+ * path does.
+ */
+function docDir(clsPath) {
+  const parts = path.dirname(clsPath).split(path.sep);
+  const i = parts.lastIndexOf('tex');
+  if (i < 0) return null;
+  parts[i] = 'doc';
+  const dir = parts.join(path.sep);
+  return fs.existsSync(dir) ? dir : null;
+}
+
+/**
+ * Only the sample file itself is shipped, so a sample that pulls in a sibling
+ * (a body fragment, a teaser figure, the package's own .bib) would land in a
+ * project whose first compile cannot find it. Such a sample is rejected and the
+ * app falls back to its generated skeleton.
+ */
+const SIBLING_MACROS = /\\(input|include|includegraphics|subfile|lstinputlisting|verbatiminput)\s*[{[]/;
+
+function selfContained(content) {
+  // Comments are not compiled, and samples routinely park an \includegraphics
+  // example behind a %.
+  const src = content.replace(/(^|[^\\])%.*$/gm, '$1');
+  if (SIBLING_MACROS.test(src)) return false;
+  const bibs = src.matchAll(/\\(?:bibliography|addbibresource)\s*(?:\[[^\]]*\])?\{([^}]*)\}/g);
+  for (const m of bibs) {
+    for (const name of m[1].split(',')) {
+      const n = name.trim().replace(/\.bib$/i, '');
+      if (n && n !== 'references') return false;
+    }
+  }
+  return true;
+}
+
+/** The smallest ready-to-edit document in the class's doc directory, if any. */
+function findSample(clsPath) {
+  const dir = docDir(clsPath);
+  if (!dir) return null;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return null; }
+  const candidates = [];
+  for (const e of entries) {
+    if (!e.isFile() || !/\.tex$/i.test(e.name)) continue;
+    if (!/(sample|template|example|skeleton|demo|starter)/i.test(e.name)) continue;
+    let stat;
+    try { stat = fs.statSync(path.join(dir, e.name)); } catch { continue; }
+    if (stat.size > MAX_SAMPLE_BYTES) continue;
+    candidates.push({ name: e.name, size: stat.size });
+  }
+  candidates.sort((a, b) => a.size - b.size || a.name.localeCompare(b.name));
+  for (const c of candidates) {
+    let content;
+    try { content = fs.readFileSync(path.join(dir, c.name), 'utf8'); } catch { continue; }
+    if (!/\\begin\s*\{document\}/.test(content)) continue;
+    if (!selfContained(content)) continue;
+    return { file: c.name, content };
+  }
+  return null;
+}
+
+async function build() {
+  const wanted = [];
+  for (const v of VENUES) for (const f of v.files) wanted.push(f);
+  const found = await locate(wanted);
+  const classes = [];
+  if (Object.keys(found).length) {
+    const pkgs = await packageData();
+    for (const v of VENUES) {
+      const file = v.files.find((f) => found[f]);
+      if (!file) continue;
+      const meta = pkgs[v.pkg] || {};
+      classes.push({
+        id: v.id,
+        // The name that goes into \documentclass / \usepackage, without the extension.
+        cls: file.replace(/\.(cls|sty)$/i, ''),
+        kind: /\.sty$/i.test(file) ? 'style' : 'class',
+        pkg: v.pkg,
+        license: meta.license || null,
+        version: meta.version || null,
+        source: meta.source || null,
+        sample: findSample(found[file]),
+      });
+    }
+  }
+  return { ok: true, generatedAt: new Date().toISOString(), classes };
+}
+
+let cached = null;
+let inflight = null;
+
+/**
+ * Cached for the life of the process: the TeX installation cannot change under
+ * it, and installing a package needs a restart anyway. There is deliberately no
+ * refresh switch — the port is unauthenticated, and a caller that could drop the
+ * cache could make every request spawn its own kpsewhich and tlmgr sweep.
+ */
+function getCatalog() {
+  if (cached) return Promise.resolve(cached);
+  if (!inflight) {
+    inflight = build()
+      .then((c) => { cached = c; inflight = null; return c; })
+      .catch(() => { inflight = null; return { ok: true, generatedAt: new Date().toISOString(), classes: [] }; });
+  }
+  return inflight;
+}
+
+module.exports = { getCatalog, selfContained, VENUES };

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -6,6 +6,7 @@
  *   POST /compile  { projectDir, rootFile, engine? }  ->
  *     { ok, pdf: <path in OUT_DIR>, log, errors: [{file,line,message,type}], durationMs }
  *   GET  /health   -> { ok: true, texlive: { release: '2026' | 'unknown', scheme: 'full' | 'medium' | 'unknown' } }
+ *   GET  /catalog  -> { ok, generatedAt, classes: [{ id, cls, kind, license, sample }] }
  *
  * The compiler shares the projects volume (read) and an output cache volume
  * (write) with the app server, so no file transfer is needed.
@@ -17,6 +18,7 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { getCatalog } = require('./catalog.js');
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 4020;
 const DATA_DIR = process.env.DATA_DIR || path.resolve(__dirname, '../../.data');
@@ -375,6 +377,10 @@ async function synctex(body) {
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && req.url === '/health') return json(res, 200, { ok: true, texlive });
+  if (req.method === 'GET' && (req.url === '/catalog' || req.url.startsWith('/catalog?'))) {
+    return getCatalog().then((c) => json(res, 200, c), (err) => json(res, 500, { ok: false, error: String(err && err.message || err) }));
+  }
+
   if (req.method === 'POST' && (req.url === '/compile' || req.url === '/synctex')) {
     let raw = '';
     req.on('data', (d) => { raw += d; });

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs && tsx test/templates.test.mjs && tsx test/templates-check.test.mjs && tsx test/skeleton-compile.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/src/catalog.ts
+++ b/apps/server/src/catalog.ts
@@ -1,0 +1,382 @@
+/**
+ * Venue templates generated from the classes installed in the compiler image.
+ *
+ * The compiler answers GET /catalog with the publisher classes it actually has
+ * (see apps/compiler/catalog.js); this module turns each into a template: the
+ * class's own sample document when the image ships one, otherwise a skeleton
+ * built here. No publisher file is ever stored in this repo.
+ *
+ * A compiler that is old, down, or built on scheme-basic yields an empty list,
+ * which is a normal answer: the folder templates stand on their own.
+ */
+import { config } from './config.js';
+import type { TemplateCategory, TemplateInfo } from './templates.js';
+
+export const VENUE_PREFIX = 'venue:';
+
+interface CatalogClass {
+  id: string;
+  cls: string;
+  kind: 'class' | 'style';
+  pkg?: string;
+  license?: string | null;
+  version?: string | null;
+  source?: string | null;
+  sample?: { file: string; content: string } | null;
+}
+
+interface VenueMeta {
+  name: string;
+  category: TemplateCategory;
+  description: string;
+  icon?: string;
+  /** Class options for the generated skeleton. */
+  options?: string;
+  /** BibTeX style for the generated skeleton; omitted when the venue uses biblatex. */
+  bibStyle?: string;
+  biblatexStyle?: string;
+  /** Packages the class needs but does not load: mnras's bst calls
+   *  \citeauthoryear, which only natbib defines. */
+  packages?: string[];
+  /** The class issues its own \bibliographystyle (jmlr); a second one is a
+   *  BibTeX error, so the skeleton only names the .bib. */
+  classSetsBibStyle?: boolean;
+  /**
+   * Where the title block goes. Getting this wrong is a fatal error on the
+   * first compile, not a cosmetic difference: REVTeX's \author is undefined in
+   * the preamble, and the AMS classes want the abstract before \maketitle.
+   *  - 'frontmatter'    — title block inside \begin{frontmatter} (elsarticle)
+   *  - 'inbody'         — title, author and affiliation after \begin{document},
+   *                       abstract before \maketitle (REVTeX, AASTeX, acmart)
+   *  - 'abstract-first' — title block in the preamble, abstract before
+   *                       \maketitle (the AMS classes)
+   *  - 'acm'            — acmart: every author needs an \affiliation with an
+   *                       \institution and a \country, or the class errors
+   * Anything else takes the plain article shape.
+   */
+  front?: 'frontmatter' | 'inbody' | 'abstract-first' | 'acm';
+}
+
+/** Display metadata per venue id from the compiler's allowlist. */
+const VENUES: Record<string, VenueMeta> = {
+  elsarticle: { name: 'Elsevier journal', category: 'Journals', description: 'Elsevier submission with the elsarticle class.', icon: '📗', options: 'preprint,review,12pt', bibStyle: 'elsarticle-num', front: 'frontmatter' },
+  ieeetran: { name: 'IEEE Transactions', category: 'Journals', description: 'IEEE journal submission with the IEEEtran class.', icon: '📘', options: 'journal', bibStyle: 'IEEEtran' },
+  ieeeconf: { name: 'IEEE conference', category: 'Conferences', description: 'IEEE conference paper with the IEEEconf class.', icon: '📙', bibStyle: 'IEEEtran' },
+  acmart: { name: 'ACM article', category: 'Conferences', description: 'ACM proceedings or journal paper with the acmart class.', icon: '📕', options: 'sigconf', bibStyle: 'ACM-Reference-Format', front: 'acm' },
+  revtex: { name: 'APS and AIP (REVTeX)', category: 'Journals', description: 'Physics journals (Physical Review, AIP) with REVTeX.', icon: '⚛️', options: 'aps,pra,twocolumn', bibStyle: 'apsrev4-2', front: 'inbody' },
+  agujournal: { name: 'AGU journal', category: 'Journals', description: 'American Geophysical Union submission.', icon: '🌍', options: 'draft', bibStyle: 'agufull08' },
+  copernicus: { name: 'Copernicus journal', category: 'Journals', description: 'Copernicus Publications submission.', icon: '🛰', options: 'manuscript', bibStyle: 'copernicus' },
+  llncs: { name: 'Springer LNCS', category: 'Conferences', description: 'Lecture Notes in Computer Science proceedings paper.', icon: '📓', bibStyle: 'splncs04' },
+  svjour3: { name: 'Springer journal', category: 'Journals', description: 'Springer journal submission with svjour3.', icon: '📔', options: 'twocolumn', bibStyle: 'spmpsci' },
+  mdpi: { name: 'MDPI journal', category: 'Journals', description: 'MDPI submission (Sensors, Applied Sciences and siblings).', icon: '📗', bibStyle: 'mdpi' },
+  jmlr: { name: 'JMLR', category: 'Journals', description: 'Journal of Machine Learning Research submission.', icon: '🤖', classSetsBibStyle: true },
+  amsart: { name: 'AMS article', category: 'Journals', description: 'American Mathematical Society article.', icon: '➗', bibStyle: 'amsplain', front: 'abstract-first' },
+  siamart: { name: 'SIAM journal', category: 'Journals', description: 'Society for Industrial and Applied Mathematics submission.', icon: '📐', bibStyle: 'siamplain' },
+  jfm: { name: 'Journal of Fluid Mechanics', category: 'Journals', description: 'Cambridge JFM submission.', icon: '🌊', bibStyle: 'jfm' },
+  aastex: { name: 'AAS journals', category: 'Journals', description: 'American Astronomical Society journals (ApJ, AJ).', icon: '🔭', options: 'twocolumn', bibStyle: 'aasjournal', front: 'inbody' },
+  mnras: { name: 'MNRAS', category: 'Journals', description: 'Monthly Notices of the Royal Astronomical Society.', icon: '✨', options: 'usenatbib', bibStyle: 'mnras' },
+  apa7: { name: 'APA 7 manuscript', category: 'Journals', description: 'APA 7th edition manuscript for psychology journals.', icon: '🧠', options: 'man', biblatexStyle: 'apa' },
+  achemso: { name: 'ACS journals', category: 'Journals', description: 'American Chemical Society journals (JACS and siblings).', icon: '⚗️', classSetsBibStyle: true },
+  aiaa: { name: 'AIAA', category: 'Conferences', description: 'American Institute of Aeronautics and Astronautics paper.', icon: '🚀', bibStyle: 'aiaa' },
+  ascelike: { name: 'ASCE journals', category: 'Journals', description: 'American Society of Civil Engineers submission.', icon: '🌉', options: 'Journal', classSetsBibStyle: true },
+  asmeconf: { name: 'ASME conference', category: 'Conferences', description: 'ASME conference proceedings paper.', icon: '🔧', bibStyle: 'asmeconf' },
+  spie: { name: 'SPIE', category: 'Conferences', description: 'SPIE proceedings paper.', icon: '🔬', bibStyle: 'spiebib' },
+  neurips: { name: 'NeurIPS', category: 'Conferences', description: 'Neural Information Processing Systems submission.', icon: '🧠', bibStyle: 'plainnat' },
+  iclr: { name: 'ICLR', category: 'Conferences', description: 'International Conference on Learning Representations submission.', icon: '🧩', bibStyle: 'plainnat' },
+  acl: { name: 'ACL', category: 'Conferences', description: 'ACL, EMNLP and NAACL submission.', icon: '💬', bibStyle: 'acl_natbib' },
+  aaai: { name: 'AAAI', category: 'Conferences', description: 'AAAI conference submission.', icon: '🎓', bibStyle: 'aaai' },
+  usenix: { name: 'USENIX', category: 'Conferences', description: 'USENIX Security, OSDI and ATC submission.', icon: '🔐', bibStyle: 'plain' },
+  cvpr: { name: 'CVPR', category: 'Conferences', description: 'CVPR, ICCV and ECCV submission.', icon: '👁', bibStyle: 'ieee_fullname' },
+};
+
+/** TeX Live license ids → the text everyone links to. */
+const LICENSE_URLS: Record<string, string> = {
+  lppl: 'https://www.latex-project.org/lppl.txt',
+  'lppl1.2': 'https://www.latex-project.org/lppl/lppl-1-2.txt',
+  'lppl1.3': 'https://www.latex-project.org/lppl/lppl-1-3c.txt',
+  'lppl1.3a': 'https://www.latex-project.org/lppl/lppl-1-3a.txt',
+  'lppl1.3b': 'https://www.latex-project.org/lppl/lppl-1-3c.txt',
+  'lppl1.3c': 'https://www.latex-project.org/lppl/lppl-1-3c.txt',
+  gpl: 'https://www.gnu.org/licenses/gpl-3.0.html',
+  gpl1: 'https://www.gnu.org/licenses/old-licenses/gpl-1.0.html',
+  gpl2: 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.html',
+  gpl3: 'https://www.gnu.org/licenses/gpl-3.0.html',
+  'gpl3+': 'https://www.gnu.org/licenses/gpl-3.0.html',
+  lgpl2: 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html',
+  lgpl3: 'https://www.gnu.org/licenses/lgpl-3.0.html',
+  mit: 'https://opensource.org/license/mit',
+  bsd: 'https://opensource.org/license/bsd-3-clause',
+  bsd2: 'https://opensource.org/license/bsd-2-clause',
+  bsd3: 'https://opensource.org/license/bsd-3-clause',
+  bsd4: 'https://spdx.org/licenses/BSD-4-Clause.html',
+  apache2: 'https://www.apache.org/licenses/LICENSE-2.0',
+  ofl: 'https://openfontlicense.org/',
+  cc0: 'https://creativecommons.org/publicdomain/zero/1.0/',
+  'cc-by-3': 'https://creativecommons.org/licenses/by/3.0/',
+  'cc-by-4': 'https://creativecommons.org/licenses/by/4.0/',
+  'cc-by-sa-3': 'https://creativecommons.org/licenses/by-sa/3.0/',
+  'cc-by-sa-4': 'https://creativecommons.org/licenses/by-sa/4.0/',
+  pd: 'https://creativecommons.org/publicdomain/mark/1.0/',
+  knuth: 'https://ctan.org/license/knuth',
+};
+
+const LICENSE_NAMES: Record<string, string> = {
+  pd: 'Public domain',
+  knuth: 'Knuth license',
+  noinfo: 'License not stated',
+  'other-free': 'Free (see the package)',
+  nosell: 'Free, no selling',
+  nocommercial: 'Non-commercial',
+};
+
+/**
+ * Own-property lookup. Every key here comes from the compiler over HTTP, and a
+ * bare index read answers 'constructor' or 'toString' with something from
+ * Object.prototype instead of undefined.
+ */
+function own<T>(map: Record<string, T>, key: string): T | undefined {
+  return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : undefined;
+}
+
+function licenseLabel(id: string): string {
+  const named = own(LICENSE_NAMES, id);
+  if (named) return named;
+  const lppl = id.match(/^lppl([\d.a-z]*)$/);
+  if (lppl) return `LPPL${lppl[1] ? ` ${lppl[1]}` : ''}`;
+  const gpl = id.match(/^(l?gpl)([\d.+]*)$/);
+  if (gpl) return `${gpl[1].toUpperCase()}${gpl[2] ? ` ${gpl[2]}` : ''}`;
+  const cc = id.match(/^cc-(by(?:-sa|-nc|-nd)*)-(\d)$/);
+  if (cc) return `CC ${cc[1].toUpperCase().replace(/-/g, '-')} ${cc[2]}.0`;
+  if (id === 'cc0') return 'CC0';
+  if (id === 'mit') return 'MIT';
+  if (/^bsd/.test(id)) return id.toUpperCase().replace('BSD', 'BSD ');
+  if (id === 'apache2') return 'Apache 2.0';
+  if (id === 'ofl') return 'SIL OFL';
+  return id;
+}
+
+const CACHE_OK_MS = 10 * 60_000;
+const CACHE_FAIL_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+/**
+ * How long a template listing waits for a catalog that is not cached yet. A
+ * compiler that is reachable but silent must not hold GET /api/templates open:
+ * the gallery answers with the folder templates and the venue half appears once
+ * the fetch lands in the cache.
+ */
+export const CATALOG_WAIT_MS = 2_000;
+
+let cache: { at: number; ttl: number; classes: CatalogClass[] } | null = null;
+let inflight: Promise<CatalogClass[]> | null = null;
+/** Bumped by resetVenueCache so an orphaned fetch cannot write over the new state. */
+let generation = 0;
+
+/** The last catalog the compiler actually answered with, however stale. */
+function lastGoodClasses(): CatalogClass[] {
+  return cache && cache.ttl === CACHE_OK_MS ? cache.classes : [];
+}
+
+/**
+ * The compiler's class list, cached. Any failure is an empty list, never a
+ * throw, and no caller waits longer than waitMs for a cold catalog: past that
+ * the answer is the last catalog the compiler gave, so a TTL rollover keeps
+ * serving the venues instead of dropping them for one request.
+ */
+export async function venueClasses(waitMs = FETCH_TIMEOUT_MS): Promise<CatalogClass[]> {
+  if (cache && Date.now() - cache.at < cache.ttl) return cache.classes;
+  const pending = inflight ?? (inflight = fetchClasses());
+  if (waitMs >= FETCH_TIMEOUT_MS) return pending;
+  return new Promise<CatalogClass[]>((resolve) => {
+    const timer = setTimeout(() => resolve(lastGoodClasses()), waitMs);
+    // The fetch keeps running into the cache; this caller just stops waiting.
+    pending.then((classes) => { clearTimeout(timer); resolve(classes); }, () => { clearTimeout(timer); resolve(lastGoodClasses()); });
+  });
+}
+
+function fetchClasses(): Promise<CatalogClass[]> {
+  const gen = generation;
+  return (async () => {
+    try {
+      const res = await fetch(`${config.compilerUrl}/catalog`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      if (!res.ok) throw new Error(`catalog HTTP ${res.status}`);
+      const body = (await res.json()) as { classes?: CatalogClass[] };
+      const classes = Array.isArray(body.classes) ? body.classes.filter((c) => c && typeof c.id === 'string' && typeof c.cls === 'string') : [];
+      if (gen === generation) cache = { at: Date.now(), ttl: CACHE_OK_MS, classes };
+      return classes;
+    } catch {
+      // A compiler that is still booting must not poison the cache for long.
+      if (gen === generation) cache = { at: Date.now(), ttl: CACHE_FAIL_MS, classes: [] };
+      return [];
+    } finally {
+      if (gen === generation) inflight = null;
+    }
+  })();
+}
+
+/** Fills the cache at boot so the first listing does not pay for the fetch. */
+export function warmVenueCache(): void {
+  void venueClasses().catch(() => undefined);
+}
+
+/** Drops the cache; the next listing re-asks the compiler. */
+export function resetVenueCache(): void {
+  cache = null;
+  inflight = null;
+  generation++;
+}
+
+export function venueTemplateInfo(c: CatalogClass): TemplateInfo | null {
+  const meta = own(VENUES, c.id);
+  if (!meta) return null;
+  const info: TemplateInfo = {
+    id: VENUE_PREFIX + c.id,
+    name: meta.name,
+    description: `${meta.description} Uses the ${c.cls} ${c.kind === 'style' ? 'style' : 'class'} installed in the compiler image.`,
+    icon: meta.icon || '📄',
+    category: meta.category,
+    documentClass: c.cls,
+  };
+  if (c.license) {
+    info.license = licenseLabel(c.license);
+    const url = own(LICENSE_URLS, c.license);
+    if (url) info.licenseUrl = url;
+  }
+  if (c.source || c.version) {
+    info.source = { url: c.source || `https://ctan.org/pkg/${c.pkg || c.id}`, version: c.version || undefined };
+  }
+  return info;
+}
+
+/** Every installed venue as a template, alphabetical inside its category. */
+export async function venueTemplates(waitMs?: number): Promise<TemplateInfo[]> {
+  const out: TemplateInfo[] = [];
+  for (const c of await venueClasses(waitMs)) {
+    const info = venueTemplateInfo(c);
+    if (info) out.push(info);
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const REFERENCES_BIB = `@article{knuth1984,
+  author  = {Knuth, Donald E.},
+  title   = {Literate Programming},
+  journal = {The Computer Journal},
+  year    = {1984},
+  volume  = {27},
+  number  = {2},
+  pages   = {97--111},
+}
+`;
+
+/**
+ * A compilable starting point for a class the image has but ships no sample for.
+ * Deliberately generic: the venue's own author guide is the authority on the
+ * options, and the tile links to it.
+ */
+export function skeleton(c: CatalogClass, meta: VenueMeta): string {
+  const head0 = c.kind === 'style'
+    ? `\\documentclass{article}\n\\usepackage{${c.cls}}\n`
+    : `\\documentclass${meta.options ? `[${meta.options}]` : ''}{${c.cls}}\n`;
+  const packages = (meta.packages || []).map((p) => `\\usepackage{${p}}\n`).join('');
+  const head = head0 + packages;
+  const bib = meta.biblatexStyle
+    ? { pre: `\\usepackage[style=${meta.biblatexStyle},backend=biber]{biblatex}\n\\addbibresource{references.bib}\n`, post: '\\printbibliography\n' }
+    : meta.classSetsBibStyle
+      ? { pre: '', post: '\\bibliography{references}\n' }
+      : { pre: '', post: `\\bibliographystyle{${meta.bibStyle || 'plain'}}\n\\bibliography{references}\n` };
+  const body = `\\section{Introduction}\nState the problem and why it matters. Cite prior work like this~\\cite{knuth1984}.\n\n`;
+  const abstract = '\\begin{abstract}\nA one-paragraph summary of the problem, your approach, and the headline result.\n\\end{abstract}\n\n';
+  const notice = `% ${meta.name} starting point, generated by Aldine from the ${c.cls} `
+    + `${c.kind === 'style' ? 'style' : 'class'} installed in the compiler image.\n`
+    + `% Check the venue's author guide for the options and sections it requires.\n`;
+  const tail = body + bib.post + '\n\\end{document}\n';
+
+  if (meta.front === 'frontmatter') {
+    return notice + head + bib.pre
+      + '\n\\begin{document}\n\n\\begin{frontmatter}\n\n'
+      + '\\title{Your title here}\n\n'
+      + '\\author[inst1]{Your Name}\n'
+      + '\\affiliation[inst1]{organization={Your institution}, country={Your country}}\n\n'
+      + abstract
+      + '\\begin{keyword}\nfirst keyword \\sep second keyword\n\\end{keyword}\n\n'
+      + '\\end{frontmatter}\n\n'
+      + tail;
+  }
+  if (meta.front === 'inbody') {
+    return notice + head + bib.pre
+      + '\n\\begin{document}\n\n'
+      + '\\title{Your title here}\n\n'
+      + '\\author{Your Name}\n'
+      + '\\affiliation{Your institution}\n\n'
+      + abstract
+      + '\\maketitle\n\n'
+      + tail;
+  }
+  if (meta.front === 'acm') {
+    // acmart refuses an author without an institution and a country.
+    return notice + head + bib.pre
+      + '\n\\begin{document}\n\n'
+      + '\\title{Your title here}\n\n'
+      + '\\author{Your Name}\n'
+      + '\\affiliation{\n  \\institution{Your institution}\n  \\city{Your city}\n  \\country{Your country}\n}\n'
+      + '\\email{you@example.org}\n\n'
+      + abstract
+      + '\\maketitle\n\n'
+      + tail;
+  }
+  if (meta.front === 'abstract-first') {
+    return notice + head + bib.pre
+      + '\n\\title{Your title here}\n\\author{Your Name}\n\\date{\\today}\n'
+      + '\n\\begin{document}\n\n'
+      + abstract
+      + '\\maketitle\n\n'
+      + tail;
+  }
+  return notice + head + bib.pre
+    + '\n\\title{Your title here}\n\\author{Your Name}\n\\date{\\today}\n'
+    + '\n\\begin{document}\n\\maketitle\n\n'
+    + abstract
+    + tail;
+}
+
+/**
+ * Only main.tex and references.bib are seeded, so a sample document that pulls
+ * in a sibling (a body fragment, a teaser figure, the package's own .bib) would
+ * fail on the project's first compile. The compiler filters these out too; this
+ * is the trust boundary, and the generated skeleton is the fallback.
+ */
+const SIBLING_MACROS = /\\(input|include|includegraphics|subfile|lstinputlisting|verbatiminput)\s*[{[]/;
+
+export function sampleIsSelfContained(content: string): boolean {
+  // Comments are not compiled, and samples routinely park an \includegraphics
+  // example behind a %.
+  const src = content.replace(/(^|[^\\])%.*$/gm, '$1');
+  if (SIBLING_MACROS.test(src)) return false;
+  for (const m of src.matchAll(/\\(?:bibliography|addbibresource)\s*(?:\[[^\]]*\])?\{([^}]*)\}/g)) {
+    for (const name of m[1].split(',')) {
+      const n = name.trim().replace(/\.bib$/i, '');
+      if (n && n !== 'references') return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Seed files for a venue template id (`venue:<id>`): the class's own sample
+ * document when the image ships one, otherwise the generated skeleton.
+ */
+export async function venueTemplateFiles(id: string): Promise<Record<string, Buffer>> {
+  const key = id.slice(VENUE_PREFIX.length);
+  const meta = own(VENUES, key);
+  // Resolve against the same list the gallery was served from (CATALOG_WAIT_MS,
+  // last-good on a slow or failing compiler): a tile the user can see must not
+  // 400 because the catalog fetch happened to fail between listing and create.
+  const cls = (await venueClasses(CATALOG_WAIT_MS)).find((c) => c.id === key);
+  if (!meta || !cls) throw new Error(`unknown template: ${id}`);
+  const sample = cls.sample?.content;
+  const main = sample && sampleIsSelfContained(sample) ? sample : skeleton(cls, meta);
+  return {
+    'main.tex': Buffer.from(main, 'utf8'),
+    'references.bib': Buffer.from(REFERENCES_BIB, 'utf8'),
+  };
+}

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -12,7 +12,8 @@ import { flushBranchDocs, refreshBranchDocsFromDisk, evictDoc, scheduleCommit, c
 import { publishProjectEvent } from './events.js';
 import { parseBib, bibKeys, BibEntry } from './bib.js';
 import { listPlugins, pluginAssetPath } from './plugins.js';
-import { listTemplates, templateFiles } from './templates.js';
+import { listAllTemplates, resolveTemplateFiles } from './templates.js';
+import { warmVenueCache } from './catalog.js';
 import { fetchBibEntry, searchWorks } from './references.js';
 import { latexWordCount, documentFiles } from './wordcount.js';
 import { unzip, zipEntryCount, ZipError } from './unzip.js';
@@ -351,15 +352,14 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // `template: "blank"` creates a project with no files at all.
   app.post<{ Body: { name?: string; files?: Record<string, string> | null; template?: string } }>('/api/projects', async (req, reply) => {
     const { name = 'Untitled Project', files, template } = req.body || {};
-    let seed: Record<string, string> | undefined;
+    let seed: Record<string, string | Buffer> | undefined;
     if (files !== undefined && files !== null) {
       const bad = seedError(files);
       if (bad) return reply.code(400).send({ error: bad });
       seed = files;
-    }
-    if (template) {
+    }    if (template) {
       try {
-        seed = templateFiles(template);
+        seed = await resolveTemplateFiles(template);
       } catch (err: any) {
         return reply.code(400).send({ error: err.message });
       }
@@ -427,7 +427,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     });
   }
 
-  app.get('/api/templates', async () => listTemplates());
+  // Asked for at boot so the first gallery request is served from the cache
+  // instead of waiting on the compiler.
+  warmVenueCache();
+  app.get('/api/templates', async () => listAllTemplates());
 
   // What the connected compiler runs. Not project-scoped, so it is not behind
   // the project auth hook; it discloses nothing beyond a TeX Live release.

--- a/apps/server/src/store.ts
+++ b/apps/server/src/store.ts
@@ -47,8 +47,7 @@ export function listProjects(): Promise<ProjectMeta[]> {
  *  ZIP entries and may not reach `.git` or `.aldine*`: the initial commit runs
  *  git on the fresh repo, so a seeded `.git/config` would execute on the
  *  server. A rejected key or a failed write leaves no repo dir behind. */
-export async function createProject(name: string, files?: Record<string, string>, ownerId?: string): Promise<ProjectMeta> {
-  const id = newId();
+export async function createProject(name: string, files?: Record<string, string | Buffer>, ownerId?: string): Promise<ProjectMeta> {  const id = newId();
   const dir = repoDir(id);
   fs.mkdirSync(dir, { recursive: true });
   const seed = files ?? {
@@ -64,7 +63,9 @@ export async function createProject(name: string, files?: Record<string, string>
     for (const [rel, content] of Object.entries(seed)) {
       const norm = importPath(rel);
       if (norm === null || isHiddenPath(norm)) throw new Error(`file path "${rel}" is not allowed`);
-      if (typeof content !== 'string') throw new Error(`content of "${rel}" must be a string`);
+      // Templates seed Buffers (a logo or figure must not go through UTF-8);
+      // user-supplied seeds are screened by seedError before they get here.
+      if (typeof content !== 'string' && !Buffer.isBuffer(content)) throw new Error(`content of "${rel}" must be text or bytes`);
       const abs = safeJoin(dir, norm);
       fs.mkdirSync(path.dirname(abs), { recursive: true });
       fs.writeFileSync(abs, content);

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -1,16 +1,38 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { config } from './config.js';
+import { CATALOG_WAIT_MS, VENUE_PREFIX, venueTemplateFiles, venueTemplates } from './catalog.js';
 
-export interface TemplateInfo { id: string; name: string; description?: string; icon?: string; order?: number }
+export type TemplateCategory = 'Journals' | 'Conferences' | 'Theses' | 'Slides' | 'General';
 
 /** Not a directory under templates/: a project with no files and no typeset
  *  root. Listed first so the grid leads with it and never hidden by an
  *  absent templates dir. */
 export const BLANK_TEMPLATE: TemplateInfo = {
-  id: 'blank', name: 'Blank', description: 'An empty project. Add the first file yourself.', icon: '▢', order: 0,
+  id: 'blank', name: 'Blank', description: 'An empty project. Add the first file yourself.', icon: '▢', order: 0, category: 'General',
 };
 
+/** Where the template came from: upstream URL and the version it was taken at. */
+export interface TemplateSource { url: string; version?: string }
+
+export interface TemplateInfo {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  order?: number;
+  category?: TemplateCategory;
+  /** \documentclass (or style) the template starts from; venue entries only. */
+  documentClass?: string;
+  /** Human-readable license of the template files, shown on the tile. */
+  license?: string;
+  licenseUrl?: string;
+  source?: TemplateSource;
+}
+
+const CATEGORIES: TemplateCategory[] = ['Journals', 'Conferences', 'Theses', 'Slides', 'General'];
+
+/** Templates shipped as folders under templates/. */
 export function listTemplates(): TemplateInfo[] {
   const dir = config.templatesDir;
   if (!fs.existsSync(dir)) return [BLANK_TEMPLATE];
@@ -27,6 +49,7 @@ export function listTemplates(): TemplateInfo[] {
         console.warn(`templates/${name} uses the built-in template id "${BLANK_TEMPLATE.id}" and is ignored`);
         continue;
       }
+      if (!meta.category || !CATEGORIES.includes(meta.category)) meta.category = 'General';
       out.push(meta);
     } catch { /* skip broken template */ }
   }
@@ -34,19 +57,44 @@ export function listTemplates(): TemplateInfo[] {
 }
 
 /** All files of a template (except template.json), as relative-path → content. */
-export function templateFiles(id: string): Record<string, string> {
+/**
+ * Folder templates plus every venue class the compiler image carries. The
+ * folder half never waits on the network: a compiler that is reachable but
+ * silent costs CATALOG_WAIT_MS and an empty venue half, not an empty gallery.
+ */
+export async function listAllTemplates(): Promise<TemplateInfo[]> {
+  const folders = listTemplates();
+  const venues = await venueTemplates(CATALOG_WAIT_MS);
+  return [...folders, ...venues];
+}
+
+/** Gallery bookkeeping, not part of the document the user starts from. */
+const NOT_SEEDED = new Set(['template.json', 'LICENSE']);
+
+/**
+ * All files of a template, as relative-path → bytes. Buffers, not strings: a
+ * template may carry a logo or a figure, and decoding those as UTF-8 corrupts
+ * them.
+ */
+export function templateFiles(id: string): Record<string, Buffer> {
   if (id === BLANK_TEMPLATE.id) return {};
   if (id.includes('..') || id.includes('/')) throw new Error('bad template id');
   const base = path.join(config.templatesDir, id);
   if (!fs.existsSync(path.join(base, 'template.json'))) throw new Error(`unknown template: ${id}`);
-  const files: Record<string, string> = {};
+  const files: Record<string, Buffer> = {};
   const walk = (rel: string) => {
     for (const e of fs.readdirSync(path.join(base, rel), { withFileTypes: true })) {
       const relPath = rel ? `${rel}/${e.name}` : e.name;
       if (e.isDirectory()) walk(relPath);
-      else if (relPath !== 'template.json') files[relPath] = fs.readFileSync(path.join(base, relPath), 'utf8');
+      else if (!(rel === '' && NOT_SEEDED.has(e.name))) files[relPath] = fs.readFileSync(path.join(base, relPath));
     }
   };
   walk('');
   return files;
+}
+
+/** Seed files for any gallery id: a folder template or a `venue:` catalog entry. */
+export async function resolveTemplateFiles(id: string): Promise<Record<string, Buffer>> {
+  if (id.startsWith(VENUE_PREFIX)) return venueTemplateFiles(id);
+  return templateFiles(id);
 }

--- a/apps/server/test/blank-project.test.mjs
+++ b/apps/server/test/blank-project.test.mjs
@@ -42,6 +42,14 @@ const mock = http.createServer((req, res) => {
   let raw = '';
   req.on('data', (d) => { raw += d; });
   req.on('end', () => {
+    // The template gallery asks this compiler for its class catalog (GET, no
+    // body); every other call is a compile request.
+    if (req.method === 'GET') {
+      const cat = Buffer.from(JSON.stringify({ ok: true, generatedAt: new Date(0).toISOString(), classes: [] }));
+      res.writeHead(200, { 'content-type': 'application/json', 'content-length': cat.length });
+      res.end(cat);
+      return;
+    }
     requests.push(JSON.parse(raw));
     const buf = Buffer.from(JSON.stringify({ ok: false, pdf: null, log: 'mock', errors: [], durationMs: 1 }));
     res.writeHead(200, { 'content-type': 'application/json', 'content-length': buf.length });

--- a/apps/server/test/skeleton-compile.test.mjs
+++ b/apps/server/test/skeleton-compile.test.mjs
@@ -1,0 +1,56 @@
+/**
+ * The generated venue skeletons have to compile. The title block is not a
+ * cosmetic choice: REVTeX's \author is undefined in the preamble and the AMS
+ * classes want the abstract before \maketitle, so a wrong shape is a fatal
+ * error on the first typeset of a brand new project.
+ *
+ * Only the classes this machine actually has are tried, through the compiler's
+ * own catalog. BasicTeX carries two of them; a machine with no TeX Live at all,
+ * or with none of the allowlist installed, skips.
+ */
+import { execFile, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import { check } from './assert.mjs';
+
+const run = promisify(execFile);
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-skeleton-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.TEMPLATES_DIR = path.join(tmp, 'templates');
+
+const skip = (why) => { console.log(`skeleton-compile: skipped (${why})`); fs.rmSync(tmp, { recursive: true, force: true }); process.exit(0); };
+
+try { execFileSync('latexmk', ['-v'], { stdio: 'ignore' }); } catch { skip('no latexmk on this machine'); }
+
+const require = createRequire(import.meta.url);
+const compilerCatalog = require('../../compiler/catalog.js');
+const local = await compilerCatalog.getCatalog();
+if (!local.classes.length) skip('this TeX installation has none of the allowlisted venue classes');
+
+const catalog = await import('../src/catalog.ts');
+globalThis.fetch = async () => ({ ok: true, json: async () => local });
+catalog.resetVenueCache();
+
+for (const cls of local.classes) {
+  const dir = path.join(tmp, cls.id);
+  fs.mkdirSync(dir, { recursive: true });
+  const files = await catalog.venueTemplateFiles(`venue:${cls.id}`);
+  for (const [name, bytes] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), bytes);
+
+  let failure = null;
+  try {
+    await run('latexmk', ['-pdf', '-interaction=nonstopmode', '-halt-on-error', 'main.tex'], { cwd: dir, timeout: 180_000 });
+  } catch (err) {
+    failure = String(err.stdout || err.message).split('\n').filter((l) => /^!|Error/.test(l)).slice(0, 4).join(' | ');
+  }
+  check(!failure, `the ${cls.cls} skeleton compiles (${failure})`);
+  check(fs.existsSync(path.join(dir, 'main.pdf')), `the ${cls.cls} skeleton produces a PDF`);
+  console.log(`  ${cls.cls}: ok`);
+}
+
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('skeleton-compile: all checks passed');

--- a/apps/server/test/templates-check.test.mjs
+++ b/apps/server/test/templates-check.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * The templates:check gate — the reason it exists is that it fails. Each case
+ * below is a template CI must refuse: no LICENSE file, no license or source
+ * metadata, an unknown category, or a folder that is not a template at all.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { check } from './assert.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const script = path.join(repoRoot, 'scripts', 'check-templates.mjs');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-tplcheck-'));
+
+const GOOD_META = {
+  id: 'ok', name: 'Fine', description: 'A complete template.',
+  license: 'MIT', licenseUrl: 'https://opensource.org/license/mit',
+  source: { url: 'https://example.org/ok', version: '1.2.3' },
+};
+
+/** Writes one template folder and returns the dir holding it. */
+function fixture(name, { meta = GOOD_META, license = 'MIT License\n', tex = '\\documentclass{article}\n' } = {}) {
+  const dir = path.join(tmp, name);
+  const base = path.join(dir, 'tpl');
+  fs.mkdirSync(base, { recursive: true });
+  if (meta !== null) fs.writeFileSync(path.join(base, 'template.json'), typeof meta === 'string' ? meta : JSON.stringify(meta));
+  if (license !== null) fs.writeFileSync(path.join(base, 'LICENSE'), license);
+  if (tex !== null) fs.writeFileSync(path.join(base, 'main.tex'), tex);
+  return dir;
+}
+
+const run = (dir) => spawnSync(process.execPath, [script, dir], { encoding: 'utf8' });
+
+const ok = run(fixture('good'));
+check(ok.status === 0, `a complete template passes: ${ok.stderr}`);
+check(ok.stdout.includes('1 template(s) checked'), 'the passing run says what it checked');
+
+const cases = [
+  ['no LICENSE file', fixture('no-license-file', { license: null }), 'no LICENSE file'],
+  ['empty LICENSE file', fixture('empty-license', { license: '   \n' }), 'LICENSE file is empty'],
+  ['no license field', fixture('no-license', { meta: { ...GOOD_META, license: undefined } }), 'needs a "license"'],
+  ['no licenseUrl', fixture('no-license-url', { meta: { ...GOOD_META, licenseUrl: undefined } }), 'needs a "licenseUrl"'],
+  ['licenseUrl is not a URL', fixture('bad-license-url', { meta: { ...GOOD_META, licenseUrl: 'see the file' } }), 'needs a "licenseUrl"'],
+  ['no source', fixture('no-source', { meta: { ...GOOD_META, source: undefined } }), 'needs a "source"'],
+  ['source without a version', fixture('no-version', { meta: { ...GOOD_META, source: { url: 'https://example.org/x' } } }), 'source.version'],
+  ['source without a URL', fixture('no-source-url', { meta: { ...GOOD_META, source: { version: '1' } } }), 'source.url'],
+  ['unknown category', fixture('bad-category', { meta: { ...GOOD_META, category: 'Posters' } }), 'is not one of'],
+  ['no template.json', fixture('not-a-template', { meta: null }), 'no template.json'],
+  ['broken template.json', fixture('broken-json', { meta: '{oops' }), 'not valid JSON'],
+  ['no .tex file', fixture('no-tex', { tex: null }), 'nothing to start from'],
+];
+
+for (const [what, dir, message] of cases) {
+  const res = run(dir);
+  check(res.status === 1, `${what} fails the gate (exit ${res.status})`);
+  check(res.stderr.includes(message), `${what} says why: expected "${message}", got "${res.stderr.trim()}"`);
+}
+
+const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-tplempty-'));
+check(run(empty).status === 1, 'a templates directory with nothing in it fails');
+check(run(path.join(tmp, 'does-not-exist')).status === 1, 'a missing templates directory fails');
+
+// The repo's own templates must pass, or the gate is decoration.
+const repoRun = run(path.join(repoRoot, 'templates'));
+check(repoRun.status === 0, `the shipped templates pass the gate: ${repoRun.stderr}`);
+
+fs.rmSync(tmp, { recursive: true, force: true });
+fs.rmSync(empty, { recursive: true, force: true });
+console.log('templates:check: all checks passed');

--- a/apps/server/test/templates.test.mjs
+++ b/apps/server/test/templates.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * Template loader and venue catalog:
+ *  - every byte of a template survives the loader (a logo is not UTF-8)
+ *  - template.json and LICENSE are gallery bookkeeping, not seed files
+ *  - venue entries carry a category, a license and a class, from the compiler
+ *  - a sample document wins over the generated skeleton, unless it needs files
+ *    we do not ship
+ *  - the generated skeleton puts the title block where the class wants it
+ *  - a compiler with no catalog leaves the folder templates alone
+ *  - creating a project from a venue id works like a folder template
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { check, eq, throws } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-templates-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+process.env.TEMPLATES_DIR = path.join(tmp, 'templates');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+// Every byte value, including NUL and everything above 0x7F: UTF-8 decoding
+// replaces the invalid sequences here with U+FFFD and the file is destroyed.
+const BINARY = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+
+const tplDir = process.env.TEMPLATES_DIR;
+fs.mkdirSync(path.join(tplDir, 'demo', 'figs'), { recursive: true });
+fs.writeFileSync(path.join(tplDir, 'demo', 'template.json'), JSON.stringify({
+  id: 'demo', name: 'Demo', description: 'A demo template.', order: 1,
+  license: 'MIT', licenseUrl: 'https://opensource.org/license/mit',
+  source: { url: 'https://example.org/demo', version: '1.0' },
+}));
+fs.writeFileSync(path.join(tplDir, 'demo', 'main.tex'), '\\documentclass{article}\n\\begin{document}Hi\\end{document}\n');
+fs.writeFileSync(path.join(tplDir, 'demo', 'LICENSE'), 'MIT License\n');
+fs.writeFileSync(path.join(tplDir, 'demo', 'logo.png'), BINARY);
+fs.writeFileSync(path.join(tplDir, 'demo', 'figs', 'plot.pdf'), BINARY);
+fs.mkdirSync(path.join(tplDir, 'slides'), { recursive: true });
+fs.writeFileSync(path.join(tplDir, 'slides', 'template.json'), JSON.stringify({ name: 'Slides', category: 'Slides', order: 2 }));
+fs.writeFileSync(path.join(tplDir, 'slides', 'main.tex'), '\\documentclass{beamer}\n');
+
+const { listTemplates, listAllTemplates, templateFiles } = await import('../src/templates.ts');
+const catalog = await import('../src/catalog.ts');
+
+// ---- binary safety ----
+const files = templateFiles('demo');
+check(Buffer.isBuffer(files['logo.png']), 'template files are Buffers, not decoded strings');
+check(files['logo.png'].equals(BINARY), 'a binary file survives the loader byte for byte');
+check(files['figs/plot.pdf'].equals(BINARY), 'a binary file in a subdirectory survives too');
+eq(Object.keys(files).sort(), ['figs/plot.pdf', 'logo.png', 'main.tex'], 'template.json and LICENSE are not seeded into projects');
+
+await throws(async () => templateFiles('../secrets'), 'bad template id', 'a traversing id is refused');
+await throws(async () => templateFiles('demo/figs'), 'bad template id', 'a nested id is refused');
+await throws(async () => templateFiles('nope'), 'unknown template', 'an unknown template is refused');
+
+// ---- folder metadata ----
+const folders = listTemplates();
+// 'blank' is a built-in tile, not a folder, and leads the grid (#8).
+eq(folders.map((t) => t.id), ['blank', 'demo', 'slides'], 'the blank tile leads the folder templates');
+const demo = folders.find((t) => t.id === 'demo');
+eq(demo.category, 'General', 'a template.json without a category lands in General');
+eq(demo.license, 'MIT', 'the license reaches the gallery');
+eq(folders.find((t) => t.id === 'slides').category, 'Slides', 'a declared category is kept');
+
+// ---- venue catalog ----
+const CATALOG = {
+  ok: true,
+  classes: [
+    { id: 'elsarticle', cls: 'elsarticle', kind: 'class', pkg: 'elsarticle', license: 'lppl1.3c', version: '3.4', source: 'https://ctan.org/pkg/elsarticle', sample: null },
+    { id: 'amsart', cls: 'amsart', kind: 'class', pkg: 'amscls', license: 'lppl1.3c', sample: { file: 'sample.tex', content: '% the class ships this\n\\documentclass{amsart}\n' } },
+    { id: 'neurips', cls: 'neurips_2024', kind: 'style', pkg: 'neurips', license: null, sample: null },
+    { id: 'not-a-venue', cls: 'whatever', kind: 'class', sample: null },
+  ],
+};
+let fetchCalls = 0;
+globalThis.fetch = async () => { fetchCalls++; return { ok: true, json: async () => CATALOG }; };
+catalog.resetVenueCache();
+
+const venues = await catalog.venueTemplates();
+eq(venues.map((t) => t.id).sort(), ['venue:amsart', 'venue:elsarticle', 'venue:neurips'], 'only allowlisted venues become templates');
+const els = venues.find((t) => t.id === 'venue:elsarticle');
+eq(els.category, 'Journals', 'elsarticle is a journal');
+eq(els.license, 'LPPL 1.3c', 'the TeX Live license id is shown the way people write it');
+eq(els.licenseUrl, 'https://www.latex-project.org/lppl/lppl-1-3c.txt', 'the license links to its text');
+eq(els.documentClass, 'elsarticle', 'the tile knows which class it starts from');
+eq(venues.find((t) => t.id === 'venue:neurips').category, 'Conferences', 'NeurIPS is a conference');
+
+await catalog.venueTemplates();
+eq(fetchCalls, 1, 'the catalog is fetched once and cached');
+
+// A TTL rollover must not drop the venue half of the gallery: the refetch runs
+// past the wait, and the listing answers with the last catalog the compiler
+// gave rather than an empty list.
+const realNow = Date.now;
+globalThis.fetch = () => new Promise(() => {});
+Date.now = () => realNow() + 11 * 60_000;
+const stale = await catalog.venueTemplates(catalog.CATALOG_WAIT_MS);
+Date.now = realNow;
+eq(stale.map((t) => t.id).sort(), ['venue:amsart', 'venue:elsarticle', 'venue:neurips'], 'an expired cache still answers while the refetch is in flight');
+
+// A fetch that resetVenueCache() abandoned settles later; it must not write its
+// failure over the cache a caller has filled since.
+catalog.resetVenueCache();
+let failOrphan;
+globalThis.fetch = () => new Promise((_, reject) => { failOrphan = reject; });
+const orphan = catalog.venueTemplates();
+catalog.resetVenueCache();
+fetchCalls = 0;
+globalThis.fetch = async () => { fetchCalls++; return { ok: true, json: async () => CATALOG }; };
+eq((await catalog.venueTemplates()).length, 3, 'the reset re-asks the compiler');
+failOrphan(new Error('abandoned'));
+await orphan;
+eq((await catalog.venueTemplates()).map((t) => t.id).sort(), ['venue:amsart', 'venue:elsarticle', 'venue:neurips'], 'an abandoned fetch does not clobber the cache that replaced it');
+eq(fetchCalls, 1, 'nor does it drop the in-flight dedup');
+
+const all = await listAllTemplates();
+eq(all.filter((t) => !t.id.startsWith('venue:')).map((t) => t.id), ['blank', 'demo', 'slides'], 'folder templates stay first');
+check(all.length === 6, 'the gallery is the blank tile, the folder templates and the venues');
+
+// ---- seed files per venue ----
+const skeleton = await catalog.venueTemplateFiles('venue:elsarticle');
+check(Buffer.isBuffer(skeleton['main.tex']), 'venue seeds are Buffers too');
+const tex = skeleton['main.tex'].toString('utf8');
+check(tex.includes('\\documentclass[preprint,review,12pt]{elsarticle}'), 'the skeleton names the class');
+check(tex.includes('\\begin{frontmatter}'), 'elsarticle gets its frontmatter block');
+check(tex.includes('\\bibliographystyle{elsarticle-num}'), 'the skeleton uses the class\u2019s usual bib style');
+check(tex.includes('\\begin{abstract}') && tex.includes('\\section{Introduction}'), 'the skeleton has an abstract and a section');
+check(skeleton['references.bib'].toString('utf8').includes('@article'), 'a bibliography file comes with it');
+
+const sampled = await catalog.venueTemplateFiles('venue:amsart');
+eq(sampled['main.tex'].toString('utf8'), '% the class ships this\n\\documentclass{amsart}\n', 'the class\u2019s own sample wins over the skeleton');
+
+const styled = (await catalog.venueTemplateFiles('venue:neurips'))['main.tex'].toString('utf8');
+check(styled.includes('\\documentclass{article}') && styled.includes('\\usepackage{neurips_2024}'), 'a style-file venue loads the style on top of article');
+
+await throws(async () => catalog.venueTemplateFiles('venue:nope'), 'unknown template', 'an unknown venue is refused');
+
+// ---- samples that need files we do not ship, and hostile keys ----
+const doc = (body) => `\\begin{document}\n${body}\n\\end{document}\n`;
+const SAMPLES = {
+  ok: true,
+  classes: [
+    { id: 'llncs', cls: 'llncs', kind: 'class', sample: { file: 's.tex', content: doc('\\input{samplebody-conf}') } },
+    { id: 'mnras', cls: 'mnras', kind: 'class', sample: { file: 's.tex', content: doc('\\bibliography{example}') } },
+    { id: 'jfm', cls: 'jfm', kind: 'class', sample: { file: 's.tex', content: doc('% \\includegraphics{teaser}\n\\bibliography{references}') } },
+    { id: 'revtex', cls: 'revtex4-2', kind: 'class' },
+    { id: 'amsart', cls: 'amsart', kind: 'class' },
+    // Keys that resolve through Object.prototype on a bare index read.
+    { id: 'constructor', cls: 'Object', kind: 'class', license: 'toString' },
+  ],
+};
+globalThis.fetch = async () => ({ ok: true, json: async () => SAMPLES });
+catalog.resetVenueCache();
+
+const generated = (id) => catalog.venueTemplateFiles(`venue:${id}`).then((f) => f['main.tex'].toString('utf8'));
+check((await generated('llncs')).includes('generated by Aldine'), 'a sample that \\inputs a sibling falls back to the skeleton');
+check((await generated('mnras')).includes('\\bibliography{references}'), 'a sample naming another .bib falls back to the skeleton');
+check((await generated('jfm')).includes('% \\includegraphics{teaser}'), 'a commented-out \\includegraphics does not disqualify a sample');
+
+// The title block shape is fatal, not cosmetic: REVTeX has no \author in the
+// preamble, and the AMS classes want the abstract before \maketitle.
+const revtex = await generated('revtex');
+check(revtex.indexOf('\\begin{document}') < revtex.indexOf('\\author{'), 'the REVTeX title block sits inside the document');
+check(revtex.indexOf('\\begin{abstract}') < revtex.indexOf('\\maketitle'), 'REVTeX gets its abstract before \\maketitle');
+const amsart = await generated('amsart');
+check(amsart.indexOf('\\title{') < amsart.indexOf('\\begin{document}'), 'the AMS title block stays in the preamble');
+check(amsart.indexOf('\\begin{abstract}') < amsart.indexOf('\\maketitle'), 'the AMS abstract comes before \\maketitle');
+
+const hostile = await catalog.venueTemplates();
+check(!hostile.some((t) => t.id === 'venue:constructor'), 'an id that names an Object.prototype key is not a template');
+await throws(async () => catalog.venueTemplateFiles('venue:constructor'), 'unknown template', 'nor can a project be created from one');
+
+// The compiler filters the same samples out at the source, so the two sides
+// cannot drift into shipping a sample nobody accepts (or nobody rejects).
+const { selfContained } = createRequire(import.meta.url)('../../compiler/catalog.js');
+check(!selfContained(doc('\\input{samplebody-conf}')), 'the compiler rejects a sample that \\inputs a sibling');
+check(!selfContained(doc('\\includegraphics{teaser.pdf}')), 'the compiler rejects a sample that needs a figure');
+check(!selfContained(doc('\\addbibresource{sample-base.bib}')), 'the compiler rejects a sample naming another .bib');
+check(selfContained(doc('% \\includegraphics{teaser}\n\\bibliography{references}')), 'the compiler keeps a self-contained sample');
+
+// ---- a compiler that is reachable but silent ----
+globalThis.fetch = () => new Promise((_, reject) => {
+  const t = setTimeout(() => reject(new Error('silent compiler')), 30_000);
+  t.unref?.();
+});
+catalog.resetVenueCache();
+const startedAt = Date.now();
+const withoutCatalog = await listAllTemplates();
+check(Date.now() - startedAt < 4_000, 'a silent compiler does not hold the template listing open');
+eq(withoutCatalog.map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates answer while the catalog is still in flight');
+
+// ---- a compiler without a catalog ----
+globalThis.fetch = async () => { throw new Error('connection refused'); };
+catalog.resetVenueCache();
+eq(await catalog.venueTemplates(), [], 'no catalog is an empty list, not an error');
+eq((await listAllTemplates()).map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates carry the gallery on their own');
+
+// ---- creating a project from either kind ----
+globalThis.fetch = async () => ({ ok: true, json: async () => CATALOG });
+catalog.resetVenueCache();
+
+const { default: Fastify } = await import('fastify');
+const { initDb, closeDb } = await import('../src/db/index.ts');
+const { registerRoutes } = await import('../src/routes.ts');
+await initDb();
+const app = Fastify({ logger: false });
+await registerRoutes(app);
+await app.ready();
+
+const create = async (template) => {
+  const res = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: template, template } });
+  check(res.statusCode === 200, `creating from ${template} answers 200, got ${res.statusCode} ${res.body}`);
+  return JSON.parse(res.body).id;
+};
+const projectFile = (id, rel) => fs.readFileSync(path.join(process.env.DATA_DIR, 'projects', id, rel));
+
+const fromFolder = await create('demo');
+check(projectFile(fromFolder, 'logo.png').equals(BINARY), 'the logo reaches the new project unmangled');
+check(!fs.existsSync(path.join(process.env.DATA_DIR, 'projects', fromFolder, 'LICENSE')), 'the template LICENSE is not copied into the paper');
+
+const fromVenue = await create('venue:elsarticle');
+check(projectFile(fromVenue, 'main.tex').toString('utf8').includes('{elsarticle}'), 'a venue project starts from that class');
+
+const bad = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: 'x', template: 'venue:nope' } });
+eq(bad.statusCode, 400, 'an unknown venue id is a 400, not a crash');
+
+const listed = JSON.parse((await app.inject({ method: 'GET', url: '/api/templates' })).body);
+check(listed.some((t) => t.id === 'venue:elsarticle' && t.category === 'Journals'), 'GET /api/templates merges the catalog in');
+
+await app.close();
+await closeDb();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('templates: all checks passed');

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -78,7 +78,19 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-export interface TemplateInfo { id: string; name: string; description?: string; icon?: string }
+export type TemplateCategory = 'Journals' | 'Conferences' | 'Theses' | 'Slides' | 'General';
+export interface TemplateInfo {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  category?: TemplateCategory;
+  documentClass?: string;
+  license?: string;
+  licenseUrl?: string;
+  source?: { url: string; version?: string };
+}
+
 /** What /api/projects/import decided while placing the archive. */
 export interface ImportedProject extends ProjectSummary {
   import: { engine: string; engineReason: string | null; transcoded: string[] };

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -161,6 +161,36 @@
 .tpl__icon { font-size: 16px; }
 .tpl__name { font-weight: 600; font-size: 13px; }
 .tpl__desc { font-size: 11px; color: var(--text-2); line-height: 1.35; }
+.tpl__license { font-size: 10px; color: var(--text-2); opacity: 0.8; margin-top: 4px; }
+.tpl-search { position: relative; margin-top: 12px; }
+.tpl-search .input { padding-right: 30px; }
+.tpl-search__clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  padding: 4px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: var(--text-2);
+  cursor: pointer;
+}
+.tpl-search__clear:hover { background: var(--bg-hover); color: var(--text); }
+.tpl-choice { font-size: 11px; color: var(--text-2); margin: 8px 0 0; }
+/* The gallery grows with the compiler image (hundreds of venues); the modal must not. */
+.tpl-gallery { max-height: 44vh; overflow-y: auto; margin-top: 4px; }
+.tpl-group + .tpl-group { margin-top: 10px; }
+.tpl-group__label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-2);
+  margin-top: 10px;
+}
+.tpl-empty { font-size: 12px; color: var(--text-2); margin: 12px 0 0; }
 
 /* ---------- login ---------- */
 .login { min-height: 100%; display: flex; align-items: center; justify-content: center; padding: 24px; }

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { api, ApiError, ProjectSummary, TemplateInfo } from '../api';
+import { api, ApiError, ProjectSummary, TemplateCategory, TemplateInfo } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
 import Modal from '../components/Modal';
@@ -20,14 +20,23 @@ import { importSummary } from '../util/engines';
 const IMPORT_MAX_ZIP_MB = 60;
 const IMPORT_MAX_ZIP_BYTES = IMPORT_MAX_ZIP_MB * 1024 * 1024;
 
+/** Gallery order; a category with no template in it is not drawn. */
+const TEMPLATE_CATEGORIES: TemplateCategory[] = ['General', 'Journals', 'Conferences', 'Theses', 'Slides'];
+
+function matchesQuery(t: TemplateInfo, q: string): boolean {
+  const hay = [t.name, t.description, t.category, t.documentClass, t.id].join(' ').toLowerCase();
+  return q.split(/\s+/).every((word) => hay.includes(word));
+}
+
 export default function Home() {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [creating, setCreating] = useState(false);
   const [themeChoice, setThemeChoice] = useState(getTheme());
   const [newName, setNewName] = useState('');
-  const [templates, setTemplates] = useState<TemplateInfo[]>([]);
+  const [templates, setTemplates] = useState<TemplateInfo[] | null>(null);
   const [template, setTemplate] = useState('article');
+  const [templateQuery, setTemplateQuery] = useState('');
   const [sharing, setSharing] = useState<ProjectSummary | null>(null);
   const [showAccount, setShowAccount] = useState(false);
   const [showGithub, setShowGithub] = useState(false);
@@ -61,11 +70,15 @@ export default function Home() {
     }).catch(() => setTemplates([]));
   }, []);
 
+  // The gallery keeps its choice while the search narrows it, so the tile that
+  // Create will actually use is often filtered away: name it in the dialog.
+  const chosen = templates?.find((t) => t.id === template) ?? null;
+  const closeCreate = () => { setCreating(false); setTemplateQuery(''); };
+
   const create = async () => {
     const name = newName.trim() || 'Untitled Project';
     try {
-      const p = await api.createProject(name, undefined, templateToPost(templates, template));
-      navigate(`/p/${p.id}`);
+      const p = await api.createProject(name, undefined, templateToPost(templates ?? [], template));      navigate(`/p/${p.id}`);
     } catch (err: any) {
       toast(`Could not create project: ${err.message}`, 'error');
     }
@@ -291,7 +304,7 @@ export default function Home() {
       )}
 
       {creating && (
-        <Modal onClose={() => setCreating(false)} label="New project">
+        <Modal onClose={closeCreate} label="New project">
           <div>
             <h2>New project</h2>
             <p className="modal__sub">Name it, pick a starting point, start writing.</p>
@@ -302,27 +315,75 @@ export default function Home() {
               value={newName}
               data-testid="new-project-name"
               onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') create(); if (e.key === 'Escape') setCreating(false); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') create(); }}
             />
-            {templates.length > 0 && (
-              <div className="tpl-grid" data-testid="template-grid">
-                {templates.map((t) => (
-                  <button
-                    key={t.id}
-                    className={`tpl ${template === t.id ? 'tpl--active' : ''}`}
-                    data-testid={`template-${t.id}`}
-                    onClick={() => setTemplate(t.id)}
-                    title={t.description}
-                  >
-                    <span className="tpl__icon">{t.icon || '📄'}</span>
-                    <span className="tpl__name">{t.name}</span>
-                    <span className="tpl__desc">{t.description}</span>
-                  </button>
-                ))}
-              </div>
+            {templates === null && <p className="tpl-empty">Loading templates…</p>}
+            {templates !== null && templates.length > 0 && (
+              <>
+                <div className="tpl-search">
+                  <input
+                    className="input"
+                    placeholder="Search templates, for example IEEE or NeurIPS"
+                    aria-label="Search templates"
+                    value={templateQuery}
+                    data-testid="template-search"
+                    onChange={(e) => setTemplateQuery(e.target.value)}
+                  />
+                  {/* Escape belongs to the dialog: the modal closes on it before
+                      any handler here could clear the query. */}
+                  {templateQuery && (
+                    <button
+                      className="tpl-search__clear"
+                      aria-label="Clear the template search"
+                      data-testid="template-search-clear"
+                      onClick={() => setTemplateQuery('')}
+                    >
+                      <IconX />
+                    </button>
+                  )}
+                </div>
+                <div className="tpl-gallery" data-testid="template-grid">
+                  {(() => {
+                    const q = templateQuery.trim().toLowerCase();
+                    const shown = q ? templates.filter((t) => matchesQuery(t, q)) : templates;
+                    if (!shown.length) {
+                      return <p className="tpl-empty" data-testid="template-empty">No template matches that. Create still starts from {chosen ? chosen.name : 'the built-in article'}.</p>;
+                    }
+                    return TEMPLATE_CATEGORIES.map((cat) => {
+                      const group = shown.filter((t) => (t.category || 'General') === cat);
+                      if (!group.length) return null;
+                      return (
+                        <div key={cat} className="tpl-group" data-testid={`template-category-${cat}`}>
+                          <div className="tpl-group__label">{cat}</div>
+                          <div className="tpl-grid">
+                            {group.map((t) => (
+                              <button
+                                key={t.id}
+                                className={`tpl ${template === t.id ? 'tpl--active' : ''}`}
+                                data-testid={`template-${t.id}`}
+                                onClick={() => setTemplate(t.id)}
+                                title={t.description}
+                              >
+                                <span className="tpl__icon">{t.icon || '📄'}</span>
+                                <span className="tpl__name">{t.name}</span>
+                                <span className="tpl__desc">{t.description}</span>
+                                {t.license && <span className="tpl__license" data-testid={`template-license-${t.id}`}>{t.license}</span>}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    });
+                  })()}
+                </div>
+                <p className="tpl-choice" data-testid="template-choice">
+                  Starting from {chosen ? chosen.name : 'the built-in article'}
+                  {chosen?.license ? ` (${chosen.license})` : ''}
+                </p>
+              </>
             )}
             <div className="modal__row">
-              <button className="btn" onClick={() => setCreating(false)}>Cancel</button>
+              <button className="btn" onClick={closeCreate}>Cancel</button>
               <button className="btn btn--primary" onClick={create} data-testid="create-project">Create</button>
             </div>
           </div>

--- a/e2e/tests/28-template-gallery.spec.ts
+++ b/e2e/tests/28-template-gallery.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '../fixtures';
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * The venue half of the gallery is whatever the compiler image has installed:
+ * on full TeX Live that is every publisher class, on the BasicTeX a laptop
+ * carries it can be nothing at all. An empty catalog is a supported state, so
+ * the venue tests skip there with a message; the folder templates and the
+ * search box are asserted in a test that never skips.
+ */
+interface Template {
+  id: string;
+  name: string;
+  category?: string;
+  documentClass?: string;
+  license?: string;
+}
+
+async function templates(request: APIRequestContext): Promise<Template[]> {
+  const res = await request.get('/api/templates');
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
+
+/**
+ * The venue half fills in behind the folder templates, so an empty answer right
+ * after boot may only mean the compiler has not finished its sweep. Poll before
+ * concluding the image has none of the classes.
+ */
+async function venuesOrSkip(request: APIRequestContext): Promise<Template[]> {
+  let venues: Template[] = [];
+  for (let i = 0; i < 15 && venues.length === 0; i++) {
+    venues = (await templates(request)).filter((t) => t.id.startsWith('venue:'));
+    if (!venues.length) await new Promise((r) => setTimeout(r, 1000));
+  }
+  test.skip(venues.length === 0, 'the compiler image ships none of the venue classes (BasicTeX): the catalog is empty');
+  return venues;
+}
+
+async function openGallery(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.getByTestId('new-project').click();
+  await expect(page.getByTestId('template-grid')).toBeVisible();
+}
+
+test.describe('template gallery', () => {
+  test('the folder templates and the search box are always there', async ({ page }) => {
+    await openGallery(page);
+
+    await expect(page.getByTestId('template-category-General')).toBeVisible();
+    for (const id of ['article', 'beamer', 'iac-paper', 'report']) {
+      await expect(page.getByTestId(`template-${id}`)).toBeVisible();
+      await expect(page.getByTestId(`template-license-${id}`)).not.toBeEmpty();
+    }
+
+    const search = page.getByTestId('template-search');
+    await expect(search).toBeVisible();
+    await search.fill('presentation');
+    await expect(page.getByTestId('template-beamer')).toBeVisible();
+    await expect(page.getByTestId('template-article')).toHaveCount(0);
+    await search.fill('zzzz no such venue');
+    await expect(page.getByTestId('template-empty')).toBeVisible();
+    // The choice survives a filter that hides its tile, and both the empty
+    // state and the footer say what Create will actually make.
+    await expect(page.getByTestId('template-empty')).toContainText('Article');
+    await expect(page.getByTestId('template-choice')).toContainText('Article');
+    await page.getByTestId('template-search-clear').click();
+    await expect(search).toHaveValue('');
+    await expect(page.getByTestId('template-article')).toBeVisible();
+
+    // The four folder templates still create a project the old way.
+    await page.getByTestId('new-project-name').fill('Folder Template Paper');
+    await page.getByTestId('template-report').click();
+    await expect(page.getByTestId('template-choice')).toContainText('Report');
+    await page.getByTestId('create-project').click();
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+  });
+
+  test('searching finds a venue tile with its licence', async ({ page, request }) => {
+    const venue = (await venuesOrSkip(request))[0];
+    await openGallery(page);
+
+    await page.getByTestId('template-search').fill(venue.name);
+    const tile = page.getByTestId(`template-${venue.id}`);
+    await expect(tile).toBeVisible();
+    await expect(tile).toContainText(venue.name);
+    if (venue.license) await expect(page.getByTestId(`template-license-${venue.id}`)).toContainText(venue.license);
+    // Venues live in their own category, never in the folder-template bucket.
+    expect(venue.category).not.toBe('General');
+    await expect(page.getByTestId(`template-category-${venue.category}`)).toBeVisible();
+  });
+
+  test('a project created from a venue tile starts from that class', async ({ page, request }) => {
+    const venue = (await venuesOrSkip(request))[0];
+    await openGallery(page);
+
+    await page.getByTestId('new-project-name').fill('Venue Paper');
+    await page.getByTestId('template-search').fill(venue.name);
+    await page.getByTestId(`template-${venue.id}`).click();
+    await expect(page.getByTestId('template-choice')).toContainText(venue.name);
+    await page.getByTestId('create-project').click();
+
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+    await expect(page.getByTestId('file-references.bib')).toBeVisible();
+
+    const id = new URL(page.url()).pathname.split('/').pop()!;
+    const file = await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`);
+    expect(file.ok()).toBeTruthy();
+    const source = await file.text();
+    expect(source).toContain(venue.documentClass!);
+    expect(source).toMatch(/\\(documentclass|usepackage)/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "npm run build -w apps/web && npm run build -w apps/server",
     "notices": "node scripts/gen-notices.mjs",
     "notices:check": "node scripts/gen-notices.mjs --check",
+    "templates:check": "node scripts/check-templates.mjs",
     "test:e2e": "npx playwright test -c e2e",
     "test:e2e:auth": "npx playwright test -c e2e/playwright.auth.config.ts"
   },

--- a/scripts/check-templates.mjs
+++ b/scripts/check-templates.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Template licence gate: every folder under templates/ must say what its files
+ * are licensed as, where they came from, and carry the licence text.
+ *
+ * A template without that cannot be shipped — the gallery shows a licence on
+ * every tile, and a starter file whose terms nobody recorded is one nobody can
+ * safely copy into a paper.
+ *
+ * Usage: node scripts/check-templates.mjs [templatesDir]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dir = path.resolve(process.argv[2] || path.join(repoRoot, 'templates'));
+
+const CATEGORIES = ['Journals', 'Conferences', 'Theses', 'Slides', 'General'];
+const isUrl = (v) => typeof v === 'string' && /^https?:\/\/\S+$/.test(v);
+const isText = (v) => typeof v === 'string' && v.trim().length > 0;
+
+function checkTemplate(name) {
+  const base = path.join(dir, name);
+  const errors = [];
+  const metaPath = path.join(base, 'template.json');
+  if (!fs.existsSync(metaPath)) return [`${name}: no template.json (a folder under templates/ must be a template)`];
+
+  let meta;
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  } catch (err) {
+    return [`${name}: template.json is not valid JSON (${err.message})`];
+  }
+
+  if (!isText(meta.name)) errors.push(`${name}: template.json needs a "name"`);
+  if (!isText(meta.license)) errors.push(`${name}: template.json needs a "license" (e.g. "MIT", "LPPL 1.3c")`);
+  if (!isUrl(meta.licenseUrl)) errors.push(`${name}: template.json needs a "licenseUrl" pointing at the licence text`);
+  if (!meta.source || typeof meta.source !== 'object') {
+    errors.push(`${name}: template.json needs a "source" with the upstream "url" and "version"`);
+  } else {
+    if (!isUrl(meta.source.url)) errors.push(`${name}: source.url must be the upstream http(s) URL`);
+    if (!isText(meta.source.version)) errors.push(`${name}: source.version must say which upstream version this copy is`);
+  }
+  if (meta.category !== undefined && !CATEGORIES.includes(meta.category)) {
+    errors.push(`${name}: category "${meta.category}" is not one of ${CATEGORIES.join(', ')}`);
+  }
+
+  const licensePath = path.join(base, 'LICENSE');
+  if (!fs.existsSync(licensePath)) errors.push(`${name}: no LICENSE file next to template.json`);
+  else if (!isText(fs.readFileSync(licensePath, 'utf8'))) errors.push(`${name}: LICENSE file is empty`);
+
+  const hasTex = fs.readdirSync(base).some((f) => f.endsWith('.tex'));
+  if (!hasTex) errors.push(`${name}: no .tex file, so there is nothing to start from`);
+
+  return errors;
+}
+
+if (!fs.existsSync(dir)) {
+  console.error(`No templates directory at ${dir}`);
+  process.exit(1);
+}
+
+const names = fs.readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name).sort();
+const errors = names.flatMap(checkTemplate);
+
+if (!names.length) {
+  console.error(`No templates found in ${dir}`);
+  process.exit(1);
+}
+if (errors.length) {
+  for (const e of errors) console.error(`  ✗ ${e}`);
+  console.error(`\n${errors.length} problem(s) in ${names.length} template(s). Add the missing licence metadata to template.json and a LICENSE file.`);
+  process.exit(1);
+}
+console.log(`${names.length} template(s) checked: ${names.join(', ')}. Licence metadata and LICENSE files present.`);

--- a/templates/article/LICENSE
+++ b/templates/article/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aldine contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/article/template.json
+++ b/templates/article/template.json
@@ -3,5 +3,12 @@
   "name": "Article",
   "description": "A clean article with biblatex — the right default for most papers.",
   "icon": "📄",
-  "order": 1
+  "order": 1,
+  "category": "General",
+  "license": "MIT",
+  "licenseUrl": "https://opensource.org/license/mit",
+  "source": {
+    "url": "https://github.com/trahloff/Aldine/tree/main/templates/article",
+    "version": "0.3.0"
+  }
 }

--- a/templates/beamer/LICENSE
+++ b/templates/beamer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aldine contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/beamer/template.json
+++ b/templates/beamer/template.json
@@ -3,5 +3,12 @@
   "name": "Presentation",
   "description": "Beamer slides with a restrained metropolis-like look.",
   "icon": "🎞",
-  "order": 3
+  "order": 3,
+  "category": "General",
+  "license": "MIT",
+  "licenseUrl": "https://opensource.org/license/mit",
+  "source": {
+    "url": "https://github.com/trahloff/Aldine/tree/main/templates/beamer",
+    "version": "0.3.0"
+  }
 }

--- a/templates/iac-paper/LICENSE
+++ b/templates/iac-paper/LICENSE
@@ -1,0 +1,15 @@
+Copyright 2026 Toby Rahloff
+
+This template, including the iac class and its biblatex styles, may be
+distributed and/or modified under the conditions of the LaTeX Project Public
+License, either version 1.3c of this license or (at your option) any later
+version. The latest version of this license is at
+
+    https://www.latex-project.org/lppl.txt
+
+This work has the LPPL maintenance status `maintained'. The Current Maintainer
+is Toby Rahloff.
+
+The iac class is an unofficial, clean-room implementation of the formatting the
+IAF/IAC manuscript guidelines describe. It is not affiliated with or endorsed by
+the International Astronautical Federation.

--- a/templates/iac-paper/template.json
+++ b/templates/iac-paper/template.json
@@ -3,5 +3,12 @@
   "name": "IAC Conference Paper",
   "description": "International Astronautical Congress manuscript (unofficial iac class, biblatex). Not affiliated with or endorsed by the IAF.",
   "icon": "🛰",
-  "order": 2
+  "order": 2,
+  "category": "General",
+  "license": "LPPL 1.3c",
+  "licenseUrl": "https://www.latex-project.org/lppl/lppl-1-3c.txt",
+  "source": {
+    "url": "https://github.com/trahloff/Aldine/tree/main/templates/iac-paper",
+    "version": "0.3.0"
+  }
 }

--- a/templates/report/LICENSE
+++ b/templates/report/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aldine contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/report/template.json
+++ b/templates/report/template.json
@@ -3,5 +3,12 @@
   "name": "Report / Thesis",
   "description": "Chapters, table of contents, and a bibliography — for longer documents.",
   "icon": "📚",
-  "order": 4
+  "order": 4,
+  "category": "General",
+  "license": "MIT",
+  "licenseUrl": "https://opensource.org/license/mit",
+  "source": {
+    "url": "https://github.com/trahloff/Aldine/tree/main/templates/report",
+    "version": "0.3.0"
+  }
 }


### PR DESCRIPTION
Closes #9.

- The New project dialog groups templates by category (General first, then Journals, Conferences, Theses, Slides), has a search box, and shows each template's licence.
- Beside the four folder templates, the gallery offers one per venue class the compiler image actually carries: the compiler answers `GET /catalog` with what `kpsewhich` finds from an allowlist and the licence `tlmgr` reports. No publisher file is vendored.
- Aldine seeds either the class's own sample document or a generated skeleton (title block, abstract, a section, the class's usual bibliography style).
- Every template folder carries a LICENSE, and template.json carries license, licenseUrl and source. `npm run templates:check` fails without them, and CI runs it.
- The template loader reads files as bytes, so a logo or figure in a template survives into the project.

**Measured, not estimated.** I ran the catalog probe inside the full TeX Live image and compiled every generated skeleton in it. A full image yields **ten** venues: elsarticle, IEEEtran, IEEEconf, acmart, REVTeX 4.2, LNCS, JMLR, AMS article, MNRAS, APA 7. All ten compile to a PDF. The issue's premise of hundreds does not hold: agujournal, Copernicus, MDPI, svjour3, siamart and JFM are not in TeX Live at all, and the conference kits (NeurIPS, ICLR, ACL, CVPR) are published as zips, so they need the curated route instead. AASTeX 7 is excluded on purpose: its author block rejects a generically generated skeleton.

Three skeletons needed venue-specific fixes found this way: acmart needs an affiliation with an institution and a country, MNRAS needs its `usenatbib` option, and JMLR sets its own bibliography style so ours must not.

Checks: server and web typecheck, server unit suite (new templates, check-script and skeleton-compile tests), web unit 26/26, e2e 28-template-gallery + 20-blank-project 7/7, 17-feedback-round1 and 01-home green.