### PR TITLE
feat: venue kits downloaded from the publisher on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- Venue kits fetched from the publisher: 25 more venues in the template
+  gallery (NeurIPS, ICLR, ICML, AISTATS, AAAI, IJCAI, ECAI, ACL/EMNLP/NAACL,
+  COLING, CVPR, ICCV, ECCV, USENIX and USENIX Security, SIAM, MDPI,
+  Copernicus, Springer Nature, IOP, Taylor and Francis, Frontiers, eLife,
+  Wiley, Optica, Cell Press) whose class files TeX Live does not carry. The
+  tile says "Downloads the official kit from <host>"; picking it downloads the
+  publisher's own kit when the project is created, takes only the files the
+  registry names, and starts the paper from the kit's own document. Aldine
+  redistributes nothing: no publisher file is stored in the repo, and each
+  tile links the venue's terms instead of claiming a licence.
+  `templates/venues.json` is the only source of kit URLs, so no request can
+  influence what is fetched; an entry that is not https, or points off the
+  host it declares, is dropped when the registry loads. Caps are 20 seconds,
+  25 MB and three same-host redirects, and a successful kit is cached under
+  `CACHE_DIR/venue-kits/` for 7 days (and used at any age when the publisher
+  is down); the cache is keyed to the registry entry, so changing a venue's
+  kit URL or file list refetches instead of serving last year's files. A kit
+  that cannot be downloaded never fails project creation: the project is
+  created from a skeleton plus a `README-venue.md` naming the kit and what to
+  do, and a toast says so. That skeleton typesets as it stands: it stands on
+  `article`, keeps the venue's page options where those are article's own (the
+  two-column 10pt letterpaper CVPR and USENIX ask for), and leaves the class
+  and style lines the kit was going to bring as comments, because the one thing
+  a failed kit did not deliver is the venue's class. A venue the
+  compiler image already has installed is listed once, as the installed class,
+  which needs no download, and the installed and fetched venues are listed in
+  one alphabet inside each category.
 - Blank projects: a "Blank" tile leads the template grid and creates a project
   with no files; `POST /api/projects` with `template: "blank"` (or `files: {}`)
   does the same. The editor's empty state says "Create a file to start writing"
@@ -172,6 +199,12 @@ All notable changes to Aldine are documented here. The format follows
   user cannot open, and identical error rows are listed once.
 - A failed typeset always says why: a run whose logs parse to no error at all
   falls back to latexmk's own summary rather than an unexplained "Failed".
+- `POST /api/projects` rejects a seed whose file name is longer than the 255
+  bytes a filesystem accepts, naming the path, instead of failing halfway
+  through the write. A creation that fails for any other reason is now a 500
+  saying "Could not create the project", with the reason in the server log:
+  a full disk or a read-only data directory is this server's fault, not a bad
+  request, and its error text names the data directory.
 - Templates are read as bytes instead of UTF-8 text, so a template carrying a
   logo, a figure or any other binary file reaches the new project intact.
 - A SyncTeX jump from the PDF is refused (409, with a toast) when the preview

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs && tsx test/templates.test.mjs && tsx test/templates-check.test.mjs && tsx test/skeleton-compile.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs && tsx test/templates.test.mjs && tsx test/templates-check.test.mjs && tsx test/skeleton-compile.test.mjs && tsx test/venue-kits.test.mjs && tsx test/venue-registry.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/src/catalog.ts
+++ b/apps/server/src/catalog.ts
@@ -57,8 +57,13 @@ interface VenueMeta {
   front?: 'frontmatter' | 'inbody' | 'abstract-first' | 'acm';
 }
 
-/** Display metadata per venue id from the compiler's allowlist. */
-const VENUES: Record<string, VenueMeta> = {
+/**
+ * Display metadata per venue id from the compiler's allowlist. Exported so the
+ * registry test can hold these descriptions and templates/venues.json to one
+ * story: a venue named here that also has a fetched tile would be two tiles for
+ * the same submission with nothing to choose between them.
+ */
+export const INSTALLED_VENUES: Record<string, VenueMeta> = {
   elsarticle: { name: 'Elsevier journal', category: 'Journals', description: 'Elsevier submission with the elsarticle class.', icon: '📗', options: 'preprint,review,12pt', bibStyle: 'elsarticle-num', front: 'frontmatter' },
   ieeetran: { name: 'IEEE Transactions', category: 'Journals', description: 'IEEE journal submission with the IEEEtran class.', icon: '📘', options: 'journal', bibStyle: 'IEEEtran' },
   ieeeconf: { name: 'IEEE conference', category: 'Conferences', description: 'IEEE conference paper with the IEEEconf class.', icon: '📙', bibStyle: 'IEEEtran' },
@@ -85,8 +90,8 @@ const VENUES: Record<string, VenueMeta> = {
   iclr: { name: 'ICLR', category: 'Conferences', description: 'International Conference on Learning Representations submission.', icon: '🧩', bibStyle: 'plainnat' },
   acl: { name: 'ACL', category: 'Conferences', description: 'ACL, EMNLP and NAACL submission.', icon: '💬', bibStyle: 'acl_natbib' },
   aaai: { name: 'AAAI', category: 'Conferences', description: 'AAAI conference submission.', icon: '🎓', bibStyle: 'aaai' },
-  usenix: { name: 'USENIX', category: 'Conferences', description: 'USENIX Security, OSDI and ATC submission.', icon: '🔐', bibStyle: 'plain' },
-  cvpr: { name: 'CVPR', category: 'Conferences', description: 'CVPR, ICCV and ECCV submission.', icon: '👁', bibStyle: 'ieee_fullname' },
+  usenix: { name: 'USENIX', category: 'Conferences', description: 'USENIX ATC, OSDI, NSDI and FAST submission.', icon: '🔐', bibStyle: 'plain' },
+  cvpr: { name: 'CVPR', category: 'Conferences', description: 'CVPR submission.', icon: '👁', bibStyle: 'ieee_fullname' },
 };
 
 /** TeX Live license ids → the text everyone links to. */
@@ -226,7 +231,7 @@ export function resetVenueCache(): void {
 }
 
 export function venueTemplateInfo(c: CatalogClass): TemplateInfo | null {
-  const meta = own(VENUES, c.id);
+  const meta = own(INSTALLED_VENUES, c.id);
   if (!meta) return null;
   const info: TemplateInfo = {
     id: VENUE_PREFIX + c.id,
@@ -257,7 +262,7 @@ export async function venueTemplates(waitMs?: number): Promise<TemplateInfo[]> {
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-const REFERENCES_BIB = `@article{knuth1984,
+export const REFERENCES_BIB = `@article{knuth1984,
   author  = {Knuth, Donald E.},
   title   = {Literate Programming},
   journal = {The Computer Journal},
@@ -367,7 +372,7 @@ export function sampleIsSelfContained(content: string): boolean {
  */
 export async function venueTemplateFiles(id: string): Promise<Record<string, Buffer>> {
   const key = id.slice(VENUE_PREFIX.length);
-  const meta = own(VENUES, key);
+  const meta = own(INSTALLED_VENUES, key);
   // Resolve against the same list the gallery was served from (CATALOG_WAIT_MS,
   // last-good on a slow or failing compiler): a tile the user can see must not
   // 400 because the catalog fetch happened to fail between listing and create.

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -20,6 +20,12 @@ export const config = {
   /** Built-in + user plugins */
   pluginsDir: process.env.PLUGINS_DIR || path.join(repoRoot, 'plugins'),
   templatesDir: process.env.TEMPLATES_DIR || path.join(repoRoot, 'templates'),
+  /**
+   * Registry of venue kits fetched from publishers. Deliberately not derived
+   * from templatesDir: the e2e suite and the unit tests point it at a fixture
+   * registry while still serving the repo's real folder templates.
+   */
+  venuesFile: process.env.VENUES_FILE || path.join(repoRoot, 'templates', 'venues.json'),
   webDist: process.env.WEB_DIST || path.join(repoRoot, 'apps/web/dist'),
 };
 

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -12,7 +12,7 @@ import { flushBranchDocs, refreshBranchDocsFromDisk, evictDoc, scheduleCommit, c
 import { publishProjectEvent } from './events.js';
 import { parseBib, bibKeys, BibEntry } from './bib.js';
 import { listPlugins, pluginAssetPath } from './plugins.js';
-import { listAllTemplates, resolveTemplateFiles } from './templates.js';
+import { listAllTemplates, resolveTemplateSeed, type TemplateSeed } from './templates.js';
 import { warmVenueCache } from './catalog.js';
 import { fetchBibEntry, searchWorks } from './references.js';
 import { latexWordCount, documentFiles } from './wordcount.js';
@@ -27,7 +27,7 @@ import * as oauth from './oauth.js';
 import * as email from './email.js';
 import { canAccess, isListed, isMember, isOwner, ownerName } from './authz.js';
 import { loginLimiter, registerLimiter, aiLimiter, refLimiter, compileGate, compileLimiter, clientKey } from './ratelimit.js';
-import { safeJoin, isTextFile, importPath, isHiddenPath, seedError, newId, BRANCH_RE } from './util.js';
+import { safeJoin, isTextFile, importPath, isHiddenPath, overlongPath, pathConflict, seedError, newId, BRANCH_RE } from './util.js';
 
 type Q = { branch?: string; path?: string; name?: string; force?: string };
 
@@ -353,19 +353,34 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Body: { name?: string; files?: Record<string, string> | null; template?: string } }>('/api/projects', async (req, reply) => {
     const { name = 'Untitled Project', files, template } = req.body || {};
     let seed: Record<string, string | Buffer> | undefined;
+    let resolved: TemplateSeed | undefined;
     if (files !== undefined && files !== null) {
       const bad = seedError(files);
       if (bad) return reply.code(400).send({ error: bad });
       seed = files;
     }    if (template) {
       try {
-        seed = await resolveTemplateFiles(template);
+        resolved = await resolveTemplateSeed(template);
+        seed = resolved.files;
       } catch (err: any) {
         return reply.code(400).send({ error: err.message });
       }
     }
-    const meta = await store.createProject(name, seed, reqUser(req)?.id);
-    return publicMeta(meta, reqUser(req));  // Promise; Fastify awaits
+    // Every path shape the caller controls is screened by seedError and
+    // kitSeedProblem, so a write that still fails here is this server's fault
+    // (a full disk, a read-only data directory) and answers 5xx. The errno
+    // text names DATA_DIR, so it is logged and not returned.
+    let meta: Awaited<ReturnType<typeof store.createProject>>;
+    try {
+      meta = await store.createProject(name, seed, reqUser(req)?.id);
+    } catch (err: any) {
+      req.log.error({ err }, 'createProject failed');
+      return reply.code(500).send({ error: 'Could not create the project' });
+    }
+    const body = await publicMeta(meta, reqUser(req));
+    // A venue kit that could not be downloaded still creates the project (from
+    // a skeleton); the client says so rather than the request failing.
+    return resolved?.venueKit ? { ...body, venueKit: resolved.venueKit } : body;
   });
 
   // ---------- sharing (owner only) ----------
@@ -490,9 +505,16 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
         const p = importPath(entry);
         if (p === null) return fail(400, `ZIP entry "${entry}" points outside the project`);
         if (p.startsWith('__MACOSX/') || isHiddenPath(p)) continue;
+        // Screened here, not at the write: fs would answer ENAMETOOLONG with
+        // the server's absolute path in the message, and the catch below
+        // would hand that to the caller.
+        const tooLong = overlongPath(p);
+        if (tooLong) return fail(400, `ZIP entry "${entry}" has ${tooLong}`);
         files[p] = data;
       }
       if (!Object.keys(files).length) return fail(400, 'ZIP had no usable files');
+      const clash = pathConflict(Object.keys(files));
+      if (clash) return fail(400, `The archive uses "${clash}" as both a file and a directory`);
       // create with text files seeded; write binaries as buffers afterward
       const textFiles: Record<string, string> = {};
       const binFiles: string[] = [];
@@ -521,7 +543,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     } catch (err: any) {
       if (created) await store.deleteProject(created.id).catch(() => {});
       if (err instanceof ZipError && err.entryCount !== undefined) entryCount = err.entryCount;
-      return fail(400, `Could not import ZIP: ${err.message}`);
+      // A ZipError names the entry and the reason and is the caller's to fix;
+      // anything else is a server fault whose message may carry on-disk paths.
+      if (err instanceof ZipError) return fail(400, `Could not import ZIP: ${err.message}`);
+      req.log.error({ err }, 'ZIP import failed unexpectedly');
+      return fail(500, 'Could not import the ZIP. Try again, or send the archive to the instance operator.');
     }
   });
 

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { config } from './config.js';
-import { CATALOG_WAIT_MS, VENUE_PREFIX, venueTemplateFiles, venueTemplates } from './catalog.js';
+import { CATALOG_WAIT_MS, VENUE_PREFIX, venueClasses, venueTemplateFiles, venueTemplates } from './catalog.js';
+import { venueKit, venueKitSeed, venueKitTemplates, type VenueKitStatus } from './venuekits.js';
 
 export type TemplateCategory = 'Journals' | 'Conferences' | 'Theses' | 'Slides' | 'General';
 
@@ -28,6 +29,8 @@ export interface TemplateInfo {
   license?: string;
   licenseUrl?: string;
   source?: TemplateSource;
+  /** Fetched-kit venues: the publisher the kit is downloaded from at create time. */
+  kit?: { host: string; url: string; homepage?: string; termsUrl?: string };
 }
 
 const CATEGORIES: TemplateCategory[] = ['Journals', 'Conferences', 'Theses', 'Slides', 'General'];
@@ -58,13 +61,23 @@ export function listTemplates(): TemplateInfo[] {
 
 /** All files of a template (except template.json), as relative-path → content. */
 /**
- * Folder templates plus every venue class the compiler image carries. The
- * folder half never waits on the network: a compiler that is reachable but
- * silent costs CATALOG_WAIT_MS and an empty venue half, not an empty gallery.
+ * Folder templates, every venue class the compiler image carries, and every
+ * venue whose kit Aldine fetches from the publisher. The folder half never
+ * waits on the network: a compiler that is reachable but silent costs
+ * CATALOG_WAIT_MS and an empty venue half, not an empty gallery.
+ *
+ * A venue in both halves is listed once, as the installed class: that seeds a
+ * project with no download at all, so it is the better of the two.
  */
 export async function listAllTemplates(): Promise<TemplateInfo[]> {
   const folders = listTemplates();
-  const venues = await venueTemplates(CATALOG_WAIT_MS);
+  const installed = await venueTemplates(CATALOG_WAIT_MS);
+  const seen = new Set(installed.map((t) => t.id));
+  const fetched = venueKitTemplates().filter((t) => !seen.has(t.id));
+  // One alphabet across both halves: a category that lists the installed venues
+  // A-Z and then starts over with the fetched ones reads as if the second half
+  // is not there. Folder templates keep their curated order, blank first.
+  const venues = [...installed, ...fetched].sort((a, b) => a.name.localeCompare(b.name));
   return [...folders, ...venues];
 }
 
@@ -93,8 +106,26 @@ export function templateFiles(id: string): Record<string, Buffer> {
   return files;
 }
 
-/** Seed files for any gallery id: a folder template or a `venue:` catalog entry. */
-export async function resolveTemplateFiles(id: string): Promise<Record<string, Buffer>> {
-  if (id.startsWith(VENUE_PREFIX)) return venueTemplateFiles(id);
-  return templateFiles(id);
+/** What a template id seeds a project with, and how the venue kit went. */
+export interface TemplateSeed {
+  files: Record<string, Buffer>;
+  /** Fetched-kit venues only. `ok: false` means the project is a skeleton. */
+  venueKit?: VenueKitStatus;
+}
+
+/**
+ * Seed files for any gallery id: a folder template, an installed venue class,
+ * or a venue whose kit is fetched from the publisher. The installed class wins
+ * the same way it does in the listing, so the tile the user saw is the one
+ * they get.
+ */
+export async function resolveTemplateSeed(id: string): Promise<TemplateSeed> {
+  if (!id.startsWith(VENUE_PREFIX)) return { files: templateFiles(id) };
+  const key = id.slice(VENUE_PREFIX.length);
+  const installed = (await venueClasses(CATALOG_WAIT_MS)).some((c) => c.id === key);
+  if (!installed) {
+    const entry = venueKit(key);
+    if (entry) return venueKitSeed(entry);
+  }
+  return { files: await venueTemplateFiles(id) };
 }

--- a/apps/server/src/util.ts
+++ b/apps/server/src/util.ts
@@ -53,6 +53,43 @@ export function isHiddenPath(rel: string): boolean {
 
 export const SEED_MAX_FILES = 1000;
 export const SEED_MAX_BYTES = 32 * 1024 * 1024;
+/** POSIX NAME_MAX. A longer path component is ENAMETOOLONG inside
+ *  createProject, which can only be reported as a server fault; caught here it
+ *  is the caller's own path and a 400 that names it. */
+export const SEED_MAX_NAME_BYTES = 255;
+
+/** A whole path can be too long even when every component fits: PATH_MAX is
+ *  1024 on macOS and 4096 on Linux, and DATA_DIR/projects/<id>/ goes in front
+ *  of every key. 900 bytes leaves room for the longest prefix we deploy. */
+export const SEED_MAX_PATH_BYTES = 900;
+
+/** The first path component too long for the filesystem, or null. */
+export function overlongName(rel: string): string | null {
+  return rel.split('/').find((seg) => Buffer.byteLength(seg) > SEED_MAX_NAME_BYTES) ?? null;
+}
+
+/** The first name used as both a file and a directory, or null: writing
+ *  `a` and then `a/b` fails halfway through with ENOTDIR, and the message
+ *  carries the server's absolute path. */
+export function pathConflict(paths: Iterable<string>): string | null {
+  const taken = new Set(paths);
+  for (const p of taken) {
+    const segs = p.split('/');
+    for (let i = 1; i < segs.length; i++) {
+      const dir = segs.slice(0, i).join('/');
+      if (taken.has(dir)) return dir;
+    }
+  }
+  return null;
+}
+
+/** Why a path cannot be written (component or whole path too long), or null. */
+export function overlongPath(rel: string): string | null {
+  const seg = overlongName(rel);
+  if (seg) return `a name longer than ${SEED_MAX_NAME_BYTES} bytes`;
+  if (Buffer.byteLength(rel) > SEED_MAX_PATH_BYTES) return `a path longer than ${SEED_MAX_PATH_BYTES} bytes`;
+  return null;
+}
 
 /**
  * Why a `files` map cannot seed a project, or null when it can. Keys are
@@ -70,6 +107,8 @@ export function seedError(files: unknown): string | null {
   for (const [rel, content] of entries) {
     const norm = importPath(rel);
     if (norm === null || isHiddenPath(norm)) return `File path "${rel}" is not allowed`;
+    const tooLong = overlongPath(norm);
+    if (tooLong) return `File path "${rel}" has ${tooLong}`;
     if (typeof content !== 'string') return `Content of "${rel}" must be a string`;
     total += Buffer.byteLength(content);
     if (total > SEED_MAX_BYTES) return `Files total more than ${Math.round(SEED_MAX_BYTES / (1024 * 1024))} MB`;

--- a/apps/server/src/venuekits.ts
+++ b/apps/server/src/venuekits.ts
@@ -515,9 +515,16 @@ export async function venueKitSeed(entry: VenueKitEntry): Promise<VenueKitSeed> 
     if (stale) {
       try { return { files: kitProject(entry, stale.files), venueKit: status(true) }; } catch { /* the skeleton, then */ }
     }
+    const network = err?.cause?.code || err?.code;
     const reason = safeReason(err?.name === 'TimeoutError' || err?.name === 'AbortError'
       ? `it did not answer within ${KIT_TIMEOUT_MS / 1000} seconds`
-      : String(err?.message || err));
+      : network === 'ENOTFOUND' || network === 'EAI_AGAIN'
+        ? `${entry.kit.host} could not be resolved`
+        : network === 'ECONNREFUSED' || network === 'ECONNRESET' || network === 'EHOSTUNREACH'
+          ? `${entry.kit.host} could not be reached`
+          : String(err?.message || err) === 'fetch failed'
+            ? `${entry.kit.host} could not be reached`
+            : String(err?.message || err));
     return { files: fallbackFiles(entry, reason), venueKit: status(false, reason) };
   }
 }

--- a/apps/server/src/venuekits.ts
+++ b/apps/server/src/venuekits.ts
@@ -1,0 +1,682 @@
+/**
+ * Venue kits fetched from the publisher.
+ *
+ * Most venues (NeurIPS, ACL, CVPR, SIAM, MDPI, Frontiers…) publish their class
+ * and style files as a zip on their own site and ship nothing to TeX Live, so
+ * the installed-class gallery in catalog.ts cannot reach them. This module
+ * downloads such a kit when the user creates the project, unpacks it with the
+ * project's own hardened ZIP reader, and seeds the paper from it.
+ *
+ * The rules that make this safe are not tunables:
+ *  - The server fetches, never the compiler: the compiler has no egress.
+ *  - templates/venues.json is the only source of URLs. Nothing in a request
+ *    reaches the fetcher, so there is no SSRF surface; an entry whose URL is
+ *    not https, or points somewhere other than the host the entry declares,
+ *    is dropped at load time rather than fetched.
+ *  - A failed fetch never fails project creation: the project is created from
+ *    the generated skeleton plus README-venue.md, and the caller says so.
+ *  - No publisher file is stored in this repo. The cache under
+ *    CACHE_DIR/venue-kits/ is a runtime cache, not a redistribution.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { config } from './config.js';
+import { unzip } from './unzip.js';
+import { importPath, isHiddenPath, overlongPath, SEED_MAX_BYTES, SEED_MAX_FILES } from './util.js';
+import type { TemplateCategory, TemplateInfo } from './templates.js';
+import { REFERENCES_BIB, VENUE_PREFIX } from './catalog.js';
+
+/** 20 s per kit, redirects included. The override can only shorten it: the
+ *  test suites use it to reach the timeout path without waiting 20 s. */
+export const KIT_TIMEOUT_MS = Math.min(20_000, Number(process.env.VENUE_KIT_TIMEOUT_MS) || 20_000);
+export const KIT_MAX_BYTES = 25 * 1024 * 1024;
+export const KIT_MAX_REDIRECTS = 3;
+export const KIT_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const VERSION = readVersion();
+const USER_AGENT = `Aldine/${VERSION} (+https://aldine.dev)`;
+
+function readVersion(): string {
+  try {
+    const pkg = new URL('../package.json', import.meta.url);
+    return JSON.parse(fs.readFileSync(pkg, 'utf8')).version || '0';
+  } catch { return '0'; }
+}
+
+export interface VenueKitSpec {
+  /** A single archive. Mutually exclusive with `urls`. */
+  url?: string;
+  /** Bare .tex/.sty files, for a venue that publishes no archive (USENIX). */
+  urls?: string[];
+  /** The only host this entry may be fetched from, redirects included. */
+  host: string;
+  /** Globs naming what to take out of the archive; a wildcard-free glob is required. */
+  take?: string[];
+  /** Kit path → project path, applied after the archive prefix is stripped. */
+  rename?: Record<string, string>;
+  /** Drop the directories the kit nests files in (Springer's bst/, Frontiers' subfolders). */
+  flatten?: boolean;
+}
+
+export interface VenueKitEntry {
+  id: string;
+  name: string;
+  category: TemplateCategory;
+  description: string;
+  icon?: string;
+  homepage: string;
+  termsUrl?: string;
+  kit: VenueKitSpec;
+  documentClass: string;
+  classOptions?: string;
+  preamble?: string[];
+  bibStyle?: string;
+  /** The class issues its own \bibliographystyle (sn-jnl); a second one is a BibTeX error. */
+  classSetsBibStyle?: boolean;
+  /** The kit's own starting document, which becomes the project's main.tex. */
+  main?: string;
+}
+
+/** Why a kit could not be used. Carries a sentence the user is shown. */
+class KitError extends Error {}
+
+const CATEGORIES: TemplateCategory[] = ['Journals', 'Conferences', 'Theses', 'Slides', 'General'];
+const ID_RE = /^[a-z0-9][a-z0-9-]{0,30}$/;
+
+// ---------- registry ----------
+
+let registry: { mtimeMs: number; entries: VenueKitEntry[] } | null = null;
+
+/**
+ * The registry, reloaded when the file changes on disk. A malformed entry is
+ * dropped with a warning rather than taking the whole gallery down with it.
+ */
+export function venueKits(): VenueKitEntry[] {
+  const file = config.venuesFile;
+  let mtimeMs = 0;
+  try { mtimeMs = fs.statSync(file).mtimeMs; } catch { mtimeMs = 0; }
+  if (registry && registry.mtimeMs === mtimeMs) return registry.entries;
+  const entries = mtimeMs ? loadRegistry(file) : [];
+  registry = { mtimeMs, entries };
+  return entries;
+}
+
+export function venueKit(id: string): VenueKitEntry | undefined {
+  return venueKits().find((e) => e.id === id);
+}
+
+function loadRegistry(file: string): VenueKitEntry[] {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err: any) {
+    console.warn(`venue kits: ${file} is not valid JSON (${err.message}); no fetched venues`);
+    return [];
+  }
+  const list = (raw as { venues?: unknown })?.venues;
+  if (!Array.isArray(list)) {
+    console.warn(`venue kits: ${file} has no "venues" array; no fetched venues`);
+    return [];
+  }
+  const out: VenueKitEntry[] = [];
+  const seen = new Set<string>();
+  for (const item of list) {
+    const problem = entryProblem(item, seen);
+    if (problem) {
+      console.warn(`venue kits: ignoring entry ${JSON.stringify((item as any)?.id ?? '?')} (${problem})`);
+      continue;
+    }
+    const entry = item as VenueKitEntry;
+    seen.add(entry.id);
+    out.push(entry);
+  }
+  return out;
+}
+
+/** Why an entry cannot be trusted, or null when it can. */
+export function entryProblem(item: unknown, seen: Set<string> = new Set()): string | null {
+  const e = item as VenueKitEntry;
+  const text = (v: unknown) => typeof v === 'string' && v.trim().length > 0;
+  if (!e || typeof e !== 'object') return 'not an object';
+  if (!text(e.id) || !ID_RE.test(e.id)) return 'id must be lower-case letters, digits and dashes';
+  if (seen.has(e.id)) return 'duplicate id';
+  if (!text(e.name)) return 'no name';
+  if (!text(e.description)) return 'no description';
+  if (!CATEGORIES.includes(e.category)) return `category must be one of ${CATEGORIES.join(', ')}`;
+  if (!https(e.homepage)) return 'homepage must be an https URL';
+  if (e.termsUrl !== undefined && !https(e.termsUrl)) return 'termsUrl must be an https URL';
+  if (!text(e.documentClass)) return 'no documentClass';
+  if (!e.main && !(Array.isArray(e.preamble) && e.preamble.length)) return 'needs either a main file or a preamble';
+  const k = e.kit;
+  if (!k || typeof k !== 'object') return 'no kit';
+  if (!text(k.host)) return 'kit.host must name the host the kit is fetched from';
+  const urls = k.url ? [k.url] : k.urls;
+  if (!Array.isArray(urls) || !urls.length) return 'kit needs a url or a urls list';
+  if (k.url && k.urls) return 'kit has both url and urls';
+  for (const u of urls) {
+    if (!fetchable(u)) return `kit url ${JSON.stringify(u)} is not https`;
+    if (new URL(u).host !== k.host) return `kit url ${JSON.stringify(u)} is not on ${k.host}`;
+  }
+  if (k.url) {
+    if (!Array.isArray(k.take) || !k.take.length) return 'an archive kit needs a take list';
+    if (k.take.some((g) => typeof g !== 'string' || !g.trim())) return 'take entries must be non-empty strings';
+    if (!k.take.some((g) => !/[*?]/.test(g))) return 'take needs at least one exact file name';
+    if (e.main && !k.take.some((g) => matches(g, e.main!))) return `main ${JSON.stringify(e.main)} is not in the take list`;
+  }
+  for (const [from, to] of Object.entries(k.rename || {})) {
+    if (!text(to) || importPath(to) !== to || isHiddenPath(to)) return `rename target ${JSON.stringify(to)} is not a project path`;
+    if (!text(from)) return 'rename source must be a path';
+  }
+  return null;
+}
+
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * https, always. The one exception is a loopback URL under ALDINE_TEST_HOOKS,
+ * which is how the unit and e2e suites point a registry at a fixture server
+ * that cannot present a certificate; a production server rejects http outright.
+ */
+function fetchable(u: unknown): boolean {
+  if (typeof u !== 'string') return false;
+  let url: URL;
+  try { url = new URL(u); } catch { return false; }
+  if (url.protocol === 'https:') return true;
+  return url.protocol === 'http:' && process.env.ALDINE_TEST_HOOKS === '1' && LOOPBACK.has(url.hostname);
+}
+
+function https(u: unknown): boolean {
+  if (typeof u !== 'string') return false;
+  try { return new URL(u).protocol === 'https:'; } catch { return false; }
+}
+
+// ---------- gallery ----------
+
+/** Every fetched venue as a gallery tile, alphabetical inside its category. */
+export function venueKitTemplates(): TemplateInfo[] {
+  return venueKits()
+    .map((e) => ({
+      id: VENUE_PREFIX + e.id,
+      name: e.name,
+      description: e.description,
+      icon: e.icon || '📄',
+      category: e.category,
+      documentClass: e.documentClass,
+      // There is no licence Aldine can assert for a publisher kit: the terms
+      // are between the author and the publisher, so link them instead.
+      license: 'Publisher terms',
+      licenseUrl: e.termsUrl || e.homepage,
+      source: { url: e.homepage },
+      kit: { host: e.kit.host, url: e.kit.url || e.kit.urls![0], homepage: e.homepage, termsUrl: e.termsUrl },
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ---------- fetching ----------
+
+const ZIP_TYPES = new Set([
+  'application/zip', 'application/x-zip-compressed', 'application/x-zip',
+  'application/zip-compressed', 'multipart/x-zip',
+]);
+const TEX_TYPES = new Set([
+  'text/x-tex', 'application/x-tex', 'application/x-latex', 'text/tex', 'text/plain',
+]);
+
+/** The media type without its parameters: Cell Press answers `application/zip;charset=UTF-8`. */
+function mediaType(header: string | null): string {
+  return (header || '').split(';')[0].trim().toLowerCase();
+}
+
+const mb = (n: number) => Math.round((n / 1024 / 1024) * 10) / 10;
+
+/**
+ * One URL's bytes, within the caps. Redirects are followed by hand so that a
+ * hop off the entry's host is refused rather than silently followed, which is
+ * what keeps a publisher's CDN from becoming an open fetch proxy.
+ */
+async function getBytes(url: string, host: string, signal: AbortSignal): Promise<{ bytes: Buffer; type: string }> {
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    const u = new URL(current);
+    if (!fetchable(current)) throw new KitError(`${u.protocol.replace(':', '')} is not https`);
+    if (u.host !== host) throw new KitError(`the download redirected to ${u.host}, which is not ${host}`);
+    const res = await fetch(current, {
+      redirect: 'manual',
+      signal,
+      headers: { 'user-agent': USER_AGENT, accept: '*/*' },
+    });
+    if (res.status >= 300 && res.status < 400) {
+      if (hop >= KIT_MAX_REDIRECTS) throw new KitError(`more than ${KIT_MAX_REDIRECTS} redirects`);
+      const loc = res.headers.get('location');
+      await res.body?.cancel().catch(() => undefined);
+      if (!loc) throw new KitError(`HTTP ${res.status} without a location header`);
+      current = new URL(loc, current).toString();
+      continue;
+    }
+    if (!res.ok) {
+      await res.body?.cancel().catch(() => undefined);
+      throw new KitError(`HTTP ${res.status}`);
+    }
+    const declared = Number(res.headers.get('content-length') || 0);
+    if (declared > KIT_MAX_BYTES) {
+      await res.body?.cancel().catch(() => undefined);
+      throw new KitError(`the kit is ${mb(declared)} MB; the limit is ${mb(KIT_MAX_BYTES)} MB`);
+    }
+    return { bytes: await readCapped(res), type: mediaType(res.headers.get('content-type')) };
+  }
+}
+
+/** Reads the body, stopping at the cap: a server may lie about content-length or omit it. */
+async function readCapped(res: Response): Promise<Buffer> {
+  if (!res.body) return Buffer.from(await res.arrayBuffer());
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let over = false;
+  // Breaking out of the loop is what closes the connection: cancelling a
+  // stream the iterator holds is a TypeError, and the download would run on.
+  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+    total += chunk.length;
+    if (total > KIT_MAX_BYTES) { over = true; break; }
+    chunks.push(Buffer.from(chunk));
+  }
+  if (over) throw new KitError(`the kit is larger than the ${mb(KIT_MAX_BYTES)} MB limit`);
+  return Buffer.concat(chunks);
+}
+
+// ---------- unpacking ----------
+
+/** Archive junk that is never part of a kit. */
+function isJunk(name: string): boolean {
+  const segs = name.split('/');
+  if (segs.includes('__MACOSX')) return true;
+  const base = segs[segs.length - 1];
+  return base === '.DS_Store' || base.startsWith('._') || base === 'Thumbs.db';
+}
+
+/** The directory prefix every entry shares, so a kit nested in one folder
+ *  seeds the project the way a flat kit does. */
+function commonDir(names: string[]): string {
+  if (!names.length) return '';
+  let prefix = names[0].split('/').slice(0, -1);
+  for (const n of names.slice(1)) {
+    const segs = n.split('/').slice(0, -1);
+    let i = 0;
+    while (i < prefix.length && i < segs.length && prefix[i] === segs[i]) i++;
+    prefix = prefix.slice(0, i);
+    if (!prefix.length) break;
+  }
+  return prefix.length ? `${prefix.join('/')}/` : '';
+}
+
+/** `*` stops at a slash, `**` does not, and a leading `**\/` also matches depth zero. */
+function globToRe(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        if (glob[i + 2] === '/') { re += '(?:.*/)?'; i += 2; } else { re += '.*'; i += 1; }
+      } else re += '[^/]*';
+    } else if (c === '?') re += '[^/]';
+    else re += c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** A glob with no slash names a file at any depth; one with a slash names a path. */
+function matches(glob: string, rel: string): boolean {
+  const re = globToRe(glob);
+  return glob.includes('/') ? re.test(rel) : re.test(rel.split('/').pop()!);
+}
+
+/**
+ * The files the entry names, keyed by their project path. Anything importPath
+ * rejects never gets here, and a kit missing a file the entry names by exact
+ * name is a failure: seeding half a kit produces a project that cannot
+ * typeset and does not say why.
+ */
+export function selectKitFiles(archive: Record<string, Buffer>, spec: VenueKitSpec): Record<string, Buffer> {
+  const usable: [string, Buffer][] = [];
+  for (const [name, data] of Object.entries(archive)) {
+    if (name.endsWith('/') || isJunk(name)) continue;
+    const norm = importPath(name);
+    if (norm === null || isHiddenPath(norm)) continue;
+    usable.push([norm, data]);
+  }
+  usable.sort((a, b) => a[0].localeCompare(b[0]));
+  const prefix = commonDir(usable.map(([n]) => n));
+  const take = spec.take || [];
+  const out: Record<string, Buffer> = {};
+  const matched = new Set<string>();
+  for (const [name, data] of usable) {
+    const rel = name.slice(prefix.length);
+    if (!rel) continue;
+    const glob = take.find((g) => matches(g, rel));
+    if (!glob) continue;
+    matched.add(glob);
+    const target = projectPath(spec, spec.flatten ? rel.split('/').pop()! : rel);
+    // Sorted order makes a collision (two `bst/x.bst` flattened onto one name)
+    // resolve the same way on every machine. Own-property test: `'constructor'
+    // in out` is true before any file has been placed, and the kit file named
+    // that would be dropped without a word.
+    if (!Object.prototype.hasOwnProperty.call(out, target)) out[target] = data;
+  }
+  const missing = take.filter((g) => !/[*?]/.test(g) && !matched.has(g));
+  if (missing.length) throw new KitError(`the archive has no ${missing.join(', ')}`);
+  return out;
+}
+
+function projectPath(spec: VenueKitSpec, rel: string): string {
+  // Own-property lookup: the key comes from the archive, and a bare index read
+  // answers an entry named "constructor" with something off Object.prototype.
+  const own = (key: string) => (spec.rename && Object.prototype.hasOwnProperty.call(spec.rename, key) ? spec.rename[key] : undefined);
+  const renamed = own(rel) ?? own(rel.split('/').pop()!) ?? rel;
+  const norm = importPath(renamed);
+  if (norm === null || isHiddenPath(norm)) throw new KitError(`the kit names a file Aldine cannot place (${rel})`);
+  return norm;
+}
+
+async function downloadKit(entry: VenueKitEntry): Promise<Record<string, Buffer>> {
+  const signal = AbortSignal.timeout(KIT_TIMEOUT_MS);
+  const spec = entry.kit;
+  if (spec.urls) {
+    const out: Record<string, Buffer> = {};
+    for (const url of spec.urls) {
+      const { bytes, type } = await getBytes(url, spec.host, signal);
+      // A missing content type is a failure here too: a proxy that strips it
+      // off an error page would otherwise seed that page as the kit.
+      if (!TEX_TYPES.has(type) && !ZIP_TYPES.has(type)) {
+        throw new KitError(`${url} answered ${type || 'no content type'}, which is not a LaTeX file`);
+      }
+      out[projectPath(spec, path.posix.basename(new URL(url).pathname))] = bytes;
+    }
+    return out;
+  }
+  const { bytes, type } = await getBytes(spec.url!, spec.host, signal);
+  if (!ZIP_TYPES.has(type)) throw new KitError(`the download answered ${type || 'no content type'}, which is not a zip`);
+  let archive: Record<string, Buffer>;
+  try {
+    archive = unzip(bytes);
+  } catch (err: any) {
+    throw new KitError(`the archive could not be read (${err.message})`);
+  }
+  return selectKitFiles(archive, spec);
+}
+
+// ---------- cache ----------
+
+function kitCacheDir(id: string): string {
+  return path.join(config.cacheDir, 'venue-kits', id);
+}
+
+interface CachedKit { files: Record<string, Buffer>; fetchedAt: number }
+
+/** What the registry says the kit is. A cache written before the entry changed
+ *  its URL, take list or renames holds last year's files, which no longer match
+ *  the preamble the skeleton writes: a different fingerprint is a cache miss. */
+function kitFingerprint(entry: VenueKitEntry): string {
+  const k = entry.kit;
+  return JSON.stringify({ url: k.url ?? null, urls: k.urls ?? null, take: k.take ?? null, rename: k.rename ?? null, flatten: !!k.flatten });
+}
+
+function readKitCache(entry: VenueKitEntry): CachedKit | null {
+  const id = entry.id;
+  const dir = kitCacheDir(id);
+  let stamp: { fetchedAt?: number; spec?: string };
+  try { stamp = JSON.parse(fs.readFileSync(path.join(dir, 'kit.json'), 'utf8')); } catch { return null; }
+  if (stamp.spec !== kitFingerprint(entry)) return null;
+  const root = path.join(dir, 'files');
+  const files: Record<string, Buffer> = {};
+  const walk = (rel: string) => {
+    for (const e of fs.readdirSync(path.join(root, rel), { withFileTypes: true })) {
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) walk(r);
+      else files[r] = fs.readFileSync(path.join(root, r));
+    }
+  };
+  try { walk(''); } catch { return null; }
+  if (!Object.keys(files).length) return null;
+  return { files, fetchedAt: Number(stamp.fetchedAt) || 0 };
+}
+
+function writeKitCache(entry: VenueKitEntry, files: Record<string, Buffer>): void {
+  const dir = kitCacheDir(entry.id);
+  const tmp = `${dir}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    for (const [rel, data] of Object.entries(files)) {
+      const abs = path.join(tmp, 'files', rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, data);
+    }
+    fs.writeFileSync(path.join(tmp, 'kit.json'), JSON.stringify({
+      id: entry.id, url: entry.kit.url || entry.kit.urls, spec: kitFingerprint(entry),
+      fetchedAt: Date.now(), files: Object.keys(files).sort(),
+    }, null, 2));
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(dir), { recursive: true });
+    fs.renameSync(tmp, dir);
+  } catch (err: any) {
+    // A cache that cannot be written is a slower gallery, not a failure.
+    console.warn(`venue kits: could not cache ${entry.id} (${err.message})`);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ---------- seeding ----------
+
+export interface VenueKitStatus {
+  id: string;
+  name: string;
+  host: string;
+  url: string;
+  ok: boolean;
+  /** Why the kit could not be downloaded; only when ok is false. */
+  reason?: string;
+}
+
+export interface VenueKitSeed {
+  files: Record<string, Buffer>;
+  venueKit: VenueKitStatus;
+}
+
+/** One download per venue at a time, however many projects are being created. */
+const inflight = new Map<string, Promise<Record<string, Buffer>>>();
+
+/**
+ * The seed files for a fetched venue. Never throws: a kit that cannot be
+ * downloaded, read, or does not carry the files the registry names produces
+ * the generated skeleton plus README-venue.md, and `venueKit.ok` is false so
+ * the caller can say so.
+ */
+export async function venueKitSeed(entry: VenueKitEntry): Promise<VenueKitSeed> {
+  const url = entry.kit.url || entry.kit.urls![0];
+  const status = (ok: boolean, reason?: string): VenueKitStatus =>
+    ({ id: entry.id, name: entry.name, host: entry.kit.host, url, ok, ...(reason ? { reason } : {}) });
+
+  const cached = readKitCache(entry);
+  if (cached && Date.now() - cached.fetchedAt < KIT_CACHE_TTL_MS) {
+    // A cache that cannot seed a project is a miss, not a failed creation.
+    try { return { files: kitProject(entry, cached.files), venueKit: status(true) }; } catch { /* refetch */ }
+  }
+  try {
+    let pending = inflight.get(entry.id);
+    if (!pending) {
+      pending = downloadKit(entry).finally(() => inflight.delete(entry.id));
+      inflight.set(entry.id, pending);
+    }
+    const kit = await pending;
+    const files = kitProject(entry, kit);
+    writeKitCache(entry, kit);
+    return { files, venueKit: status(true) };
+  } catch (err: any) {
+    // Whatever its age: a kit that was good last week beats a skeleton that
+    // does not carry the venue's class at all.
+    const stale = cached ?? readKitCache(entry);
+    if (stale) {
+      try { return { files: kitProject(entry, stale.files), venueKit: status(true) }; } catch { /* the skeleton, then */ }
+    }
+    const reason = safeReason(err?.name === 'TimeoutError' || err?.name === 'AbortError'
+      ? `it did not answer within ${KIT_TIMEOUT_MS / 1000} seconds`
+      : String(err?.message || err));
+    return { files: fallbackFiles(entry, reason), venueKit: status(false, reason) };
+  }
+}
+
+/**
+ * One line of plain text. A failure sentence quotes the publisher's own bytes
+ * (a ZIP entry name reaches the ZipError message verbatim), and it is written
+ * into a LaTeX comment in main.tex: a newline there would close the comment and
+ * run the rest as LaTeX in a document the compiler is about to typeset.
+ */
+function safeReason(text: string): string {
+  const clean = text.replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim();
+  return clean.length > 200 ? `${clean.slice(0, 197)}...` : clean;
+}
+
+/**
+ * Kit files as a project seed, refused when they are not one. The ZIP reader's
+ * caps (40 MB per entry, 200 MB inflated) are not a project's: every other seed
+ * goes through seedError, and a kit that skipped those limits would fail inside
+ * createProject, which is a 500 and no project rather than the skeleton this
+ * module promises.
+ */
+function kitProject(entry: VenueKitEntry, kit: Record<string, Buffer>): Record<string, Buffer> {
+  const files = projectFiles(entry, kit);
+  const bad = kitSeedProblem(files);
+  if (bad) throw new KitError(`the kit cannot seed a project (${bad})`);
+  return files;
+}
+
+/** Why an assembled kit cannot be written to a fresh project, or null. */
+export function kitSeedProblem(files: Record<string, Buffer>): string | null {
+  const names = Object.keys(files);
+  if (names.length > SEED_MAX_FILES) return `it has ${names.length} files; the limit is ${SEED_MAX_FILES}`;
+  let total = 0;
+  for (const name of names) total += files[name].length;
+  if (total > SEED_MAX_BYTES) return `it is ${mb(total)} MB unpacked; the limit is ${mb(SEED_MAX_BYTES)} MB`;
+  // The publisher's own entry names: one past NAME_MAX is ENAMETOOLONG inside
+  // createProject, and this module owes the caller a skeleton, not a 500.
+  for (const name of names) {
+    const tooLong = overlongPath(name);
+    if (tooLong) return `it has ${tooLong}`;
+  }
+  // createProject writes the seed and then `.gitignore`: a name that is both a
+  // file and a directory fails halfway through, with the project half written.
+  const taken = new Set([...names, '.gitignore']);
+  for (const name of names) {
+    const segs = name.split('/');
+    for (let i = 1; i < segs.length; i++) {
+      const dir = segs.slice(0, i).join('/');
+      if (taken.has(dir)) return `"${dir}" is both a file and a directory`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Kit files as a project: the kit's own starting document becomes main.tex,
+ * which is the root file createProject picks and the name every other route
+ * assumes.
+ */
+function projectFiles(entry: VenueKitEntry, kit: Record<string, Buffer>): Record<string, Buffer> {
+  const out: Record<string, Buffer> = { ...kit };
+  if (entry.main) {
+    const key = Object.prototype.hasOwnProperty.call(out, entry.main)
+      ? entry.main
+      : Object.keys(out).find((k) => k.split('/').pop() === entry.main);
+    if (key) {
+      const doc = out[key];
+      delete out[key];
+      out['main.tex'] = doc;
+      return out;
+    }
+  }
+  // A kit with no starting document (or one the take list missed) still gives
+  // the class; the skeleton loads it.
+  out['main.tex'] = Buffer.from(skeleton(entry), 'utf8');
+  if (!Object.keys(out).some((f) => f.endsWith('.bib'))) out['references.bib'] = Buffer.from(REFERENCES_BIB, 'utf8');
+  return out;
+}
+
+function fallbackFiles(entry: VenueKitEntry, reason: string): Record<string, Buffer> {
+  return {
+    'main.tex': Buffer.from(skeleton(entry, reason), 'utf8'),
+    'references.bib': Buffer.from(REFERENCES_BIB, 'utf8'),
+    'README-venue.md': Buffer.from(readme(entry, reason), 'utf8'),
+  };
+}
+
+/** Every line prefixed with `%`, so no text a publisher influenced can end the
+ *  comment and become live LaTeX. */
+function comment(text: string): string {
+  return text.split(/\r\n|\r|\n/).map((line) => `% ${line}`).join('\n') + '\n';
+}
+
+/** The article preamble a failed kit leaves behind, with the venue's own lines
+ *  commented out. A style-file venue already stands on article, so its
+ *  \documentclass line is stock article and stays live, class options and all:
+ *  only the \usepackage lines the kit would bring are waiting on it. */
+function fallbackHead(entry: VenueKitEntry, classLine: string, preamble: string[]): string {
+  if (entry.documentClass === 'article') {
+    const waiting = preamble.length
+      ? comment("Once the kit's files are in this project, uncomment the line it brings:") + comment(preamble.join('\n'))
+      : '';
+    return `${classLine}\n` + waiting;
+  }
+  return comment("Once the kit's files are in this project, swap article for the class it ships:")
+    + comment([classLine, ...preamble].join('\n'))
+    + '\\documentclass{article}\n';
+}
+
+/** A starting document for the venue, in the plain article shape. */
+export function skeleton(entry: VenueKitEntry, failure?: string): string {
+  const url = entry.kit.url || entry.kit.urls![0];
+  const notice = failure
+    ? comment(`${entry.name} starting point, generated by Aldine.\n`
+      + `The official kit could not be downloaded from ${entry.kit.host} (${failure}),\n`
+      + `so this project does not carry the venue's class yet. Get it from\n`
+      + `${url} and add its .cls, .sty and .bst files here; see README-venue.md.`)
+    : comment(`${entry.name} starting point, generated by Aldine from the official kit.\n`
+      + `Check the venue's author guide for the options and sections it requires:\n`
+      + `${entry.homepage}`);
+  const classLine = `\\documentclass${entry.classOptions ? `[${entry.classOptions}]` : ''}{${entry.documentClass}}`;
+  const preamble = entry.preamble || [];
+  // Without the kit, the venue's class and style are exactly what this project
+  // does not have: naming either is a fatal error on the first typeset of a
+  // brand new project. Stand on article, which every image carries, and keep
+  // the venue's real lines as a comment to swap in once the files are here.
+  const head = failure ? fallbackHead(entry, classLine, preamble) : `${classLine}\n${preamble.map((line) => `${line}\n`).join('')}`;
+  // The venue's bib style ships with the kit, so a failed kit has plain and
+  // nothing else; classSetsBibStyle only holds for the venue's own class.
+  const bib = failure
+    ? '\\bibliographystyle{plain}\n\\bibliography{references}\n'
+    : entry.classSetsBibStyle
+      ? '\\bibliography{references}\n'
+      : `\\bibliographystyle{${entry.bibStyle || 'plain'}}\n\\bibliography{references}\n`;
+  return notice + head
+    + '\n\\title{Your title here}\n\\author{Your Name}\n\\date{\\today}\n'
+    + '\n\\begin{document}\n\\maketitle\n\n'
+    + '\\begin{abstract}\nA one-paragraph summary of the problem, your approach, and the headline result.\n\\end{abstract}\n\n'
+    + '\\section{Introduction}\nState the problem and why it matters. Cite prior work like this~\\cite{knuth1984}.\n\n'
+    + bib
+    + '\n\\end{document}\n';
+}
+
+function readme(entry: VenueKitEntry, reason: string): string {
+  const url = entry.kit.url || entry.kit.urls!.join('\n  ');
+  return `# ${entry.name} kit\n\n`
+    + `Aldine could not download the official ${entry.name} kit while creating this\n`
+    + `project, so \`main.tex\` is a skeleton and the venue's class files are missing.\n\n`
+    + `- Kit: ${url}\n`
+    + `- Why it failed: ${reason}\n`
+    + `- Author guide: ${entry.homepage}\n`
+    + (entry.termsUrl ? `- The venue's terms: ${entry.termsUrl}\n` : '')
+    + `\n## What to do\n\n`
+    + `1. Download the kit yourself from the link above.\n`
+    + `2. Add its \`.cls\`, \`.sty\` and \`.bst\` files to this project (drag them into the\n`
+    + `   file tree, or import the zip from the projects page).\n`
+    + `3. Typeset. \`main.tex\` stands on \`article\` until then; the venue's own\n`
+    + `   lines sit at the top of the file as a comment, ready to swap in.\n\n`
+    + `Aldine does not redistribute publisher files. The kit's terms are between you\n`
+    + `and the publisher.\n`;
+}

--- a/apps/server/test/import-route.test.mjs
+++ b/apps/server/test/import-route.test.mjs
@@ -73,7 +73,7 @@ try {
   const bin = Buffer.concat([Buffer.from([0, 1, 2, 3]), crypto.randomBytes(64)]);
   res = await importZip({ 'main.tex': doc, 'figs': 'a text file named like the dir', 'figs/plot.png': bin });
   eq(res.statusCode, 400, 'collision → 400');
-  check(res.json().error.startsWith('Could not import ZIP'), `collision reports the import failure: ${res.json().error}`);
+  check(/both a file and a directory/.test(res.json().error), `collision names the clashing entry: ${res.json().error}`);
   eq(await projectIds(), before, 'half-imported project removed');
   eq(fs.readdirSync(path.join(process.env.DATA_DIR, 'projects')), [], 'orphan repo dir removed');
 

--- a/apps/server/test/skeleton-compile.test.mjs
+++ b/apps/server/test/skeleton-compile.test.mjs
@@ -7,6 +7,10 @@
  * Only the classes this machine actually has are tried, through the compiler's
  * own catalog. BasicTeX carries two of them; a machine with no TeX Live at all,
  * or with none of the allowlist installed, skips.
+ *
+ * The fetched venues are held to the same invariant on their failure path: a
+ * kit that could not be downloaded leaves a project without the venue's class,
+ * so the skeleton it seeds must compile with nothing but a stock TeX Live.
  */
 import { execFile, execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -21,6 +25,7 @@ const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-skeleton-'));
 process.env.DATA_DIR = path.join(tmp, 'data');
 process.env.META_DIR = path.join(tmp, 'secrets');
 process.env.TEMPLATES_DIR = path.join(tmp, 'templates');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
 
 const skip = (why) => { console.log(`skeleton-compile: skipped (${why})`); fs.rmSync(tmp, { recursive: true, force: true }); process.exit(0); };
 
@@ -50,6 +55,36 @@ for (const cls of local.classes) {
   check(!failure, `the ${cls.cls} skeleton compiles (${failure})`);
   check(fs.existsSync(path.join(dir, 'main.pdf')), `the ${cls.cls} skeleton produces a PDF`);
   console.log(`  ${cls.cls}: ok`);
+}
+
+// ---- the fallback skeleton of every fetched venue ----
+
+// Failed kits differ only in their comments and their \documentclass options
+// (a style-file venue keeps its own), so the distinct bodies are compiled once
+// each rather than once per venue.
+const kits = await import('../src/venuekits.ts');
+const { REFERENCES_BIB } = catalog;
+const bodies = new Map();
+for (const entry of kits.venueKits()) {
+  const tex = kits.skeleton(entry, 'the publisher did not answer');
+  const body = tex.split('\n').filter((l) => !l.startsWith('%')).join('\n');
+  if (!bodies.has(body)) bodies.set(body, { entry, tex });
+}
+let n = 0;
+for (const { entry, tex } of bodies.values()) {
+  const dir = path.join(tmp, `fallback-${n++}`);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'main.tex'), tex);
+  fs.writeFileSync(path.join(dir, 'references.bib'), REFERENCES_BIB);
+  let failure = null;
+  try {
+    await run('latexmk', ['-pdf', '-interaction=nonstopmode', '-halt-on-error', 'main.tex'], { cwd: dir, timeout: 180_000 });
+  } catch (err) {
+    failure = String(err.stdout || err.message).split('\n').filter((l) => /^!|Error/.test(l)).slice(0, 4).join(' | ');
+  }
+  check(!failure, `the ${entry.name} fallback skeleton compiles without the kit (${failure})`);
+  check(fs.existsSync(path.join(dir, 'main.pdf')), `the ${entry.name} fallback skeleton produces a PDF`);
+  console.log(`  fallback (${entry.name} shape): ok`);
 }
 
 fs.rmSync(tmp, { recursive: true, force: true });

--- a/apps/server/test/templates.test.mjs
+++ b/apps/server/test/templates.test.mjs
@@ -8,6 +8,9 @@
  *  - the generated skeleton puts the title block where the class wants it
  *  - a compiler with no catalog leaves the folder templates alone
  *  - creating a project from a venue id works like a folder template
+ *  - a fetched venue joins the same gallery, and an installed class of the
+ *    same venue wins, so a venue is never listed twice
+ *  - a fetched venue whose kit cannot be downloaded still creates the project
  */
 import fs from 'node:fs';
 import os from 'node:os';
@@ -20,6 +23,10 @@ process.env.DATA_DIR = path.join(tmp, 'data');
 process.env.META_DIR = path.join(tmp, 'secrets');
 process.env.CACHE_DIR = path.join(tmp, 'cache');
 process.env.TEMPLATES_DIR = path.join(tmp, 'templates');
+process.env.VENUES_FILE = path.join(tmp, 'venues.json');
+// Loopback URLs are only fetchable under the test hook; port 1 refuses at once,
+// so the kit failure path is exercised without touching the network.
+process.env.ALDINE_TEST_HOOKS = '1';
 delete process.env.DATABASE_URL;
 delete process.env.REDIS_URL;
 
@@ -41,6 +48,20 @@ fs.writeFileSync(path.join(tplDir, 'demo', 'figs', 'plot.pdf'), BINARY);
 fs.mkdirSync(path.join(tplDir, 'slides'), { recursive: true });
 fs.writeFileSync(path.join(tplDir, 'slides', 'template.json'), JSON.stringify({ name: 'Slides', category: 'Slides', order: 2 }));
 fs.writeFileSync(path.join(tplDir, 'slides', 'main.tex'), '\\documentclass{beamer}\n');
+
+const kitVenue = (id, name) => ({
+  id, name, category: 'Conferences', description: `${name} submission.`,
+  homepage: 'https://example.org/authors',
+  kit: { url: 'http://127.0.0.1:1/kit.zip', host: '127.0.0.1:1', take: ['venue.sty'] },
+  documentClass: 'article', preamble: ['\\usepackage{venue}'], bibStyle: 'plain',
+});
+// `neurips` is also in the stubbed compiler catalog below: the gallery must
+// show one NeurIPS tile, the installed one, which needs no download.
+// 'AA Venue' sorts before every installed venue: the two halves of the venue
+// gallery are one alphabet, not one after the other.
+fs.writeFileSync(process.env.VENUES_FILE, JSON.stringify({
+  venues: [kitVenue('neurips', 'NeurIPS'), kitVenue('testvenue', 'Test Venue'), kitVenue('aavenue', 'AA Venue')],
+}));
 
 const { listTemplates, listAllTemplates, templateFiles } = await import('../src/templates.ts');
 const catalog = await import('../src/catalog.ts');
@@ -118,7 +139,14 @@ eq(fetchCalls, 1, 'nor does it drop the in-flight dedup');
 
 const all = await listAllTemplates();
 eq(all.filter((t) => !t.id.startsWith('venue:')).map((t) => t.id), ['blank', 'demo', 'slides'], 'folder templates stay first');
-check(all.length === 6, 'the gallery is the blank tile, the folder templates and the venues');
+check(all.length === 8, 'the gallery is the blank tile, the folder templates, the installed venues and the fetched ones');
+const venueHalf = all.filter((t) => t.id.startsWith('venue:')).map((t) => t.name);
+eq(venueHalf, [...venueHalf].sort((a, b) => a.localeCompare(b)), 'installed and fetched venues share one alphabet, so a category does not restart it');
+eq(all.filter((t) => t.id === 'venue:neurips').length, 1, 'a venue that is both installed and fetchable is listed once');
+check(!all.find((t) => t.id === 'venue:neurips').kit, 'the installed class wins the tile: no download needed');
+const fetched = all.find((t) => t.id === 'venue:testvenue');
+eq(fetched.kit.host, '127.0.0.1:1', 'a fetched venue says which host its kit comes from');
+eq(fetched.license, 'Publisher terms', 'a fetched venue links the publisher\u2019s terms instead of claiming a licence');
 
 // ---- seed files per venue ----
 const skeleton = await catalog.venueTemplateFiles('venue:elsarticle');
@@ -190,13 +218,13 @@ catalog.resetVenueCache();
 const startedAt = Date.now();
 const withoutCatalog = await listAllTemplates();
 check(Date.now() - startedAt < 4_000, 'a silent compiler does not hold the template listing open');
-eq(withoutCatalog.map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates answer while the catalog is still in flight');
+eq(withoutCatalog.filter((t) => !t.kit).map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates answer while the catalog is still in flight');
 
 // ---- a compiler without a catalog ----
 globalThis.fetch = async () => { throw new Error('connection refused'); };
 catalog.resetVenueCache();
 eq(await catalog.venueTemplates(), [], 'no catalog is an empty list, not an error');
-eq((await listAllTemplates()).map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates carry the gallery on their own');
+eq((await listAllTemplates()).filter((t) => !t.kit).map((t) => t.id), ['blank', 'demo', 'slides'], 'the folder templates carry the gallery on their own');
 
 // ---- creating a project from either kind ----
 globalThis.fetch = async () => ({ ok: true, json: async () => CATALOG });
@@ -224,11 +252,46 @@ check(!fs.existsSync(path.join(process.env.DATA_DIR, 'projects', fromFolder, 'LI
 const fromVenue = await create('venue:elsarticle');
 check(projectFile(fromVenue, 'main.tex').toString('utf8').includes('{elsarticle}'), 'a venue project starts from that class');
 
+// A kit that cannot be downloaded creates the project anyway, from the
+// skeleton, and says so instead of failing the request.
+const kitRes = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: 'Fetched', template: 'venue:testvenue' } });
+eq(kitRes.statusCode, 200, 'a venue whose kit is unreachable still creates the project');
+const kitBody = JSON.parse(kitRes.body);
+eq(kitBody.venueKit.ok, false, 'the response says the kit could not be downloaded');
+check(kitBody.venueKit.reason.length > 0, 'and why');
+check(projectFile(kitBody.id, 'README-venue.md').toString('utf8').includes('http://127.0.0.1:1/kit.zip'), 'README-venue.md names the kit URL');
+// The venue's own class is what the project does not have, so the skeleton
+// stands on article and keeps the venue's line as a comment.
+const kitMain = projectFile(kitBody.id, 'main.tex').toString('utf8');
+check(kitMain.includes('\\documentclass{article}'), 'the skeleton starts from a class the image has');
+check(kitMain.includes('% \\usepackage{venue}'), 'the venue\u2019s own line waits as a comment');
+
 const bad = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: 'x', template: 'venue:nope' } });
 eq(bad.statusCode, 400, 'an unknown venue id is a 400, not a crash');
 
+// A name past every path component limit is the caller's own path, so the
+// screen names it and answers 400 before any of the project is written.
+const tooLong = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: 'Long', files: { [`${'a'.repeat(300)}.tex`]: 'x' } } });
+eq(tooLong.statusCode, 400, 'a seed name the filesystem cannot write is a 400');
+check(JSON.parse(tooLong.body).error.includes('longer than 255 bytes'), 'and it says which limit the path is past');
+
 const listed = JSON.parse((await app.inject({ method: 'GET', url: '/api/templates' })).body);
 check(listed.some((t) => t.id === 'venue:elsarticle' && t.category === 'Journals'), 'GET /api/templates merges the catalog in');
+
+// What is left in the createProject catch is this server failing to write: a
+// read-only or missing data directory, a full disk. That is a 5xx, and its
+// errno text names DATA_DIR, so the answer is a fixed sentence. Standing a
+// regular file where `projects/` belongs is ENOTDIR for any user, root
+// included, unlike a chmod.
+const projectsDir = path.join(process.env.DATA_DIR, 'projects');
+fs.renameSync(projectsDir, `${projectsDir}.held`);
+fs.writeFileSync(projectsDir, 'not a directory');
+const unwritable = await app.inject({ method: 'POST', url: '/api/projects', payload: { name: 'Nowhere' } });
+fs.rmSync(projectsDir);
+fs.renameSync(`${projectsDir}.held`, projectsDir);
+eq(unwritable.statusCode, 500, 'a data directory this server cannot write is a 500, not a bad request');
+eq(JSON.parse(unwritable.body).error, 'Could not create the project', 'and the answer is one fixed sentence');
+check(!unwritable.body.includes(process.env.DATA_DIR), 'the data directory is not handed to the caller');
 
 await app.close();
 await closeDb();

--- a/apps/server/test/venue-kits.test.mjs
+++ b/apps/server/test/venue-kits.test.mjs
@@ -1,0 +1,463 @@
+/**
+ * Venue kits fetched from a publisher, against a local HTTP server. No test
+ * here reaches the network, and no publisher file is stored in the repo: every
+ * fixture archive is built in-test.
+ *
+ * What is asserted:
+ *  - a good kit is unpacked, filtered to the files the registry names, and the
+ *    kit's own document becomes main.tex
+ *  - archive junk, absolute names and `..` escapes never reach a project
+ *  - 404, timeout, oversize (declared and streamed), a non-zip content type, a
+ *    corrupt archive and a kit missing a named file all fall back to the
+ *    skeleton plus README-venue.md instead of failing project creation
+ *  - a redirect off the entry's host is refused; a same-host one is followed
+ *  - a fresh cache serves without a request; a stale one still serves when the
+ *    fetch fails
+ *  - a registry entry that is not https, or points off its own host, is dropped
+ *  - publisher text in a failure message cannot break out of the LaTeX comment
+ *    it is written into, and the fallback skeleton compiles without the kit
+ *  - a kit past the project seed limits, or one naming a path that is both a
+ *    file and a directory, is a skeleton rather than a failed creation
+ *  - a cache written for a different kit URL or take list is a miss
+ */
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { check, eq } from './assert.mjs';
+import { buildZip } from './zip.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-venue-kits-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+process.env.TEMPLATES_DIR = path.join(tmp, 'templates');
+process.env.VENUES_FILE = path.join(tmp, 'venues.json');
+// The fixture server cannot present a certificate; this is the same test-only
+// gate routes.ts uses for its disown hook.
+process.env.ALDINE_TEST_HOOKS = '1';
+process.env.VENUE_KIT_TIMEOUT_MS = '1500';
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+// ---- fixture archives ----
+
+const STY = '\\ProvidesPackage{venue}\n';
+const TEX = '\\documentclass{article}\n\\usepackage{venue}\n\\begin{document}\nHello\n\\end{document}\n';
+const BIB = '@article{knuth1984,author={Knuth, Donald E.},title={Literate Programming},year={1984}}\n';
+const PDF = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x00, 0xff]);
+
+const GOOD_ZIP = buildZip({
+  'kit-1.0/': '',
+  'kit-1.0/venue.sty': STY,
+  'kit-1.0/sample.tex': TEX,
+  'kit-1.0/sample.bib': BIB,
+  'kit-1.0/figs/plot.pdf': PDF,
+  'kit-1.0/manual.pdf': PDF,           // not in `take`
+  'kit-1.0/.DS_Store': 'junk',
+  '__MACOSX/kit-1.0/._venue.sty': 'junk',
+  '../evil.sty': 'escape',
+  '/etc/passwd': 'absolute',
+});
+const NESTED_ZIP = buildZip({
+  'pack/main.cls': '\\ProvidesClass{pack}\n',
+  'pack/doc.tex': TEX,
+  'pack/bst/first.bst': 'first',
+  'pack/bst/second.bst': 'second',
+});
+const NO_FILES_ZIP = buildZip({ 'kit-1.0/readme.txt': 'nothing useful here' });
+const BIG = Buffer.alloc(1024 * 1024);
+// A second archive for the same venue id, so a registry that changes its kit
+// URL can be told apart from the cache written for the old one.
+const OK2_ZIP = buildZip({
+  'kit-2.0/venue.sty': '\\ProvidesPackage{venue}[2027]\n',
+  'kit-2.0/sample.tex': TEX,
+  'kit-2.0/sample.bib': BIB,
+});
+// The entry name reaches the reader's error message verbatim, and that message
+// is written into main.tex as a comment: a newline in it would end the comment
+// and run the rest as LaTeX. bzip2 is a method the reader refuses by name.
+const INJECT_NAME = 'a.sty\n\\immediate\\write18{id > /tmp/pwned}\n\\input{/etc/passwd}\n%';
+const INJECT_ZIP = buildZip({ [INJECT_NAME]: { data: STY, method: 12 } });
+// `x.sty` is both a file and a directory: createProject writes the seed into a
+// fresh repo, so this is an EEXIST halfway through, not a bad tile.
+const COLLIDE_ZIP = buildZip({ 'x.sty': STY, 'x.sty/y.sty': STY });
+// Past the 1000-file seed limit every other path into createProject respects.
+const MANY_ZIP = buildZip(Object.fromEntries([
+  ['venue.sty', STY],
+  ...Array.from({ length: 1200 }, (_, i) => [`f${i}.tex`, 'x']),
+]));
+
+// ---- fixture server ----
+
+const hits = {};
+let flakyFails = false;
+
+function handler(req, res) {
+  const url = new URL(req.url, 'http://x');
+  hits[url.pathname] = (hits[url.pathname] || 0) + 1;
+  const zip = (buf, type = 'application/zip') => {
+    res.writeHead(200, { 'content-type': type, 'content-length': String(buf.length) });
+    res.end(buf);
+  };
+  switch (url.pathname) {
+    case '/ok.zip': return zip(GOOD_ZIP);
+    case '/ok2.zip': return zip(OK2_ZIP);
+    case '/inject.zip': return zip(INJECT_ZIP);
+    case '/collide.zip': return zip(COLLIDE_ZIP);
+    case '/many.zip': return zip(MANY_ZIP);
+    case '/nested.zip': return zip(NESTED_ZIP, 'application/x-zip-compressed');
+    case '/paramtype.zip': return zip(GOOD_ZIP, 'application/zip;charset=UTF-8');
+    case '/missing.zip': return zip(NO_FILES_ZIP);
+    case '/corrupt.zip': return zip(Buffer.from('this is not a zip at all'));
+    case '/wrongtype.zip': return zip(GOOD_ZIP, 'text/html');
+    case '/notfound.zip': res.writeHead(404); return res.end('no');
+    case '/slow.zip': return;  // never answers: the fetch must time out
+    case '/big-declared.zip':
+      res.writeHead(200, { 'content-type': 'application/zip', 'content-length': String(30 * 1024 * 1024) });
+      return res.end(BIG);
+    case '/big-stream.zip': {
+      res.writeHead(200, { 'content-type': 'application/zip', 'transfer-encoding': 'chunked' });
+      let n = 0;
+      const pump = () => {
+        while (n < 26) { n++; if (!res.write(BIG)) return res.once('drain', pump); }
+        res.end();
+      };
+      return pump();
+    }
+    case '/hop.zip': res.writeHead(302, { location: '/ok.zip' }); return res.end();
+    case '/relative-hop.zip': res.writeHead(301, { location: `http://127.0.0.1:${port}/ok.zip` }); return res.end();
+    case '/loop.zip': res.writeHead(302, { location: '/loop.zip' }); return res.end();
+    case '/offhost.zip': res.writeHead(302, { location: `http://127.0.0.1:${otherPort}/ok.zip` }); return res.end();
+    case '/flaky.zip':
+      if (flakyFails) { res.writeHead(500); return res.end('down'); }
+      return zip(GOOD_ZIP);
+    case '/bare.tex':
+      res.writeHead(200, { 'content-type': 'text/x-tex' });
+      return res.end(TEX);
+    case '/bare-2020.sty':
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+      return res.end(STY);
+    case '/bare-notype.tex':
+      // A proxy that strips the content-type off an error page: the bytes are
+      // not a LaTeX file, and nothing says so.
+      res.writeHead(200);
+      return res.end('<html>maintenance</html>');
+    default: res.writeHead(404); return res.end('?');
+  }
+}
+
+const server = http.createServer(handler);
+const other = http.createServer(handler);
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+await new Promise((r) => other.listen(0, '127.0.0.1', r));
+const port = server.address().port;
+const otherPort = other.address().port;
+const origin = `http://127.0.0.1:${port}`;
+
+// ---- registry ----
+
+const base = {
+  category: 'Conferences',
+  description: 'A venue used only by this test.',
+  homepage: 'https://example.org/authors',
+  termsUrl: 'https://example.org/terms',
+  documentClass: 'article',
+  preamble: ['\\usepackage{venue}'],
+  bibStyle: 'plain',
+};
+const archive = (id, file, take = ['venue.sty', 'sample.tex', 'sample.bib', '**/figs/*.pdf'], extra = {}) => ({
+  ...base, id, name: id.toUpperCase(),
+  kit: { url: `${origin}/${file}`, host: `127.0.0.1:${port}`, take },
+  main: 'sample.tex',
+  ...extra,
+});
+
+/** An entry whose kit is expected to fail: no `main`, so the preamble carries it. */
+const failing = (id, file, take = ['venue.sty'], extra = {}) => ({
+  ...base, id, name: id.toUpperCase(),
+  kit: { url: `${origin}/${file}`, host: `127.0.0.1:${port}`, take },
+  ...extra,
+});
+
+const VENUES = [
+  archive('good', 'ok.zip'),
+  failing('inject', 'inject.zip'),
+  failing('collide', 'collide.zip', ['x.sty', '*.sty']),
+  failing('toomany', 'many.zip', ['venue.sty', '*.tex']),
+  // The venue's own class and style, which a failed kit does not deliver.
+  failing('venuecls', 'notfound.zip', ['venuecls.cls'], {
+    documentClass: 'venuecls', preamble: ['\\usepackage{venuesty}'], bibStyle: 'venuebst',
+  }),
+  failing('clsbib', 'notfound.zip', ['venuecls2.cls'], {
+    documentClass: 'venuecls2', preamble: ['\\usepackage{venuesty2}'], classSetsBibStyle: true,
+  }),
+  // A style-file venue with class options: the options are stock article's and
+  // survive the fallback. Its own-class twin's options do not.
+  failing('styopts', 'notfound.zip', ['venue.sty'], { classOptions: '10pt,twocolumn,letterpaper' }),
+  failing('clsopts', 'notfound.zip', ['venuecls3.cls'], {
+    documentClass: 'venuecls3', classOptions: 'sigconf,anonymous',
+  }),
+  // `constructor` is an Object.prototype key: a `main` the kit does not carry
+  // must be a miss, not the Object constructor written into main.tex.
+  { ...base, id: 'protomain', name: 'PROTOMAIN', main: 'constructor',
+    kit: { url: `${origin}/ok.zip`, host: `127.0.0.1:${port}`, take: ['venue.sty', '*'] } },
+  { ...base, id: 'notype', name: 'NOTYPE',
+    kit: { urls: [`${origin}/bare-notype.tex`], host: `127.0.0.1:${port}` } },
+  archive('paramtype', 'paramtype.zip'),
+  archive('notfound', 'notfound.zip'),
+  archive('slow', 'slow.zip'),
+  archive('bigdeclared', 'big-declared.zip'),
+  archive('bigstream', 'big-stream.zip'),
+  archive('wrongtype', 'wrongtype.zip'),
+  archive('corrupt', 'corrupt.zip'),
+  archive('missing', 'missing.zip'),
+  archive('hop', 'hop.zip'),
+  archive('relhop', 'relative-hop.zip'),
+  archive('loop', 'loop.zip'),
+  archive('offhost', 'offhost.zip'),
+  archive('flaky', 'flaky.zip'),
+  {
+    ...base, id: 'nested', name: 'NESTED',
+    kit: { url: `${origin}/nested.zip`, host: `127.0.0.1:${port}`, take: ['main.cls', 'doc.tex', '*.bst'], flatten: true },
+    documentClass: 'main', main: 'doc.tex',
+  },
+  {
+    ...base, id: 'bare', name: 'BARE',
+    kit: {
+      urls: [`${origin}/bare.tex`, `${origin}/bare-2020.sty`],
+      host: `127.0.0.1:${port}`,
+      rename: { 'bare-2020.sty': 'venue.sty' },
+    },
+    main: 'bare.tex',
+  },
+  // Dropped at load time, every one of them.
+  { ...base, id: 'plain-http', name: 'HTTP', kit: { url: 'http://example.org/kit.zip', host: 'example.org', take: ['a.sty'] }, main: 'a.tex' },
+  { ...base, id: 'offallow', name: 'OFF', kit: { url: 'https://elsewhere.example/kit.zip', host: 'example.org', take: ['a.sty'] }, main: 'a.tex' },
+  { ...base, id: 'notake', name: 'NOTAKE', kit: { url: 'https://example.org/kit.zip', host: 'example.org' }, main: 'a.tex' },
+  { ...base, id: 'globonly', name: 'GLOB', kit: { url: 'https://example.org/kit.zip', host: 'example.org', take: ['*.sty'] }, main: 'a.tex' },
+  { ...base, id: 'no-main-no-preamble', name: 'EMPTY', preamble: [], kit: { url: 'https://example.org/k.zip', host: 'example.org', take: ['a.sty'] } },
+  { ...base, id: 'good', name: 'DUPLICATE', kit: { url: `${origin}/ok.zip`, host: `127.0.0.1:${port}`, take: ['venue.sty'] }, main: 'venue.sty' },
+  { ...base, id: 'escape', name: 'ESCAPE', kit: { url: 'https://example.org/k.zip', host: 'example.org', take: ['a.sty'], rename: { 'a.sty': '../a.sty' } }, main: 'a.tex' },
+];
+fs.writeFileSync(process.env.VENUES_FILE, JSON.stringify({ venues: VENUES }, null, 2));
+
+const kits = await import('../src/venuekits.ts');
+
+// ---- registry validation ----
+
+const loaded = kits.venueKits().map((e) => e.id);
+eq(loaded.sort(), [
+  'bare', 'bigdeclared', 'bigstream', 'clsbib', 'clsopts', 'collide', 'corrupt', 'flaky', 'good',
+  'hop', 'inject', 'loop', 'missing', 'nested', 'notfound', 'notype', 'offhost',
+  'paramtype', 'protomain', 'relhop', 'slow', 'styopts', 'toomany', 'venuecls', 'wrongtype',
+].sort(), 'only entries that pass validation are loaded');
+
+const problem = (over) => kits.entryProblem({ ...archive('x', 'ok.zip'), ...over });
+check(/not https/.test(problem({ kit: { url: 'http://example.org/k.zip', host: 'example.org', take: ['a.sty'] } })), 'a non-loopback http URL is refused');
+check(/is not on/.test(problem({ kit: { url: 'https://elsewhere.example/k.zip', host: 'example.org', take: ['a.sty'] } })), 'a URL off the entry\u2019s own host is refused');
+check(/take list/.test(problem({ kit: { url: 'https://example.org/k.zip', host: 'example.org' } })), 'an archive kit without a take list is refused');
+check(/category/.test(problem({ category: 'Nonsense' })), 'an unknown category is refused');
+check(/homepage/.test(problem({ homepage: 'ftp://example.org' })), 'a homepage that is not https is refused');
+check(/main file or a preamble/.test(problem({ main: undefined, preamble: [] })), 'an entry with neither a main nor a preamble is refused');
+check(/not in the take list/.test(problem({ main: 'elsewhere.tex' })), 'a main the take list cannot produce is refused');
+check(/rename target/.test(problem({ kit: { url: `${origin}/ok.zip`, host: `127.0.0.1:${port}`, take: ['sample.tex'], rename: { 'sample.tex': '../a.sty' } } })), 'a rename that escapes the project is refused');
+check(kits.entryProblem(archive('x', 'ok.zip')) === null, 'a well-formed entry has no problem');
+
+// ---- the good path ----
+
+const seed = async (id) => kits.venueKitSeed(kits.venueKit(id));
+
+const good = await seed('good');
+check(good.venueKit.ok, 'a kit that downloads and unpacks is a success');
+eq(Object.keys(good.files).sort(), ['figs/plot.pdf', 'main.tex', 'sample.bib', 'venue.sty'], 'only the files the entry names reach the project');
+eq(good.files['main.tex'].toString('utf8'), TEX, 'the kit\u2019s own document becomes main.tex');
+check(good.files['figs/plot.pdf'].equals(PDF), 'a binary file survives byte for byte');
+check(!('README-venue.md' in good.files), 'a successful kit needs no README');
+eq(hits['/ok.zip'], 1, 'the kit was downloaded once');
+
+const cached = await seed('good');
+eq(hits['/ok.zip'], 1, 'a fresh cache answers without a second request');
+eq(Object.keys(cached.files).sort(), ['figs/plot.pdf', 'main.tex', 'sample.bib', 'venue.sty'], 'the cache round-trips every file');
+check(cached.files['figs/plot.pdf'].equals(PDF), 'the cache round-trips bytes, not text');
+
+check((await seed('paramtype')).venueKit.ok, 'content-type parameters (application/zip;charset=UTF-8) are not part of the type');
+
+const nested = await seed('nested');
+check(nested.venueKit.ok, 'a nested archive unpacks');
+eq(Object.keys(nested.files).sort(), ['first.bst', 'main.cls', 'main.tex', 'second.bst'], 'flatten drops the directories the kit nests files in');
+
+const bare = await seed('bare');
+check(bare.venueKit.ok, 'a venue that publishes bare files instead of an archive works');
+eq(Object.keys(bare.files).sort(), ['main.tex', 'venue.sty'], 'a bare file is renamed the way the entry says');
+eq(bare.files['venue.sty'].toString('utf8'), STY, 'the renamed style file has the right content');
+
+// ---- failures: the project is still created ----
+
+const failed = async (id, part, msg) => {
+  const r = await seed(id);
+  check(!r.venueKit.ok, `${msg}: expected a failure, got a success`);
+  check(r.venueKit.reason.includes(part), `${msg}: reason "${r.venueKit.reason}" should mention "${part}"`);
+  eq(Object.keys(r.files).sort(), ['README-venue.md', 'main.tex', 'references.bib'], `${msg}: the project is the skeleton plus the README`);
+  check(r.files['main.tex'].toString('utf8').includes('\\documentclass'), `${msg}: the skeleton is a document`);
+  check(r.files['README-venue.md'].toString('utf8').includes(r.venueKit.url), `${msg}: the README names the kit URL`);
+  return r;
+};
+
+const gone = await failed('notfound', 'HTTP 404', 'a kit that is not there');
+await failed('slow', 'seconds', 'a server that never answers');
+await failed('bigdeclared', 'limit', 'a kit that declares more than the size cap');
+await failed('bigstream', 'limit', 'a kit that streams past the size cap without declaring a length');
+await failed('wrongtype', 'not a zip', 'a kit served as something other than an archive');
+await failed('corrupt', 'could not be read', 'an archive that is not a zip');
+await failed('missing', 'venue.sty', 'an archive without the files the entry names');
+await failed('offhost', 'which is not', 'a redirect off the entry\u2019s own host');
+await failed('loop', 'redirects', 'a redirect loop');
+
+const readme = (await seed('notfound')).files['README-venue.md'].toString('utf8');
+check(readme.includes('https://example.org/authors'), 'the README links the author guide');
+check(readme.includes('https://example.org/terms'), 'the README links the venue\u2019s terms');
+check(!/—/.test(readme), 'no em-dashes in what the user reads');
+
+check((await seed('hop')).venueKit.ok, 'a redirect that stays on the entry\u2019s host is followed');
+check((await seed('relhop')).venueKit.ok, 'an absolute same-host redirect is followed too');
+await failed('notype', 'no content type', 'a bare file served without a content type');
+
+// ---- publisher text never becomes LaTeX ----
+
+// The reason quotes the archive's own entry name, which the publisher chooses.
+const inject = await failed('inject', 'could not be read', 'an archive whose entry name carries LaTeX');
+check(!/[\r\n]/.test(inject.venueKit.reason), 'the failure reason is one line, whatever the archive named its entries');
+const injectTex = inject.files['main.tex'].toString('utf8');
+const live = (tex) => tex.split('\n').filter((l) => !l.startsWith('%')).join('\n');
+check(!live(injectTex).includes('write18'), 'nothing the publisher wrote runs as LaTeX in main.tex');
+check(!live(injectTex).includes('/etc/passwd'), 'nor does an \\input the archive name asked for');
+check(live(injectTex).trimStart().startsWith('\\documentclass'), 'the document still starts at \\documentclass');
+const injectReadme = inject.files['README-venue.md'].toString('utf8');
+check(injectReadme.split('\n').filter((l) => l.includes('write18')).length === 1, 'the README keeps the publisher text on the one line that quotes it');
+
+// ---- a kit that is not a project seed ----
+
+// The archive caps are not the seed caps: every other path into createProject
+// is held to 1000 files, and a name that is both a file and a directory fails
+// the write halfway through.
+await failed('collide', 'file and a directory', 'a kit naming one path as both a file and a directory');
+await failed('toomany', 'the limit is 1000', 'a kit with more files than a project seed allows');
+
+// The byte budget, which no fixture archive should have to carry.
+eq(kits.kitSeedProblem({ 'a.sty': Buffer.alloc(33 * 1024 * 1024) }), 'it is 33 MB unpacked; the limit is 32 MB',
+  'a kit past the 32 MB seed budget is refused before createProject sees it');
+eq(kits.kitSeedProblem({ 'a.sty': Buffer.from('x') }), null, 'an ordinary kit passes');
+eq(kits.kitSeedProblem({ '.gitignore': Buffer.from('x') }), null, 'the project\u2019s own .gitignore only clashes as a directory');
+check(kits.kitSeedProblem({ '.gitignore/x': Buffer.from('x') }) !== null, 'a kit that makes .gitignore a directory is refused');
+// NAME_MAX: a publisher entry one byte past it is ENAMETOOLONG inside
+// createProject, which owes the caller a skeleton rather than a 500.
+eq(kits.kitSeedProblem({ [`${'a'.repeat(256)}.sty`]: Buffer.from('x') }), 'it has a name longer than 255 bytes',
+  'a kit whose file name the filesystem cannot write is refused before createProject sees it');
+eq(kits.kitSeedProblem({ [`${'a'.repeat(251)}.sty`]: Buffer.from('x') }), null, 'a name the filesystem can write passes');
+
+// ---- the fallback skeleton stands on its own ----
+
+const noKit = await failed('venuecls', 'HTTP 404', 'a venue whose class the project does not have');
+const noKitTex = noKit.files['main.tex'].toString('utf8');
+check(live(noKitTex).includes('\\documentclass{article}'), 'without the kit the skeleton starts from article, which every image has');
+check(!live(noKitTex).includes('venuecls'), 'the venue class it does not have is not named in live LaTeX');
+check(!live(noKitTex).includes('venuesty'), 'nor is the style the kit was going to bring');
+check(noKitTex.includes('% \\documentclass{venuecls}'), 'the real class is kept as a comment to swap in');
+check(noKitTex.includes('% \\usepackage{venuesty}'), 'so is the preamble the venue wants');
+check(live(noKitTex).includes('\\bibliographystyle{plain}'), 'the bib style is one BibTeX has, not the kit\u2019s own .bst');
+check(!live(noKitTex).includes('venuebst'), 'the venue\u2019s .bst is not named without the kit');
+// A style-file venue already stands on article: only its \usepackage waits.
+const goneTex = gone.files['main.tex'].toString('utf8');
+eq(goneTex.match(/^\\documentclass/gm).length, 1, 'the fallback names one live document class');
+check(goneTex.includes('% \\usepackage{venue}'), 'the style the kit was going to bring is a comment, not a missing package');
+
+// The commented preamble must sit BELOW the live \documentclass: uncommenting
+// a \usepackage above it is a fatal error, and the comment says to uncomment.
+{
+  const live = goneTex.indexOf('\n\\documentclass');
+  const waiting = goneTex.indexOf('% \\usepackage');
+  check(live >= 0 && waiting > live, 'the commented preamble follows the live documentclass');
+}
+check(!live(goneTex).includes('\\usepackage{venue}'), 'and it is not loaded before it exists');
+const clsBib = await failed('clsbib', 'HTTP 404', 'a venue whose class sets its own bib style');
+const clsBibTex = clsBib.files['main.tex'].toString('utf8');
+check(live(clsBibTex).includes('\\bibliographystyle{plain}'), 'a class that would set the bib style is not there either, so the skeleton sets one');
+
+// A style-file venue's class options are article's own (10pt, twocolumn,
+// letterpaper): dropping them silently gives a one-column default page and
+// leaves no record of the shape the venue asked for.
+const styOpts = await failed('styopts', 'HTTP 404', 'a style-file venue with class options');
+const styOptsTex = styOpts.files['main.tex'].toString('utf8');
+check(live(styOptsTex).includes('\\documentclass[10pt,twocolumn,letterpaper]{article}'),
+  'a style-file venue keeps its class options without the kit');
+eq(styOptsTex.match(/^\\documentclass/gm).length, 1, 'and still names one live document class');
+// The own-class branch cannot: `sigconf` means nothing to article.
+const clsOpts = await failed('clsopts', 'HTTP 404', 'an own-class venue with class options');
+const clsOptsTex = clsOpts.files['main.tex'].toString('utf8');
+check(live(clsOptsTex).includes('\\documentclass{article}'), 'an own-class venue falls back to plain article');
+check(!live(clsOptsTex).includes('sigconf'), 'its class options are not handed to article, which does not know them');
+check(clsOptsTex.includes('% \\documentclass[sigconf,anonymous]{venuecls3}'), 'they wait in the comment with the class');
+
+// ---- a main the kit does not carry ----
+
+// 'constructor' answers `in` on any object literal: the miss must be a miss.
+const proto = await seed('protomain');
+check(proto.venueKit.ok, 'a kit whose named main is absent is still a good kit');
+check(proto.files['main.tex'].toString('utf8').includes('generated by Aldine from the official kit'),
+  'the generated skeleton stands in for the document the kit does not carry');
+check(Buffer.isBuffer(proto.files['main.tex']), 'main.tex is bytes, not something off Object.prototype');
+eq(Object.keys(kits.selectKitFiles({ 'kit/constructor': Buffer.from('c'), 'kit/toString': Buffer.from('t') },
+  { host: 'x', take: ['constructor', 'toString'] })).sort(), ['constructor', 'toString'],
+  'a kit file named after an Object.prototype key is placed, not silently dropped');
+
+// ---- the cache outlives the publisher ----
+
+flakyFails = false;
+check((await seed('flaky')).venueKit.ok, 'the flaky kit caches while it is up');
+const stamp = path.join(process.env.CACHE_DIR, 'venue-kits', 'flaky', 'kit.json');
+const meta = JSON.parse(fs.readFileSync(stamp, 'utf8'));
+meta.fetchedAt = Date.now() - 30 * 24 * 60 * 60 * 1000;
+fs.writeFileSync(stamp, JSON.stringify(meta));
+flakyFails = true;
+const stale = await seed('flaky');
+check(stale.venueKit.ok, 'a cached kit is used when the fetch fails, whatever its age');
+eq(Object.keys(stale.files).sort(), ['figs/plot.pdf', 'main.tex', 'sample.bib', 'venue.sty'], 'the stale cache seeds the whole kit');
+check(hits['/flaky.zip'] >= 2, 'the stale cache was only used after the refetch failed');
+
+// ---- a registry change outranks the cache ----
+
+// The cached kit is the old URL's files; the skeleton would still name the new
+// preamble, so a project seeded from the cache could not typeset.
+const registryFile = process.env.VENUES_FILE;
+const bumped = VENUES.map((v) => (v.id === 'good' ? { ...v, kit: { ...v.kit, url: `${origin}/ok2.zip` } } : v));
+fs.writeFileSync(registryFile, JSON.stringify({ venues: bumped }, null, 2));
+eq(kits.venueKit('good').kit.url, `${origin}/ok2.zip`, 'the registry reloads when the file changes');
+const rolled = await seed('good');
+check(rolled.venueKit.ok, 'the new kit downloads');
+eq(hits['/ok2.zip'], 1, 'a cache written for the old kit URL is a miss, not seven days of last year\u2019s files');
+check(rolled.files['venue.sty'].toString('utf8').includes('2027'), 'the project gets the files the registry names now');
+
+// ---- selection is not a path oracle ----
+
+const hostile = { 'kit/a.sty': Buffer.from('a'), '../b.sty': Buffer.from('b'), 'kit/.git/config': Buffer.from('c') };
+eq(Object.keys(kits.selectKitFiles(hostile, { host: 'x', take: ['a.sty', '*.sty', 'config*'] })), ['a.sty'],
+  'a `..` entry and a .git entry are never selected, however wide the globs');
+let refused = null;
+try { kits.selectKitFiles(hostile, { host: 'x', take: ['a.sty', 'b.sty'] }); } catch (err) { refused = err.message; }
+check(refused && refused.includes('b.sty'), 'an entry the archive does not have is a failure, not a half-seeded project');
+
+// ---- the gallery ----
+
+const tiles = kits.venueKitTemplates();
+const tile = tiles.find((t) => t.id === 'venue:good');
+eq(tile.category, 'Conferences', 'the tile keeps its category');
+eq(tile.kit.host, `127.0.0.1:${port}`, 'the tile says which host the kit comes from');
+eq(tile.license, 'Publisher terms', 'the tile does not claim a licence Aldine cannot assert');
+eq(tile.licenseUrl, 'https://example.org/terms', 'the tile links the venue\u2019s terms');
+check(tiles.every((t) => t.id.startsWith('venue:')), 'fetched venues share the venue id space with the installed classes');
+
+server.close();
+other.close();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('venue kits: all checks passed');

--- a/apps/server/test/venue-registry.test.mjs
+++ b/apps/server/test/venue-registry.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * The shipped registry, templates/venues.json. Nothing here fetches anything:
+ * this is the load-time gate the server applies at boot, run against the real
+ * file so a bad entry fails CI rather than disappearing from the gallery with
+ * a warning nobody reads.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { check, eq } from './assert.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-venue-registry-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'secrets');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+// No test hooks: the shipped registry must pass the production rules, where
+// only https is fetchable.
+delete process.env.ALDINE_TEST_HOOKS;
+delete process.env.VENUES_FILE;
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+const file = path.join(repoRoot, 'templates', 'venues.json');
+check(fs.existsSync(file), 'templates/venues.json is the registry the server loads');
+const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+check(Array.isArray(raw.venues) && raw.venues.length > 0, 'the registry carries a non-empty venues array');
+
+const kits = await import('../src/venuekits.ts');
+const loaded = kits.venueKits();
+eq(loaded.length, raw.venues.length, 'every entry in the file passes validation (none is dropped at load)');
+
+const ids = loaded.map((e) => e.id);
+eq(ids.length, new Set(ids).size, 'venue ids are unique');
+
+for (const e of loaded) {
+  const where = `venue "${e.id}"`;
+  check(kits.entryProblem(e) === null, `${where} passes the load-time gate`);
+  check(['Journals', 'Conferences', 'Theses', 'Slides', 'General'].includes(e.category), `${where} has a gallery category`);
+  check(new URL(e.homepage).protocol === 'https:', `${where} has an https homepage`);
+  check(!!e.main || (e.preamble || []).length > 0, `${where} has either a main file or a preamble`);
+  check(!!e.documentClass, `${where} names a document class`);
+  const urls = e.kit.url ? [e.kit.url] : e.kit.urls;
+  for (const u of urls) {
+    check(new URL(u).protocol === 'https:', `${where}: ${u} is https`);
+    eq(new URL(u).host, e.kit.host, `${where}: the kit URL is on the host the entry allows`);
+  }
+  if (e.kit.url) {
+    check((e.kit.take || []).some((g) => !/[*?]/.test(g)), `${where} names at least one exact file to take`);
+  }
+  // The tile links the venue's own terms; that is all Aldine can say about a
+  // publisher kit it never redistributes.
+  if (e.termsUrl) check(new URL(e.termsUrl).protocol === 'https:', `${where} has an https termsUrl`);
+}
+
+// An installed class that still claims a venue the registry now ships on its
+// own tile puts two tiles for the same submission in the gallery, with nothing
+// on either to choose between them. Dedup is by id, so only the descriptions
+// can say this wrong.
+const { INSTALLED_VENUES } = await import('../src/catalog.ts');
+for (const e of loaded) {
+  for (const [id, meta] of Object.entries(INSTALLED_VENUES)) {
+    if (id === e.id) continue;
+    check(!meta.description.includes(e.name),
+      `the installed "${id}" description claims ${e.name}, which has its own fetched tile: "${meta.description}"`);
+  }
+}
+
+const tiles = kits.venueKitTemplates();
+eq(tiles.length, loaded.length, 'every registry entry becomes a gallery tile');
+check(tiles.every((t) => t.kit && t.kit.host && t.kit.url), 'every fetched tile says where its kit comes from');
+check(tiles.every((t) => t.id.startsWith('venue:')), 'fetched tiles live in the venue id space');
+
+// A kit unpacked into the repo would ship a publisher file with Aldine. Every
+// path under templates/ is either the registry or part of a folder template.
+const stray = [];
+for (const name of fs.readdirSync(path.join(repoRoot, 'templates'), { withFileTypes: true })) {
+  if (name.isFile()) { if (name.name !== 'venues.json') stray.push(name.name); continue; }
+  if (!fs.existsSync(path.join(repoRoot, 'templates', name.name, 'template.json'))) stray.push(`${name.name}/`);
+}
+eq(stray, [], 'nothing but folder templates and the registry lives under templates/');
+
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log(`venue registry: ${loaded.length} venues checked, all valid`);

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -89,6 +89,23 @@ export interface TemplateInfo {
   license?: string;
   licenseUrl?: string;
   source?: { url: string; version?: string };
+  /** Fetched-kit venues: where the official kit is downloaded from at create time. */
+  kit?: { host: string; url: string; homepage?: string; termsUrl?: string };
+}
+
+/** How the venue kit went while the project was being created. */
+export interface VenueKitStatus {
+  id: string;
+  name: string;
+  host: string;
+  url: string;
+  ok: boolean;
+  reason?: string;
+}
+
+/** POST /api/projects: a fetched-venue project also reports its kit. */
+export interface CreatedProject extends ProjectSummary {
+  venueKit?: VenueKitStatus;
 }
 
 /** What /api/projects/import decided while placing the archive. */
@@ -100,7 +117,7 @@ export interface CompilerInfo { ok: boolean; texlive: { release: string; scheme:
 export const api = {
   listProjects: () => req<ProjectSummary[]>('/api/projects'),
   createProject: (name: string, files?: Record<string, string>, template?: string) =>
-    req<ProjectSummary>('/api/projects', { method: 'POST', body: JSON.stringify({ name, files, template }) }),
+    req<CreatedProject>('/api/projects', { method: 'POST', body: JSON.stringify({ name, files, template }) }),
   templates: () => req<TemplateInfo[]>('/api/templates'),
   /** Multipart so the browser streams the File itself; the JSON + base64
    *  shape stays on the server for API clients. */

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -875,3 +875,11 @@
   .split-pdf, .pdf-pane { display: none; }
   .sidebar { position: absolute; z-index: 30; height: 100%; box-shadow: var(--shadow-pop); }
 }
+
+/* The typesetting log opens at its first error; mark it so the eye lands there. */
+.logview__hit {
+  background: color-mix(in srgb, var(--error) 22%, transparent);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 2px;
+}

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -161,6 +161,7 @@
 .tpl__icon { font-size: 16px; }
 .tpl__name { font-weight: 600; font-size: 13px; }
 .tpl__desc { font-size: 11px; color: var(--text-2); line-height: 1.35; }
+.tpl__kit { font-size: 10px; color: var(--text-3); margin-top: 4px; }
 .tpl__license { font-size: 10px; color: var(--text-2); opacity: 0.8; margin-top: 4px; }
 .tpl-search { position: relative; margin-top: 12px; }
 .tpl-search .input { padding-right: 30px; }

--- a/apps/web/src/components/Onboarding.tsx
+++ b/apps/web/src/components/Onboarding.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import Modal from './Modal';
 import { shortcut } from '../platform';
 /** First-run welcome shown once (localStorage-gated by the parent). */
@@ -5,6 +6,9 @@ export default function Onboarding({ onNew, onGithub, onImportZip, onClose }: {
   onNew(): void; onGithub(): void; onImportZip(file: File): void; onClose(): void;
 }) {
   const start = (fn: () => void) => { onClose(); fn(); };
+  // A <label> around a hidden file input is not focusable, so the tile was
+  // mouse-only; a button that opens the input keeps it on the tab order.
+  const zipInput = useRef<HTMLInputElement>(null);
 
   return (
     <Modal onClose={onClose} label="Welcome to Aldine" testId="onboarding" wide>
@@ -17,15 +21,16 @@ export default function Onboarding({ onNew, onGithub, onImportZip, onClose }: {
             <span className="onboard__tile-title">Start a paper</span>
             <span className="onboard__tile-sub">A blank doc or a template.</span>
           </button>
-          <label className="onboard__tile onboard__tile--gh" onClick={() => start(onGithub)} data-testid="onboard-github">
+          <button className="onboard__tile onboard__tile--gh" onClick={() => start(onGithub)} data-testid="onboard-github">
             <span className="onboard__tile-title">Import from GitHub</span>
             <span className="onboard__tile-sub">Clone a repo, then push &amp; pull as you write.</span>
-          </label>
-          <label className="onboard__tile" data-testid="onboard-zip">
+          </button>
+          <button className="onboard__tile" data-testid="onboard-zip" onClick={() => zipInput.current?.click()}>
             <span className="onboard__tile-title">Import a ZIP</span>
             <span className="onboard__tile-sub">Bring a project over from Overleaf.</span>
-            <input type="file" accept=".zip" hidden onChange={(e) => { if (e.target.files?.[0]) { const f = e.target.files[0]; onClose(); onImportZip(f); } }} />
-          </label>
+          </button>
+          <input ref={zipInput} type="file" accept=".zip" hidden aria-hidden="true" tabIndex={-1}
+            onChange={(e) => { if (e.target.files?.[0]) { const f = e.target.files[0]; onClose(); onImportZip(f); } }} />
         </div>
 
         <ul className="onboard__points">

--- a/apps/web/src/components/Toast.tsx
+++ b/apps/web/src/components/Toast.tsx
@@ -13,7 +13,9 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const push = useCallback((text: string, kind: Toast['kind'] = 'info') => {
     const id = Date.now() + Math.random();
     setToasts((t) => [...t, { id, text, kind }]);
-    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 3400);
+    // An error carries a sentence to read and usually something to do about
+    // it, so it stays about twice as long as a confirmation.
+    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), kind === 'error' ? 7000 : 3400);
   }, []);
   return (
     <ToastCtx.Provider value={push}>

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -74,6 +74,11 @@ export default function Editor() {
     });
   }, []);
   const [showLog, setShowLog] = useState(false);
+  // Scroll the log to its first error once the dialog has rendered.
+  const logHit = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (showLog) logHit.current?.scrollIntoView({ block: 'center' });
+  }, [showLog]);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -889,7 +894,19 @@ export default function Editor() {
         <Modal onClose={() => setShowLog(false)} label="Typesetting log" wide>
           <div>
             <h2>Typesetting log</h2>
-            <pre className="logview" data-testid="log-view">{compile.result.log || '(no log)'}</pre>
+            <pre className="logview" data-testid="log-view">{(() => {
+              const log = compile.result.log || '(no log)';
+              // Open at the first error, not at the pdfTeX banner: the reason
+              // for opening the log is 300 lines below the top.
+              const at = log.search(/^(?:! |[^\n]*:\d+: )/m);
+              if (at < 0) return log;
+              const end = log.indexOf('\n', at);
+              return (<>
+                {log.slice(0, at)}
+                <mark className="logview__hit" ref={logHit} data-testid="log-first-error">{log.slice(at, end < 0 ? undefined : end)}</mark>
+                {end < 0 ? '' : log.slice(end)}
+              </>);
+            })()}</pre>
             <div className="modal__row">
               <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginRight: 'auto', fontSize: 12.5 }} title="On: the run stops at the first error and the preview keeps the previous PDF. Off: the run continues to the end and the complete PDF is shown beside the errors">
                 <input type="checkbox" data-testid="stop-on-error-toggle" checked={!!project?.stopOnFirstError} onChange={(e) => setStopOnFirstError(e.target.checked)} />

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -24,7 +24,7 @@ const IMPORT_MAX_ZIP_BYTES = IMPORT_MAX_ZIP_MB * 1024 * 1024;
 const TEMPLATE_CATEGORIES: TemplateCategory[] = ['General', 'Journals', 'Conferences', 'Theses', 'Slides'];
 
 function matchesQuery(t: TemplateInfo, q: string): boolean {
-  const hay = [t.name, t.description, t.category, t.documentClass, t.id].join(' ').toLowerCase();
+  const hay = [t.name, t.description, t.category, t.documentClass, t.id, t.kit?.host].join(' ').toLowerCase();
   return q.split(/\s+/).every((word) => hay.includes(word));
 }
 
@@ -78,7 +78,11 @@ export default function Home() {
   const create = async () => {
     const name = newName.trim() || 'Untitled Project';
     try {
-      const p = await api.createProject(name, undefined, templateToPost(templates ?? [], template));      navigate(`/p/${p.id}`);
+      const p = await api.createProject(name, undefined, templateToPost(templates ?? [], template));
+      if (p.venueKit && !p.venueKit.ok) {
+        toast(`Could not download the ${p.venueKit.name} kit from ${p.venueKit.host}. The project was created from a skeleton; README-venue.md says where to get the kit.`, 'error');
+      }
+      navigate(`/p/${p.id}`);
     } catch (err: any) {
       toast(`Could not create project: ${err.message}`, 'error');
     }
@@ -367,6 +371,13 @@ export default function Home() {
                                 <span className="tpl__icon">{t.icon || '📄'}</span>
                                 <span className="tpl__name">{t.name}</span>
                                 <span className="tpl__desc">{t.description}</span>
+                                {/* The kit is downloaded when the project is created, not now:
+                                    say so before the user picks the tile. */}
+                                {t.kit && (
+                                  <span className="tpl__kit" data-testid={`template-kit-${t.id}`}>
+                                    Downloads the official kit from {t.kit.host}
+                                  </span>
+                                )}
                                 {t.license && <span className="tpl__license" data-testid={`template-license-${t.id}`}>{t.license}</span>}
                               </button>
                             ))}
@@ -379,6 +390,7 @@ export default function Home() {
                 <p className="tpl-choice" data-testid="template-choice">
                   Starting from {chosen ? chosen.name : 'the built-in article'}
                   {chosen?.license ? ` (${chosen.license})` : ''}
+                  {chosen?.kit ? `. Aldine downloads the official kit from ${chosen.kit.host} when you create the project.` : ''}
                 </p>
               </>
             )}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api, ApiError, ProjectSummary, TemplateCategory, TemplateInfo } from '../api';
 import { useToast } from '../components/Toast';
@@ -31,6 +31,7 @@ function matchesQuery(t: TemplateInfo, q: string): boolean {
 export default function Home() {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
+  const zipInput = useRef<HTMLInputElement>(null);
   const [creating, setCreating] = useState(false);
   const [themeChoice, setThemeChoice] = useState(getTheme());
   const [newName, setNewName] = useState('');
@@ -70,15 +71,24 @@ export default function Home() {
     }).catch(() => setTemplates([]));
   }, []);
 
-  // The gallery keeps its choice while the search narrows it, so the tile that
-  // Create will actually use is often filtered away: name it in the dialog.
-  const chosen = templates?.find((t) => t.id === template) ?? null;
+  // A search that hides the chosen tile would leave Create acting on something
+  // the user cannot see, so the first result of a narrowing search becomes the
+  // choice. With no search, or when the choice is still on screen, it stands.
+  const shownTemplates = (() => {
+    const q = templateQuery.trim().toLowerCase();
+    if (!templates) return [] as TemplateInfo[];
+    return q ? templates.filter((t) => matchesQuery(t, q)) : templates;
+  })();
+  const effectiveTemplate = shownTemplates.some((t) => t.id === template)
+    ? template
+    : shownTemplates[0]?.id ?? template;
+  const chosen = templates?.find((t) => t.id === effectiveTemplate) ?? null;
   const closeCreate = () => { setCreating(false); setTemplateQuery(''); };
 
   const create = async () => {
     const name = newName.trim() || 'Untitled Project';
     try {
-      const p = await api.createProject(name, undefined, templateToPost(templates ?? [], template));
+      const p = await api.createProject(name, undefined, templateToPost(templates ?? [], effectiveTemplate));
       if (p.venueKit && !p.venueKit.ok) {
         toast(`Could not download the ${p.venueKit.name} kit from ${p.venueKit.host}. The project was created from a skeleton; README-venue.md says where to get the kit.`, 'error');
       }
@@ -175,11 +185,9 @@ export default function Home() {
                 <button className="btn btn--small" data-testid="logout" onClick={async () => { await api.logout(); setUser(null); }}>Sign out</button>
               </span>
             )}
-            <label className="btn" data-testid="import-zip">
-              Import ZIP
-              <input type="file" accept=".zip" hidden data-testid="import-input" aria-label="Import a project from a ZIP file"
-                onChange={async (e) => { if (e.target.files?.[0]) await importZip(e.target.files[0]); e.target.value = ''; }} />
-            </label>
+            <button className="btn" data-testid="import-zip" onClick={() => zipInput.current?.click()}>Import ZIP</button>
+            <input ref={zipInput} type="file" accept=".zip" hidden data-testid="import-input" aria-hidden="true" tabIndex={-1}
+              onChange={async (e) => { if (e.target.files?.[0]) await importZip(e.target.files[0]); e.target.value = ''; }} />
             <button className="btn" onClick={() => setShowGithub(true)} data-testid="new-from-github">
               From GitHub
             </button>
@@ -202,9 +210,7 @@ export default function Home() {
             <div style={{ display: 'flex', gap: 10, justifyContent: 'center', flexWrap: 'wrap' }}>
               <button className="btn btn--primary" onClick={() => setCreating(true)}>New project</button>
               <button className="btn" onClick={() => setShowGithub(true)}>Import from GitHub</button>
-              <label className="btn">Import a ZIP
-                <input type="file" accept=".zip" hidden onChange={async (e) => { if (e.target.files?.[0]) await importZip(e.target.files[0]); e.target.value = ''; }} />
-              </label>
+              <button className="btn" onClick={() => zipInput.current?.click()}>Import a ZIP</button>
             </div>
           </div>
         ) : (
@@ -348,8 +354,7 @@ export default function Home() {
                 </div>
                 <div className="tpl-gallery" data-testid="template-grid">
                   {(() => {
-                    const q = templateQuery.trim().toLowerCase();
-                    const shown = q ? templates.filter((t) => matchesQuery(t, q)) : templates;
+                    const shown = shownTemplates;
                     if (!shown.length) {
                       return <p className="tpl-empty" data-testid="template-empty">No template matches that. Create still starts from {chosen ? chosen.name : 'the built-in article'}.</p>;
                     }
@@ -363,7 +368,7 @@ export default function Home() {
                             {group.map((t) => (
                               <button
                                 key={t.id}
-                                className={`tpl ${template === t.id ? 'tpl--active' : ''}`}
+                                className={`tpl ${effectiveTemplate === t.id ? 'tpl--active' : ''}`}
                                 data-testid={`template-${t.id}`}
                                 onClick={() => setTemplate(t.id)}
                                 title={t.description}

--- a/docs/venue-kits-spec.md
+++ b/docs/venue-kits-spec.md
@@ -1,0 +1,104 @@
+# Venue kits fetched from the publisher (spec)
+
+Context: issue #9 asked for "as many journal and conference templates as
+possible". The gallery in PR #22 covers the fifteen venue classes TeX Live
+actually installs. Every remaining venue (NeurIPS, ICLR, ICML, ACL, CVPR,
+AAAI, USENIX, IJCAI, SIAM, MDPI, Copernicus, Springer Nature, Elsevier CAS,
+IOP, SAGE, Taylor & Francis, PLOS, Frontiers, eLife and friends) publishes a
+zip on its own site and is absent from TeX Live.
+
+Decision by the owner (2026-09-04): **fetch the kit from the publisher when
+the user creates the project**. Aldine redistributes nothing, so the licence
+question is the publisher's own terms between them and the author. Ship as
+many venues as can be made to work.
+
+## Rules
+
+1. **The server fetches, never the compiler.** The compiler has no egress by
+   design (deploy/docker-compose): keep it that way.
+2. **A fixed registry, no user-supplied URLs.** `templates/venues.json` in the
+   repo is the only source of kit URLs. Nothing in a request may influence the
+   URL, so there is no SSRF surface. Reject a registry entry at load time whose
+   URL is not `https:` or whose host is not in the entry's own allowlist.
+3. **A failed fetch never fails project creation.** The project is created from
+   the generated skeleton plus a short `README-venue.md` naming the venue, the
+   kit URL and what to do. The user sees one toast saying the kit could not be
+   downloaded and the project was created from a skeleton.
+4. **Nothing from a publisher is committed to this repo.** Fixtures for tests
+   are built in-test.
+5. Caps and manners: 20 s timeout, 25 MB per kit, redirects followed only to
+   the same host (max 3), `content-type` must look like a zip or a tex/style
+   file, `User-Agent: Aldine/<version> (+https://aldine.dev)`. Cache a
+   successful kit under `CACHE_DIR/venue-kits/<id>/` and reuse it for 7 days;
+   a cached kit is used when the fetch fails, whatever its age.
+6. Unpack with the project's own hardened `unzip.ts`. Take only the files the
+   registry entry names (globs), never the whole archive, and never anything
+   that `importPath` rejects. A kit that does not contain the named files is a
+   failure, so rule 3 applies.
+
+## Registry entry
+
+```json
+{
+  "id": "neurips",
+  "name": "NeurIPS",
+  "category": "Conferences",
+  "description": "Neural Information Processing Systems submission.",
+  "homepage": "https://neurips.cc/Conferences/2025/PaperInformation/StyleFiles",
+  "termsUrl": "https://neurips.cc/...",
+  "kit": {
+    "url": "https://media.neurips.cc/Conferences/NeurIPS2025/Styles.zip",
+    "host": "media.neurips.cc",
+    "take": ["*.sty", "*.bst", "*.tex"],
+    "rename": { "neurips_2025.sty": "neurips.sty" }
+  },
+  "documentClass": "article",
+  "preamble": ["\\usepackage{neurips}"],
+  "bibStyle": "plainnat",
+  "main": "main.tex"
+}
+```
+
+`main` names the file the kit itself provides as a starting document when it
+has one; otherwise Aldine generates the skeleton and loads the kit's style
+from the preamble list. The tile shows the venue name, the category, and
+"downloads the official kit from <host>".
+
+## Research stage (do this first)
+
+For every venue below, find the current official kit URL and record what the
+page says about reuse. Verify each URL actually returns a zip or style file
+(HEAD or a ranged GET, do not download the whole thing repeatedly). Drop a
+venue that has no stable public URL, and say so in the summary rather than
+guessing a URL.
+
+Conferences: NeurIPS, ICLR, ICML, ACL/EMNLP/NAACL, CVPR/ICCV/ECCV, AAAI,
+IJCAI, USENIX, SIGGRAPH, CHI (acmart covers CHI, note it), KDD/WWW (acmart),
+COLING, ECAI, AISTATS, CoRL, ICRA/IROS (IEEEtran, note it).
+
+Journals: SIAM, MDPI, Copernicus, Springer Nature (sn-jnl), Elsevier CAS,
+IOP, SAGE, Taylor & Francis (interact), PLOS, Frontiers, eLife, Wiley,
+Optica, APS (REVTeX covers), Nature (no public LaTeX kit — check), Science
+(check), Cell Press, BMJ, JMLR (already a class), Physical Review (REVTeX).
+
+A venue already covered by an installed class must NOT get a second tile:
+name it in the summary instead.
+
+## Acceptance
+
+- Unit tests for the fetcher against a local HTTP server: success, 404,
+  timeout, oversize, wrong content type, corrupt zip, missing named files,
+  redirect off-host, cache hit, stale cache after a failure. No network in
+  tests.
+- Registry validation test: every entry parses, has an https URL whose host
+  matches `kit.host`, a homepage, a category, and either `main` or a
+  preamble.
+- One e2e: a venue tile whose kit URL points at a local fixture server creates
+  a project containing the kit's files; with the server down, the project is
+  created from the skeleton and the toast says so.
+- The gallery lists installed-class venues and fetched venues together,
+  deduplicated by venue.
+- CHANGELOG entry. No publisher file in the repo. `npm run templates:check`
+  still passes.
+- Report in the summary: how many venues the registry carries, which were
+  dropped and why, and which are covered by an installed class instead.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -38,7 +38,10 @@ export default defineConfig({
     {
       // OPENROUTER_API_KEY/OPENAI_API_KEY are emptied so an ambient key can't
       // override the mock Anthropic endpoint the AI-fix test relies on.
-      command: `npm run build -w apps/web && PORT=${PORT} DATA_DIR=$(pwd)/.data-e2e OPENROUTER_API_KEY= OPENAI_API_KEY= ZOTERO_API_BASE=http://localhost:${MOCK} DOI_API_BASE=http://localhost:${MOCK} ARXIV_API_BASE=http://localhost:${MOCK} OPENALEX_API_BASE=http://localhost:${MOCK} ANTHROPIC_API_KEY=test-ai-key ANTHROPIC_BASE_URL=http://localhost:${MOCK} npx tsx apps/server/src/index.ts`,
+      // VENUES_FILE points at the registry the mock server writes (it names the
+      // mock's own port), so no venue test ever reaches a real publisher;
+      // ALDINE_TEST_HOOKS is what makes a loopback kit URL fetchable at all.
+      command: `npm run build -w apps/web && PORT=${PORT} DATA_DIR=$(pwd)/.data-e2e ALDINE_TEST_HOOKS=1 VENUES_FILE=$(pwd)/.data-e2e/venues-e2e.json OPENROUTER_API_KEY= OPENAI_API_KEY= ZOTERO_API_BASE=http://localhost:${MOCK} DOI_API_BASE=http://localhost:${MOCK} ARXIV_API_BASE=http://localhost:${MOCK} OPENALEX_API_BASE=http://localhost:${MOCK} ANTHROPIC_API_KEY=test-ai-key ANTHROPIC_BASE_URL=http://localhost:${MOCK} npx tsx apps/server/src/index.ts`,
       cwd: '..',
       port: PORT,
       reuseExistingServer: true,

--- a/e2e/tests/29-venue-kits.spec.ts
+++ b/e2e/tests/29-venue-kits.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../fixtures';
+import type { APIRequestContext, Page } from '@playwright/test';
+
+/**
+ * Venues whose class files TeX Live does not carry: the server downloads the
+ * publisher's kit when the project is created. The registry under test points
+ * at the mock publisher in tests/mock-zotero.mjs, so nothing here reaches a
+ * real venue, and the archive is built in that process rather than committed.
+ */
+interface Template {
+  id: string;
+  name: string;
+  kit?: { host: string; url: string };
+}
+
+/** The registry is written by the mock server, so it can land after boot. */
+async function kitTemplates(request: APIRequestContext): Promise<Template[]> {
+  let tiles: Template[] = [];
+  for (let i = 0; i < 15 && tiles.length === 0; i++) {
+    const res = await request.get('/api/templates');
+    expect(res.ok()).toBeTruthy();
+    tiles = ((await res.json()) as Template[]).filter((t) => !!t.kit);
+    if (!tiles.length) await new Promise((r) => setTimeout(r, 1000));
+  }
+  expect(tiles.length, 'the fetched-venue registry is served').toBeGreaterThan(0);
+  return tiles;
+}
+
+async function openGallery(page: Page) {
+  await page.goto('/');
+  await page.getByTestId('new-project').click();
+  await expect(page.getByTestId('template-grid')).toBeVisible();
+}
+
+async function pick(page: Page, name: string, id: string) {
+  await page.getByTestId('template-search').fill(name);
+  await page.getByTestId(`template-${id}`).click();
+  await expect(page.getByTestId('template-choice')).toContainText(name);
+}
+
+test.describe('venue kits fetched from the publisher', () => {
+  test('a tile says it downloads the kit, and the project is the kit', async ({ page, request }) => {
+    const tiles = await kitTemplates(request);
+    const kit = tiles.find((t) => t.id === 'venue:e2ekit')!;
+    expect(kit, 'the fixture venue is listed').toBeTruthy();
+
+    await openGallery(page);
+    await page.getByTestId('template-search').fill('E2E Venue Kit');
+    // The download happens at create time, and the tile says so before the pick.
+    await expect(page.getByTestId('template-kit-venue:e2ekit')).toContainText(`Downloads the official kit from ${kit.kit!.host}`);
+    await expect(page.getByTestId('template-license-venue:e2ekit')).toContainText('Publisher terms');
+
+    await page.getByTestId('new-project-name').fill('Kit Paper');
+    await pick(page, 'E2E Venue Kit', 'venue:e2ekit');
+    await page.getByTestId('create-project').click();
+
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    // The kit's own document becomes main.tex; its style file comes along.
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+    await expect(page.getByTestId('file-e2evenue.sty')).toBeVisible();
+    await expect(page.getByTestId('file-e2e.bib')).toBeVisible();
+
+    const id = new URL(page.url()).pathname.split('/').pop()!;
+    const main = await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`);
+    expect(await main.text()).toContain('From the venue kit.');
+    const sty = await request.get(`/api/projects/${id}/file?branch=main&path=e2evenue.sty`);
+    expect(await sty.text()).toContain('ProvidesPackage{e2evenue}');
+    // Only what the registry names: the archive's manual and its junk stay out.
+    const files = (await (await request.get(`/api/projects/${id}/files?branch=main`)).json()) as { path: string }[];
+    const paths = files.map((f) => f.path);
+    expect(paths).toEqual(expect.arrayContaining(['e2e.bib', 'e2evenue.sty', 'main.tex']));
+    expect(paths).not.toContain('kit-manual.pdf');
+    expect(paths.some((p) => p.includes('__MACOSX'))).toBeFalsy();
+  });
+
+  test('a kit that cannot be downloaded still creates the project, and says so', async ({ page, request }) => {
+    await kitTemplates(request);
+    await openGallery(page);
+    await page.getByTestId('new-project-name').fill('Skeleton Paper');
+    await pick(page, 'E2E Missing Kit', 'venue:e2egone');
+
+    const toast = page.locator('.toast', { hasText: 'Could not download the E2E Missing Kit kit' });
+    await page.getByTestId('create-project').click();
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('created from a skeleton');
+
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+
+    const id = new URL(page.url()).pathname.split('/').pop()!;
+    // README-venue.md is not a source file, so it is in the project without
+    // being in the default file tree.
+    const readme = await request.get(`/api/projects/${id}/file?branch=main&path=README-venue.md`);
+    expect(readme.ok()).toBeTruthy();
+    const text = await readme.text();
+    expect(text).toContain('no-such-kit.zip');
+    expect(text).toContain('https://example.org/authors');
+  });
+});

--- a/e2e/tests/mock-zotero.mjs
+++ b/e2e/tests/mock-zotero.mjs
@@ -1,5 +1,9 @@
-/** Mock Zotero Web API + DOI/arXiv reference lookup for e2e tests. */
+/** Mock Zotero Web API + DOI/arXiv reference lookup + a venue kit host, for e2e tests. */
+import fs from 'node:fs';
 import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildZip } from '../../apps/server/test/zip.mjs';
 
 const KEY = 'test-key-123';
 const USER = 777;
@@ -77,6 +81,14 @@ const server = http.createServer((req, res) => {
     return send(200, `<?xml version="1.0"?>\n<feed><title>arXiv Query</title><entry><title>A Mock arXiv Paper</title><published>2019-01-01T00:00:00Z</published><author><name>Alice Smith</name></author><author><name>Bob Jones</name></author></entry></feed>`);
   }
 
+  // --- Mock venue kit publisher (see apps/server/src/venuekits.ts) ---
+  // The registry the app server reads points here, so the kit path is exercised
+  // end to end without the suite ever reaching a real publisher.
+  if (url.pathname === '/venue-kit.zip') {
+    res.writeHead(200, { 'content-type': 'application/zip', 'content-length': String(VENUE_KIT.length) });
+    return res.end(VENUE_KIT);
+  }
+
   if (auth !== KEY) return send(403, { error: 'bad key' });
 
   if (url.pathname === '/keys/current') {
@@ -104,4 +116,38 @@ const server = http.createServer((req, res) => {
 });
 
 const port = Number(process.env.E2E_MOCK_PORT || 4919);
+
+/** A publisher kit, built here rather than committed: no publisher file, and
+ *  no file of ours pretending to be one, ever lands in the repo. */
+const VENUE_KIT = buildZip({
+  'e2e-kit-1.0/e2evenue.sty': '\\ProvidesPackage{e2evenue}\n\\endinput\n',
+  'e2e-kit-1.0/e2e-sample.tex': '\\documentclass{article}\n\\usepackage{e2evenue}\n\\begin{document}\nFrom the venue kit.\n\\end{document}\n',
+  'e2e-kit-1.0/e2e.bib': '@article{knuth1984,author={Knuth, Donald E.},title={Literate Programming},year={1984}}\n',
+  'e2e-kit-1.0/kit-manual.pdf': '%PDF-1.7 not taken\n',
+  '__MACOSX/e2e-kit-1.0/._e2evenue.sty': 'junk',
+});
+
+/**
+ * The venue registry the app server loads (VENUES_FILE in playwright.config).
+ * Written here because only this process knows the mock's port; the server
+ * re-reads the file when it changes, so the order the two start in does not
+ * matter.
+ */
+const venue = (id, name, file) => ({
+  id, name, category: 'Conferences',
+  description: `${name} submission, used by the e2e suite.`,
+  homepage: 'https://example.org/authors',
+  termsUrl: 'https://example.org/terms',
+  kit: { url: `http://localhost:${port}/${file}`, host: `localhost:${port}`, take: ['e2evenue.sty', 'e2e-sample.tex', 'e2e.bib'] },
+  documentClass: 'article',
+  preamble: ['\\usepackage{e2evenue}'],
+  bibStyle: 'plain',
+  main: 'e2e-sample.tex',
+});
+const registry = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.data-e2e/venues-e2e.json');
+fs.mkdirSync(path.dirname(registry), { recursive: true });
+fs.writeFileSync(registry, JSON.stringify({
+  venues: [venue('e2ekit', 'E2E Venue Kit', 'venue-kit.zip'), venue('e2egone', 'E2E Missing Kit', 'no-such-kit.zip')],
+}, null, 2));
+
 server.listen(port, () => console.log(`[mock-zotero] on :${port}`));

--- a/templates/venues.json
+++ b/templates/venues.json
@@ -1,0 +1,543 @@
+{
+  "note": "Venue kits Aldine downloads from the publisher when a project is created. This file is the only source of kit URLs: nothing in a request can influence them. No publisher file is stored in this repo. See docs/venue-kits-spec.md.",
+  "venues": [
+    {
+      "id": "neurips",
+      "name": "NeurIPS",
+      "category": "Conferences",
+      "description": "Neural Information Processing Systems submission (2026 style files).",
+      "icon": "🧠",
+      "homepage": "https://neurips.cc/Conferences/2026/CallForPapers",
+      "termsUrl": "https://neurips.cc/Conferences/2026/CallForPapers",
+      "kit": {
+        "url": "https://media.neurips.cc/Conferences/NeurIPS2026/Formatting_Instructions_For_NeurIPS_2026.zip",
+        "host": "media.neurips.cc",
+        "take": ["neurips_2026.sty", "neurips_2026.tex", "checklist.tex"]
+      },
+      "documentClass": "article",
+      "preamble": ["\\usepackage{neurips_2026}"],
+      "bibStyle": "plainnat",
+      "main": "neurips_2026.tex"
+    },
+    {
+      "id": "iclr",
+      "name": "ICLR",
+      "category": "Conferences",
+      "description": "International Conference on Learning Representations submission (2027 style files).",
+      "icon": "🧩",
+      "homepage": "https://iclr.cc/Conferences/2027/AuthorGuidelines",
+      "termsUrl": "https://iclr.cc/Conferences/2027/AuthorGuidelines",
+      "kit": {
+        "url": "https://media.iclr.cc/Conferences/ICLR2027/iclr-2027-style-files.zip",
+        "host": "media.iclr.cc",
+        "take": [
+          "iclr2027_conference.sty",
+          "iclr2027_conference.bst",
+          "iclr2027_conference.tex",
+          "iclr2027_conference.bib",
+          "math_commands.tex"
+        ]
+      },
+      "documentClass": "article",
+      "preamble": ["\\usepackage{iclr2027_conference}"],
+      "bibStyle": "iclr2027_conference",
+      "main": "iclr2027_conference.tex"
+    },
+    {
+      "id": "icml",
+      "name": "ICML",
+      "category": "Conferences",
+      "description": "International Conference on Machine Learning submission (2026 style files).",
+      "icon": "📈",
+      "homepage": "https://icml.cc/Conferences/2026/AuthorInstructions",
+      "termsUrl": "https://icml.cc/Conferences/2026/AuthorInstructions",
+      "kit": {
+        "url": "https://media.icml.cc/Conferences/ICML2026/Styles/icml2026.zip",
+        "host": "media.icml.cc",
+        "take": [
+          "icml2026.sty",
+          "icml2026.bst",
+          "example_paper.tex",
+          "example_paper.bib",
+          "algorithm.sty",
+          "algorithmic.sty"
+        ]
+      },
+      "documentClass": "article",
+      "preamble": ["\\usepackage{icml2026}"],
+      "bibStyle": "icml2026",
+      "main": "example_paper.tex"
+    },
+    {
+      "id": "aistats",
+      "name": "AISTATS",
+      "category": "Conferences",
+      "description": "Artificial Intelligence and Statistics submission (2026 paper pack).",
+      "icon": "📊",
+      "homepage": "https://virtual.aistats.org/Conferences/2026/CallForPapers",
+      "termsUrl": "https://virtual.aistats.org/Conferences/2026/CameraReadyInstructions",
+      "kit": {
+        "url": "https://aistats.org/aistats2026/AISTATS2026PaperPack.zip",
+        "host": "aistats.org",
+        "take": ["aistats2026.sty", "sample_paper.tex", "supplement.tex"]
+      },
+      "documentClass": "article",
+      "preamble": ["\\usepackage{aistats2026}"],
+      "bibStyle": "plainnat",
+      "main": "sample_paper.tex"
+    },
+    {
+      "id": "aaai",
+      "name": "AAAI",
+      "category": "Conferences",
+      "description": "AAAI conference submission (AAAI-27 author kit, anonymous version).",
+      "icon": "🎓",
+      "homepage": "https://aaai.org/conference/aaai/aaai-27/submission-instructions/",
+      "termsUrl": "https://aaai.org/conference/aaai/aaai-27/submission-instructions/",
+      "kit": {
+        "url": "https://aaai.org/wp-content/uploads/2026/05/AuthorKit27.zip",
+        "host": "aaai.org",
+        "take": [
+          "aaai2027.sty",
+          "aaai2027.bst",
+          "aaai2027.bib",
+          "AnonymousSubmission2027.tex",
+          "ReproducibilityChecklist.tex",
+          "**/Figures/*.pdf"
+        ]
+      },
+      "documentClass": "article",
+      "classOptions": "letterpaper",
+      "preamble": ["\\usepackage[submission]{aaai2027}"],
+      "bibStyle": "aaai2027",
+      "main": "AnonymousSubmission2027.tex"
+    },
+    {
+      "id": "ijcai",
+      "name": "IJCAI",
+      "category": "Conferences",
+      "description": "IJCAI-ECAI 2026 main track submission.",
+      "icon": "🕹",
+      "homepage": "https://www.ijcai.org/authors_kit",
+      "termsUrl": "https://2026.ijcai.org/ijcai-ecai-2026-call-for-papers-main-track/",
+      "kit": {
+        "url": "https://www.ijcai.org/sites/default/files/Guidelines/FormattingGuidelines-IJCAI-ECAI-26.zip",
+        "host": "www.ijcai.org",
+        "take": ["ijcai26.sty", "ijcai26.tex", "ijcai26.bib", "named.bst"]
+      },
+      "documentClass": "article",
+      "preamble": ["\\usepackage{ijcai26}"],
+      "bibStyle": "named",
+      "main": "ijcai26.tex"
+    },
+    {
+      "id": "ecai",
+      "name": "ECAI proceedings",
+      "category": "Conferences",
+      "description": "European Conference on Artificial Intelligence proceedings (IOS Press ecai class).",
+      "icon": "🇪🇺",
+      "homepage": "https://vtex-soft.github.io/texsupport.iospress-ecai/",
+      "termsUrl": "https://ecai2025.org/call-for-papers/",
+      "kit": {
+        "url": "https://codeload.github.com/vtex-soft/texsupport.iospress-ecai/zip/refs/heads/master",
+        "host": "codeload.github.com",
+        "take": ["ecai.cls", "ecai.bst", "ecai.bib", "ecai-sample-and-instructions.tex", "ecaif01.pdf"]
+      },
+      "documentClass": "ecai",
+      "bibStyle": "ecai",
+      "main": "ecai-sample-and-instructions.tex"
+    },
+    {
+      "id": "acl",
+      "name": "ACL, EMNLP and NAACL",
+      "category": "Conferences",
+      "description": "The rolling *ACL style files, used by ACL, EMNLP and NAACL.",
+      "icon": "💬",
+      "homepage": "https://github.com/acl-org/acl-style-files",
+      "termsUrl": "https://github.com/acl-org/acl-style-files#instructions-for-authors",
+      "kit": {
+        "url": "https://codeload.github.com/acl-org/acl-style-files/zip/refs/heads/master",
+        "host": "codeload.github.com",
+        "take": ["acl.sty", "acl_natbib.bst", "acl_latex.tex", "custom.bib"]
+      },
+      "documentClass": "article",
+      "classOptions": "11pt",
+      "preamble": ["\\usepackage{acl}"],
+      "bibStyle": "acl_natbib",
+      "main": "acl_latex.tex"
+    },
+    {
+      "id": "coling",
+      "name": "COLING",
+      "category": "Conferences",
+      "description": "International Conference on Computational Linguistics submission (COLING 2025 style files).",
+      "icon": "🗣",
+      "homepage": "https://coling2025.org/calls/submission_guidlines/",
+      "termsUrl": "https://coling2025.org/calls/submission_guidlines/",
+      "kit": {
+        "url": "https://coling2025.org/downloads/coling-2025.zip",
+        "host": "coling2025.org",
+        "take": ["coling.sty", "coling_natbib.bst", "coling_latex.tex", "custom.bib"]
+      },
+      "documentClass": "article",
+      "classOptions": "11pt",
+      "preamble": ["\\usepackage{coling}"],
+      "bibStyle": "coling_natbib",
+      "main": "coling_latex.tex"
+    },
+    {
+      "id": "cvpr",
+      "name": "CVPR",
+      "category": "Conferences",
+      "description": "Computer Vision and Pattern Recognition submission (CVPR 2026 author kit).",
+      "icon": "👁",
+      "homepage": "https://cvpr.thecvf.com/Conferences/2026/AuthorGuidelines",
+      "termsUrl": "https://cvpr.thecvf.com/Conferences/2026/AuthorGuidelines",
+      "kit": {
+        "url": "https://codeload.github.com/cvpr-org/author-kit/zip/refs/tags/CVPR2026-v1(latex)",
+        "host": "codeload.github.com",
+        "take": [
+          "cvpr.sty",
+          "ieeenat_fullname.bst",
+          "main.tex",
+          "preamble.tex",
+          "main.bib",
+          "**/sec/*.tex"
+        ]
+      },
+      "documentClass": "article",
+      "classOptions": "10pt,twocolumn,letterpaper",
+      "preamble": ["\\usepackage[review]{cvpr}"],
+      "bibStyle": "ieeenat_fullname",
+      "main": "main.tex"
+    },
+    {
+      "id": "iccv",
+      "name": "ICCV",
+      "category": "Conferences",
+      "description": "International Conference on Computer Vision submission (ICCV 2025 author kit).",
+      "icon": "🖼",
+      "homepage": "https://iccv.thecvf.com/Conferences/2025/AuthorGuidelines",
+      "termsUrl": "https://iccv.thecvf.com/Conferences/2025/AuthorGuidelines",
+      "kit": {
+        "url": "https://media.eventhosts.cc/Conferences/ICCV2025/ICCV2025-Author-Kit-Feb.zip",
+        "host": "media.eventhosts.cc",
+        "take": [
+          "iccv.sty",
+          "ieeenat_fullname.bst",
+          "main.tex",
+          "preamble.tex",
+          "main.bib",
+          "**/sec/*.tex"
+        ]
+      },
+      "documentClass": "article",
+      "classOptions": "10pt,twocolumn,letterpaper",
+      "preamble": ["\\usepackage[review]{iccv}"],
+      "bibStyle": "ieeenat_fullname",
+      "main": "main.tex"
+    },
+    {
+      "id": "eccv",
+      "name": "ECCV",
+      "category": "Conferences",
+      "description": "European Conference on Computer Vision submission (ECCV paper template).",
+      "icon": "🎥",
+      "homepage": "https://eccv.ecva.net/Conferences/2026/SubmissionPolicies",
+      "termsUrl": "https://eccv.ecva.net/Conferences/2026/SubmissionPolicies",
+      "kit": {
+        "url": "https://codeload.github.com/paolo-favaro/paper-template/zip/refs/tags/Latest",
+        "host": "codeload.github.com",
+        "take": [
+          "eccv.sty",
+          "eccvabbrv.sty",
+          "llncs.cls",
+          "splncs04.bst",
+          "main.tex",
+          "main.bib",
+          "*.eps"
+        ]
+      },
+      "documentClass": "llncs",
+      "classOptions": "runningheads",
+      "preamble": ["\\usepackage{eccv}"],
+      "bibStyle": "splncs04",
+      "main": "main.tex"
+    },
+    {
+      "id": "usenix-security",
+      "name": "USENIX Security",
+      "category": "Conferences",
+      "description": "USENIX Security submission (2026 template). The template may not be altered.",
+      "icon": "🔐",
+      "homepage": "https://www.usenix.org/conference/usenixsecurity26/instructions-presenters-and-authors",
+      "termsUrl": "https://www.usenix.org/conference/usenixsecurity26/call-for-papers",
+      "kit": {
+        "url": "https://www.usenix.org/sites/default/files/conference-files/usenixsecurity2026_latex_templates.zip",
+        "host": "www.usenix.org",
+        "take": ["usenix.sty", "usenixsecurity2026.tex"]
+      },
+      "documentClass": "article",
+      "classOptions": "letterpaper,twocolumn,10pt",
+      "preamble": ["\\usepackage{usenix}"],
+      "bibStyle": "plainurl",
+      "main": "usenixsecurity2026.tex"
+    },
+    {
+      "id": "usenix",
+      "name": "USENIX (OSDI, ATC, NSDI, FAST)",
+      "category": "Conferences",
+      "description": "The shared USENIX conference template used by OSDI, ATC, NSDI and FAST.",
+      "icon": "🖥",
+      "homepage": "https://www.usenix.org/conferences/author-resources/paper-templates",
+      "termsUrl": "https://www.usenix.org/conferences/author-resources/paper-templates",
+      "kit": {
+        "urls": [
+          "https://www.usenix.org/sites/default/files/usenix2019_v3.1.tex",
+          "https://www.usenix.org/sites/default/files/usenix-2020-09.sty"
+        ],
+        "host": "www.usenix.org",
+        "rename": { "usenix-2020-09.sty": "usenix2019_v3.sty" }
+      },
+      "documentClass": "article",
+      "classOptions": "letterpaper,twocolumn,10pt",
+      "preamble": ["\\usepackage{usenix2019_v3}"],
+      "bibStyle": "plain",
+      "main": "usenix2019_v3.1.tex"
+    },
+    {
+      "id": "siamart",
+      "name": "SIAM journals",
+      "category": "Journals",
+      "description": "Society for Industrial and Applied Mathematics submission (siamart macros).",
+      "icon": "📐",
+      "homepage": "https://epubs.siam.org/journal-authors",
+      "termsUrl": "https://epubs.siam.org/journal-authors",
+      "kit": {
+        "url": "https://epubs.siam.org/pb-assets/macros/standard/siamart_251216.zip",
+        "host": "epubs.siam.org",
+        "take": [
+          "siamart251216.cls",
+          "siamplain.bst",
+          "ex_article.tex",
+          "ex_shared.tex",
+          "references.bib",
+          "*.eps",
+          "*.dat"
+        ]
+      },
+      "documentClass": "siamart251216",
+      "classOptions": "review",
+      "bibStyle": "siamplain",
+      "main": "ex_article.tex"
+    },
+    {
+      "id": "mdpi",
+      "name": "MDPI journals",
+      "category": "Journals",
+      "description": "MDPI submission (Sensors, Applied Sciences and siblings).",
+      "icon": "📗",
+      "homepage": "https://www.mdpi.com/authors/latex",
+      "termsUrl": "https://www.mdpi.com/authors/latex",
+      "kit": {
+        "url": "https://mdpi-res.com/data/MDPI_template_ACS.zip",
+        "host": "mdpi-res.com",
+        "take": ["template.tex", "**/Definitions/*"]
+      },
+      "documentClass": "Definitions/mdpi",
+      "classOptions": "journal,article,submit,moreauthors",
+      "bibStyle": "mdpi",
+      "main": "template.tex"
+    },
+    {
+      "id": "copernicus",
+      "name": "Copernicus journals",
+      "category": "Journals",
+      "description": "Copernicus Publications submission. Pick your journal abbreviation as a class option.",
+      "icon": "🛰",
+      "homepage": "https://publications.copernicus.org/for_authors/manuscript_preparation.html",
+      "termsUrl": "https://publications.copernicus.org/for_authors/licence_and_copyright.html",
+      "kit": {
+        "url": "https://publications.copernicus.org/Copernicus_LaTeX_Package.zip",
+        "host": "publications.copernicus.org",
+        "take": ["copernicus.cls", "copernicus.cfg", "copernicus.bst", "*.sty", "template.tex"]
+      },
+      "documentClass": "copernicus",
+      "classOptions": "acp, manuscript",
+      "bibStyle": "copernicus",
+      "main": "template.tex"
+    },
+    {
+      "id": "springernature",
+      "name": "Springer Nature journals",
+      "category": "Journals",
+      "description": "Springer Nature journal article (sn-jnl). The class picks the bibliography style.",
+      "icon": "📔",
+      "homepage": "https://www.springernature.com/gp/authors/campaigns/latex-author-support",
+      "termsUrl": "https://www.springernature.com/gp/authors/campaigns/latex-author-support",
+      "kit": {
+        "url": "https://cms-resources.apps.public.k8s.springernature.io/springer-cms/rest/v1/content/18782940/data/v12",
+        "host": "cms-resources.apps.public.k8s.springernature.io",
+        "take": ["sn-jnl.cls", "sn-article.tex", "sn-bibliography.bib", "*.bst", "*.eps"],
+        "flatten": true
+      },
+      "documentClass": "sn-jnl",
+      "classOptions": "pdflatex,sn-mathphys-num",
+      "classSetsBibStyle": true,
+      "main": "sn-article.tex"
+    },
+    {
+      "id": "iop",
+      "name": "IOP Publishing",
+      "category": "Journals",
+      "description": "IOP Publishing journal article (iopjournal class).",
+      "icon": "🧲",
+      "homepage": "https://publishingsupport.iopscience.iop.org/questions/latex-template/",
+      "termsUrl": "https://publishingsupport.iopscience.iop.org/questions/latex-template/",
+      "kit": {
+        "url": "https://publishingsupport.iopscience.iop.org/wp-content/uploads/2025/07/ioplatextemplate.zip",
+        "host": "publishingsupport.iopscience.iop.org",
+        "take": ["iopjournal.cls", "iopjournal-template.tex", "figure*.pdf"]
+      },
+      "documentClass": "iopjournal",
+      "bibStyle": "unsrt",
+      "main": "iopjournal-template.tex"
+    },
+    {
+      "id": "tandf",
+      "name": "Taylor and Francis (Interact)",
+      "category": "Journals",
+      "description": "Taylor and Francis journal article, Chicago author-date variant of the Interact bundle.",
+      "icon": "📙",
+      "homepage": "https://authorservices.taylorandfrancis.com/publishing-your-research/writing-your-paper/formatting-and-templates/",
+      "termsUrl": "https://authorservices.taylorandfrancis.com/publishing-your-research/writing-your-paper/formatting-and-templates/",
+      "kit": {
+        "url": "https://files.taylorandfrancis.com/interactcadlatex.zip",
+        "host": "files.taylorandfrancis.com",
+        "take": ["interact.cls", "tfcad.bst", "interactcadsample.tex", "interactcadsample.bib"]
+      },
+      "documentClass": "interact",
+      "bibStyle": "tfcad",
+      "main": "interactcadsample.tex"
+    },
+    {
+      "id": "frontiers",
+      "name": "Frontiers",
+      "category": "Journals",
+      "description": "Frontiers journal article, Vancouver reference style.",
+      "icon": "🏔",
+      "homepage": "https://www.frontiersin.org/guidelines/author-guidelines",
+      "termsUrl": "https://www.frontiersin.org/guidelines/author-guidelines",
+      "kit": {
+        "url": "https://www.frontiersin.org/design/zip/Frontiers_LaTeX_Templates.zip",
+        "host": "www.frontiersin.org",
+        "take": [
+          "FrontiersinVancouver.cls",
+          "Frontiers-Vancouver.bst",
+          "frontiers.tex",
+          "test.bib",
+          "logo*.pdf",
+          "*-logo.pdf"
+        ],
+        "flatten": true
+      },
+      "documentClass": "FrontiersinVancouver",
+      "bibStyle": "Frontiers-Vancouver",
+      "main": "frontiers.tex"
+    },
+    {
+      "id": "elife",
+      "name": "eLife",
+      "category": "Journals",
+      "description": "eLife submission (elife class).",
+      "icon": "🧬",
+      "homepage": "https://reviewer.elifesciences.org/author-guide",
+      "termsUrl": "https://reviewer.elifesciences.org/author-guide",
+      "kit": {
+        "url": "https://cdn.elifesciences.org/author-guide/elife-latex-template.zip",
+        "host": "cdn.elifesciences.org",
+        "take": [
+          "elife.cls",
+          "vancouver-elife.bst",
+          "elife-template.tex",
+          "elife-sample.bib",
+          "*.jpg",
+          "elife-*-fig*.pdf"
+        ]
+      },
+      "documentClass": "elife",
+      "bibStyle": "vancouver-elife",
+      "main": "elife-template.tex"
+    },
+    {
+      "id": "wiley",
+      "name": "Wiley journals",
+      "category": "Journals",
+      "description": "Wiley journal article in the Optimal Design layout. Needs XeLaTeX or LuaLaTeX for its STIX fonts.",
+      "icon": "📘",
+      "homepage": "https://authors.wiley.com/author-resources/Journal-Authors/Prepare/latex-template.html",
+      "termsUrl": "https://authors.wiley.com/author-resources/Journal-Authors/Prepare/latex-template.html",
+      "kit": {
+        "url": "https://authors.wiley.com/asset/WileyDesign.zip",
+        "host": "authors.wiley.com",
+        "take": [
+          "USG.cls",
+          "wileyNJD-Chicago.bst",
+          "wileyNJD-Chicago.bib",
+          "Optimal-Design-layout.tex",
+          "NJDnatbib.sty",
+          "NJDapacite.sty",
+          "mla.sty",
+          "LETTERSP.STY",
+          "**/Fonts/Stix/*.otf"
+        ]
+      },
+      "documentClass": "USG",
+      "bibStyle": "wileyNJD-Chicago",
+      "main": "Optimal-Design-layout.tex"
+    },
+    {
+      "id": "optica",
+      "name": "Optica Publishing Group",
+      "category": "Journals",
+      "description": "Optica journal article (Optics Express, Optics Letters and siblings).",
+      "icon": "🔆",
+      "homepage": "https://opg.optica.org/content/author/portal/item/templates-default/",
+      "termsUrl": "https://opg.optica.org/content/author/portal/item/templates-default/",
+      "kit": {
+        "url": "https://opg.optica.org/resources/author/templates/latex-universal-template.zip",
+        "host": "opg.optica.org",
+        "take": [
+          "optica-article.cls",
+          "opticajnl.bst",
+          "Optica-template.tex",
+          "sample.bib",
+          "**/styles/*.sty",
+          "opticafig*.pdf"
+        ]
+      },
+      "documentClass": "optica-article",
+      "bibStyle": "opticajnl",
+      "main": "Optica-template.tex"
+    },
+    {
+      "id": "cellpress",
+      "name": "Cell Press",
+      "category": "Journals",
+      "description": "Cell Press article template. Plain article class plus the publisher's citation style.",
+      "icon": "🔬",
+      "homepage": "https://www.cell.com/information-for-authors/article-templates",
+      "termsUrl": "https://www.cell.com/information-for-authors/article-templates",
+      "kit": {
+        "url": "https://www.cell.com/pb-assets/journals/platform/authour-resources/cell-press-latex-template-1747231785383.zip",
+        "host": "www.cell.com",
+        "take": ["article-template.tex", "numbered.bst", "numcompress.sty", "references.bib", "Figure*.jpg"]
+      },
+      "documentClass": "article",
+      "classOptions": "12pt,letterpaper",
+      "preamble": ["\\usepackage{numcompress}"],
+      "bibStyle": "numbered",
+      "main": "article-template.tex"
+    }
+  ]
+}


### PR DESCRIPTION
Builds on #22 (merge that first). Together they answer #9's "as many venues as possible".

- **25 more venues**, none of which are in TeX Live: 14 conferences (NeurIPS, ICLR, ICML, AISTATS, AAAI, IJCAI, ECAI, ACL/EMNLP/NAACL, COLING, CVPR, ICCV, ECCV, USENIX Security, USENIX OSDI/ATC/NSDI/FAST) and 11 journals (SIAM, MDPI, Copernicus, Springer Nature, IOP, Taylor and Francis, Frontiers, eLife, Wiley, Optica, Cell Press). With #22's fifteen installed-class venues that is forty tiles.
- **Aldine redistributes nothing.** Creating a project from such a tile downloads the venue's own kit from the venue's own site at that moment, so the publisher's terms stay between the venue and the author. No publisher file is in this repo.
- **No request can steer a fetch**: URLs come only from `templates/venues.json`, validated at load. 25 MB and 20 second caps, same-host redirects only, unpacked by the hardened ZIP reader taking only the files the entry names, cached for a week and reused when a publisher is down.
- **A failed download never fails project creation.** The project is created from a skeleton that carries the venue's own lines as a comment plus a note naming the kit URL, and one toast says the download did not work.
- **Dropped, with reasons**: CoRL and Science have no fetchable public URL, PLOS redirects off-host to signed storage, SAGE distributes through Overleaf only, BMJ and Nature publish no LaTeX kit. SIGGRAPH, CHI, KDD, WWW, IEEE conferences, ICRA/IROS, Physical Review and JMLR are already covered by an installed class and deliberately get no second tile.

Checks: server and web typecheck, server unit suite (venue-kit and registry tests), web unit 26/26, e2e 29-venue-kits, 28-template-gallery and 17-feedback-round1 16/16.

Three review findings were left open by the workflow and are fixed here: the fallback skeleton put the commented preamble above `\\documentclass` (following its own instruction was a fatal error), the ZIP import could return a filesystem error carrying the server's absolute path as a 400, and long paths were screened per component but not as a whole.