### PR TITLE
compiler: finish the run so bibliographies resolve, and report .blg errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,26 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- Typesetting now really runs to completion: latexmk is forced past a failing
+  pass, so bibtex and the reruns that resolve citations and cross-references
+  still happen. Dropping `-halt-on-error` alone was not enough — latexmk gave
+  up after the pass that errored ("Errors, so I did not complete making
+  targets"), and a paper with one bad macro or one malformed `.bib` entry
+  rendered with every `\cite` as `[?]` and every `\ref` as `??`. Two real
+  papers that used to typeset that way now come out complete (one grew from 41
+  pages to 53 once its bibliography returned). "Stop on first error" keeps the
+  old behaviour.
+- Bibliography errors are reported with the file and line to fix. bibtex and
+  biber write them to the `.blg`, never the LaTeX log, so a malformed entry
+  used to surface only as hundreds of "Citation undefined" warnings and a
+  preview header that said "Failed" with nothing in the problems list. A
+  broken `.bib` now lists rows like "refs.bib · line 42 — BibTeX: I was
+  expecting a `,' or a `}'" that jump straight to the entry.
+- An error inside a generated file (the `.bbl` bibtex just wrote) says which
+  file it came from instead of offering a link into the output directory the
+  user cannot open, and identical error rows are listed once.
+- A failed typeset always says why: a run whose logs parse to no error at all
+  falls back to latexmk's own summary rather than an unexplained "Failed".
 - ZIP import reads ZIP64 archives (64-bit sizes and offsets, the ZIP64
   end-of-central-directory record), so exports from tools that write ZIP64
   headers no longer fail as "not a zip file" or import partially. An entry

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -71,6 +71,54 @@ function parseLog(log) {
   return errors;
 }
 
+/**
+ * Parse the bibliography log (.blg, written by both bibtex and biber) for
+ * errors. They never reach the LaTeX log: a malformed .bib entry makes bibtex
+ * write no .bbl at all, and the LaTeX log then shows only the fallout — one
+ * "Citation undefined" warning per citation, hundreds of them, none of which
+ * names the file and line to fix. bibtex's own `Warning--` lines are the noise
+ * the user cannot act on and stay out.
+ */
+function parseBibLog(log) {
+  const errors = [];
+  for (const line of log.split('\n')) {
+    // bibtex: "I was expecting a `,' or a `}'---line 42 of file refs.bib".
+    // A `Warning--` continuation is "--line N of file X" (two dashes) and so
+    // does not match.
+    const located = line.match(/^(.*\S)---line (\d+) of file (\S+)/);
+    if (located) {
+      errors.push({ type: 'error', file: located[3], line: Number(located[2]), message: `BibTeX: ${located[1].trim()}` });
+      continue;
+    }
+    // bibtex failures with no place to point at: a missing .bst or .bib file.
+    if (/^(I couldn't open|Sorry---you)/.test(line)) {
+      errors.push({ type: 'error', line: null, message: `BibTeX: ${line.trim()}` });
+      continue;
+    }
+    // biber: "[0] ... ERROR - Cannot find 'refs.bib'!"
+    const biber = line.match(/\b(ERROR|WARN) - (.*\S)/);
+    if (biber) errors.push({ type: biber[1] === 'ERROR' ? 'error' : 'warning', line: null, message: `Biber: ${biber[2].trim()}` });
+  }
+  return errors;
+}
+
+/**
+ * latexmk's own reason for failing, for a run whose logs parse to no error at
+ * all — a missing input file, an engine that would not start. Without it the
+ * UI can only say "typesetting failed" and leave the user nothing to act on.
+ */
+function latexmkFailure(out) {
+  const at = out.lastIndexOf('Collected error summary');
+  if (at < 0) return [];
+  const items = [];
+  for (const line of out.slice(at).split('\n').slice(1)) {
+    if (!/^\s+\S/.test(line)) break;
+    const text = line.trim();
+    if (!text.startsWith('Refer to')) items.push(text);
+  }
+  return items.map((message) => ({ type: 'error', line: null, message: `Typesetting failed: ${message}` }));
+}
+
 function run(cmd, args, opts, timeoutMs) {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { ...opts });
@@ -166,7 +214,14 @@ async function compileInner(body) {
     // still exits non-zero when errors occurred, so the caller gets a complete
     // PDF plus the error list (the default). With it, the run stops at the
     // first error and the PDF on disk is truncated at that page.
-    ...(haltOnError ? ['-halt-on-error'] : []),
+    //
+    // -f is the other half of running to completion, and only nonstopmode
+    // without it looks like it works: latexmk gives up after the pass that
+    // errored ("Errors, so I did not complete making targets"), so bibtex and
+    // the reruns that resolve citations and cross-references never happen. A
+    // paper with one bad macro then renders every \cite as [?] and every
+    // \ref as ??. latexmk still exits non-zero, so `ok` stays false.
+    ...(haltOnError ? ['-halt-on-error'] : ['-f']),
     '-file-line-error',
     // no -no-shell-escape: the image sets texmf shell_escape=p (restricted),
     // so only whitelisted programs (epstopdf, kpsewhich, bibtex, …) run.
@@ -211,7 +266,18 @@ async function compileInner(body) {
   }
   const durationMs = Date.now() - t0;
   let log = readLog(out);
+  // A previous run's outputs stay on disk when this run fails, so existence
+  // alone says nothing about which run wrote them. "Fresh" = written by this
+  // run: mtime at or after the sentinel's (same clock, second granularity at
+  // worst, and a write in the sentinel's own second still counts).
+  const isFresh = (f) => { try { return fs.statSync(f).mtimeMs >= freshSince; } catch { return false; } };
+  const bibLogPath = path.join(outAbs, `${base}.blg`);
   const errors = parseLog(log);
+  // Only this run's .blg: a stale one from before the user fixed the .bib
+  // would report errors that no longer exist.
+  if (isFresh(bibLogPath)) {
+    try { errors.push(...parseBibLog(fs.readFileSync(bibLogPath, 'utf8'))); } catch { /* unreadable is not an error */ }
+  }
   // -file-line-error paths are relative to the compile dir (the root file's
   // dir, thanks to -cd) — reduce in-project ones to project-relative paths so
   // the editor's error links and the AI-fix prompt name files the way the rest
@@ -220,13 +286,31 @@ async function compileInner(body) {
     if (typeof e.file !== 'string' || !e.file) continue;
     const abs = path.resolve(absDir, rootDir, e.file);
     if (abs === absDir || abs.startsWith(absDir + path.sep)) e.file = path.relative(absDir, abs);
+    // An error inside a generated file (the .bbl bibtex just wrote, an .aux)
+    // has a real line number in a file the user cannot open or fix. Say which
+    // file it was and drop the link, so the row explains the fallout while the
+    // .bib error above it stays the one to click.
+    if (e.file.split(path.sep).includes(OUT_SUBDIR)) {
+      e.message = `${path.basename(e.file)} (generated)${e.line != null ? ` line ${e.line}` : ''}: ${e.message}`;
+      e.file = null;
+      e.line = null;
+    }
   }
+  // One broken .bib entry makes every pass report the same generated-file error;
+  // identical rows tell the user nothing the first one did not.
+  const seen = new Set();
+  const deduped = errors.filter((e) => {
+    const key = `${e.type}\u0000${e.file ?? ''}\u0000${e.line ?? ''}\u0000${e.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  errors.length = 0;
+  errors.push(...deduped);
   const ok = code === 0 && fs.existsSync(pdfPath);
-  // A previous run's PDF/SyncTeX stay on disk when this run fails, so existence
-  // alone says nothing about which run wrote them. "Fresh" = written by this
-  // run: mtime at or after the sentinel's (same clock, second granularity at
-  // worst, and a write in the sentinel's own second still counts).
-  const isFresh = (f) => { try { return fs.statSync(f).mtimeMs >= freshSince; } catch { return false; } };
+  // Never report a failure the user cannot read: a run that fails with nothing
+  // in either log falls back to latexmk's own summary.
+  if (!ok && !timedOut && !errors.some((e) => e.type === 'error')) errors.push(...latexmkFailure(out));
   const synctexPath = path.join(absDir, rootDir, OUT_SUBDIR, `${base}.synctex.gz`);
   return {
     ok,
@@ -308,6 +392,12 @@ const server = http.createServer(async (req, res) => {
   json(res, 404, { ok: false, error: 'not found' });
 });
 
-probeTexLive().finally(() => {
-  server.listen(PORT, () => console.log(`[compiler] listening on :${PORT}, data=${DATA_DIR}, texlive=${texlive.release} (${texlive.scheme})`));
-});
+// The log parsers are pure and worth testing without a TeX Live image; the
+// server only starts when this file is run directly (the image's CMD).
+module.exports = { parseLog, parseBibLog, latexmkFailure };
+
+if (require.main === module) {
+  probeTexLive().finally(() => {
+    server.listen(PORT, () => console.log(`[compiler] listening on :${PORT}, data=${DATA_DIR}, texlive=${texlive.release} (${texlive.scheme})`));
+  });
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs"
+    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/test/biblog.test.mjs
+++ b/apps/server/test/biblog.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * Bibliography-log parsing. A malformed .bib entry never reaches the LaTeX
+ * log: bibtex writes no .bbl and LaTeX then reports only one "Citation
+ * undefined" warning per citation — hundreds of rows, none naming the line to
+ * fix. These are the lines that do name it.
+ */
+import { createRequire } from 'node:module';
+import { check, eq } from './assert.mjs';
+
+const { parseBibLog, latexmkFailure } = createRequire(import.meta.url)('../../compiler/server.js');
+
+// ---- bibtex ----
+const blg = [
+  'This is BibTeX, Version 0.99d',
+  'Database file #1: refs.bib',
+  "I was expecting a `,' or a `}'---line 42 of file refs.bib",
+  ' : @ARTICLE{alpha2001,',
+  "You're missing a field part---line 57 of file refs.bib",
+  'Repeated entry---line 91 of file refs.bib',
+  'Warning--entry type for "beta2002" isn\'t style-file defined',
+  '--line 103 of file refs.bib',
+  'Warning--missing publisher in gamma2003',
+  '(There were 3 error messages)',
+].join('\n');
+
+eq(parseBibLog(blg), [
+  { type: 'error', file: 'refs.bib', line: 42, message: "BibTeX: I was expecting a `,' or a `}'" },
+  { type: 'error', file: 'refs.bib', line: 57, message: "BibTeX: You're missing a field part" },
+  { type: 'error', file: 'refs.bib', line: 91, message: 'BibTeX: Repeated entry' },
+], 'the three located errors, and none of the Warning-- noise');
+
+// A `Warning--` continuation line is "--line N of file X" (two dashes) and
+// must not be mistaken for an error's "---line N of file X".
+check(!parseBibLog('--line 103 of file refs.bib').length, 'a warning continuation is not an error');
+
+eq(parseBibLog("I couldn't open style file plainnat.bst"), [
+  { type: 'error', line: null, message: "BibTeX: I couldn't open style file plainnat.bst" },
+], 'a missing .bst has no line to point at but still has to be said');
+
+// ---- biber ----
+eq(parseBibLog("[0] Utils.pm:410> ERROR - Cannot find 'refs.bib'!"), [
+  { type: 'error', line: null, message: "Biber: Cannot find 'refs.bib'!" },
+], 'biber error');
+eq(parseBibLog('[62] Biber.pm:130> WARN - Duplicate entry key: "alpha2001"'), [
+  { type: 'warning', line: null, message: 'Biber: Duplicate entry key: "alpha2001"' },
+], 'biber warning stays a warning');
+
+check(!parseBibLog('The style file: plainnat.bst\nDatabase file #1: refs.bib').length, 'ordinary bibtex chatter parses to nothing');
+
+// ---- latexmk's own summary ----
+const out = [
+  'Latexmk: Errors, so I did not complete making targets',
+  'Collected error summary (may duplicate other messages):',
+  "  pdflatex: Command for 'pdflatex' gave return code 1",
+  "      Refer to '.aldine-out/main.log' and/or above output for details",
+  'Latexmk: Undoing directory change',
+].join('\n');
+
+eq(latexmkFailure(out), [
+  { type: 'error', line: null, message: "Typesetting failed: pdflatex: Command for 'pdflatex' gave return code 1" },
+], 'the summary line, without the "Refer to" that points at a log the user already has');
+
+eq(latexmkFailure('Latexmk: Nothing to do.'), [], 'a run with no summary contributes nothing');
+
+console.log('biblog tests passed');

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -659,7 +659,7 @@ export default function Editor() {
           {activeFile ? (
             <>
               <div className="pane__header">
-                <span className="statusbar__file">{activeFile}</span>
+                <span className="statusbar__file" data-testid="active-file">{activeFile}</span>
                 {visualEnabled && mode === 'visual' && <FormatToolbar target={codeRef} />}
                 <span className="toolbar__spacer" />
                 <button

--- a/e2e/tests/17-feedback-round1.spec.ts
+++ b/e2e/tests/17-feedback-round1.spec.ts
@@ -174,6 +174,74 @@ test.describe('compile to completion', () => {
       await expect(page.getByTestId('pdf-stale')).toBeVisible();
     } finally { await cleanup(request, id); }
   });
+
+  test('a document with a bibliography resolves its citations even when a pass fails', async ({ page, request }) => {
+    const id = await createProject(request, 'Run To End Bib');
+    try {
+      // Every real paper has a bibliography, and running to completion is what
+      // gets it: latexmk stops after a failed pass unless forced, so bibtex and
+      // the reruns never happen and each \cite renders as [?].
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'refs.bib',
+        content: '@article{knuth1984,\n  author = {Knuth, Donald E.},\n  title = {Literate Programming},\n  journal = {The Computer Journal},\n  year = {1984},\n}\n' } });
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\section{Intro}\\label{sec:intro}',
+        'Literate programming \\cite{knuth1984} and \\ref{sec:intro}.',
+        '\\thisMacroDoesNotExist',
+        '\\bibliographystyle{plain}',
+        '\\bibliography{refs}',
+        '\\end{document}',
+        '' ].join('\n') } });
+
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      const first = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const result = await (await first).json();
+
+      expect(result.ok).toBe(false);
+      expect(result.pdfUrl).toBeTruthy();
+      expect(result.errors.some((e: { message: string }) => /undefined control sequence/i.test(e.message))).toBe(true);
+      // the point of the test: the failed pass did not cost the bibliography
+      expect(result.log).not.toMatch(/Citation `knuth1984' .* undefined/);
+      expect(result.log).not.toMatch(/Reference `sec:intro' .* undefined/);
+      expect(result.log).toMatch(/Output written on/);
+    } finally { await cleanup(request, id); }
+  });
+
+  test('a broken .bib entry is reported with its line instead of a wall of undefined citations', async ({ page, request }) => {
+    const id = await createProject(request, 'Broken Bib');
+    try {
+      // A missing closing brace: bibtex writes no usable .bbl, so the LaTeX log
+      // carries only "Citation undefined" — the line to fix is in the .blg.
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'refs.bib',
+        content: '@article{a,\n  title = {One},\n  year = {2001},\n\n@article{b,\n  title = {Two},\n  year = {2002},\n}\n' } });
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'main.tex', content: [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Text \\cite{a} and \\cite{b}.',
+        '\\bibliographystyle{plain}',
+        '\\bibliography{refs}',
+        '\\end{document}',
+        '' ].join('\n') } });
+
+      await withoutAutoTypeset(page);
+      await openProject(page, id);
+      const first = compileResponse(page);
+      await page.getByTestId('typeset-button').click();
+      const result = await (await first).json();
+
+      const bib = result.errors.filter((e: { type: string; file?: string }) => e.type === 'error' && e.file === 'refs.bib');
+      expect(bib.length).toBeGreaterThan(0);
+      expect(bib[0].line).toBeGreaterThan(1);
+      expect(bib[0].message).toMatch(/^BibTeX: /);
+      // the row is a link into refs.bib, not a dead end
+      await expect(page.getByTestId('errors-panel')).toBeVisible();
+      await page.getByTestId('errors-panel').getByText(/BibTeX: /).first().click();
+      await expect(page.getByTestId('active-file')).toHaveText('refs.bib');
+    } finally { await cleanup(request, id); }
+  });
 });
 
 test.describe('stale preview', () => {


### PR DESCRIPTION
Closes the open half of #6.

## What was wrong

Dropping `-halt-on-error` was only half of compiling to completion. latexmk still gives up after the pass that errored — *"Errors, so I did not complete making targets"* — so bibtex and the reruns that resolve citations and cross-references never happen. Any document with a bibliography and one bad macro came out with every `\cite` as `[?]` and every `\ref` as `??`.

The e2e added for #6 passed because its fixture has no bibliography. Every real paper has one.

Bibliography errors were invisible for a related reason: bibtex and biber write them to the `.blg`, never the LaTeX log. A malformed `.bib` entry surfaced only as one "Citation undefined" warning per citation — hundreds of rows, none naming a line — above a preview header that said "Failed" with nothing actionable in the problems list.

## Changes

- `-f` unless the project asks to stop on the first error, so the remaining passes run. latexmk still exits non-zero, so `ok` stays false and the error list stands beside the PDF.
- Parse this run’s `.blg` (matched by mtime, so a stale one cannot report fixed errors) for bibtex’s located errors and biber’s `ERROR`/`WARN` lines. bibtex’s `Warning--` chatter stays out — it is the part the user cannot act on.
- An error inside a generated file (the `.bbl` bibtex just wrote) named a path under `.aldine-out` that the user cannot open, and every pass reported it again. Now it says which generated file it came from without offering the link, and identical rows are listed once.
- A run whose logs parse to no error at all falls back to latexmk’s own summary, so a failure always says why.
- `parseLog`, `parseBibLog` and `latexmkFailure` are exported for the unit test; the server only listens when `server.js` runs directly, as the image’s CMD does.

## Measured against real documents

Three documents that a user reported as "does not work" were reproduced in an isolated instance against full TeX Live.

| | before | after |
|---|---|---|
| Paper A (Nature-style class, 169 bib entries) | Failed, 341 warnings, 0 errors, 41 pp, 283 unresolved citations | 4 errors — three of them clickable into the `.bib` — 53 pp, 0 unresolved |
| Paper B (AAS journal macros) | Failed, 71 rows, 58 unresolved citations | 1 error at its real line, 8 pp, 0 unresolved |
| Paper C (XeLaTeX, Persian) | already fine after the #12 hotfix | unchanged, 0.2 s |

Paper C also settles the open acceptance item on #12: the reporter’s own document, verified rather than a reconstruction.

## Tests

- `apps/server/test/biblog.test.mjs` — bibtex located errors, the `Warning--` continuation that must not be mistaken for one, a missing `.bst`, biber errors and warnings, and latexmk’s summary.
- Two e2e in `17-feedback-round1`: a document with a bibliography keeps its citations through a failed pass; a broken `.bib` is reported with its line and the row opens the file. Both were confirmed to fail against the previous compiler before being accepted.
- Full suite green: 86 e2e, 26 web unit, server unit, typecheck.