### PR TITLE
web: keep dialog actions in view and stop the editor scrolling sideways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,17 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- A dialog taller than the window no longer hides its own buttons. The panel
+  caps at 70% of the window height and scrolls; the action row scrolled away
+  with the content, so on a laptop-sized window the New project dialog showed
+  no Create button and Project settings no Close. The row is pinned to the
+  bottom of the panel now, in every dialog.
+- The editor no longer scrolls sideways. The preview toolbar (status, engine,
+  zoom, Download, Auto) is wider than a narrow preview pane, and it pushed the
+  page out instead of fitting: the app toolbar slid off the right edge and the
+  Auto switch went with it. The toolbar wraps instead, and shrinking the window
+  now pulls an over-wide preview pane back with it rather than leaving it at
+  the width it had when the tab was opened.
 - Typesetting now really runs to completion: latexmk is forced past a failing
   pass, so bibtex and the reruns that resolve citations and cross-references
   still happen. Dropping `-halt-on-error` alone was not enough — latexmk gave

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -133,7 +133,22 @@
 }
 .modal h2 { margin: 0 0 4px; font-size: 15px; font-weight: 600; }
 .modal p.modal__sub { margin: 0 0 14px; color: var(--text-2); }
-.modal__row { display: flex; gap: 8px; margin-top: 14px; justify-content: flex-end; }
+/* The action row stays put while a long dialog scrolls under it. The template
+   gallery and the settings list are both taller than the 70vh cap, and a
+   Create button that has scrolled out of sight reads as a dialog with no way
+   to finish. `bottom` cancels the panel's own bottom padding so the row sits
+   flush with the panel edge. */
+.modal__row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  position: sticky;
+  bottom: -20px;
+  z-index: 1;
+  margin: 14px -20px -20px;
+  padding: 12px 20px 20px;
+  background: var(--bg-panel);
+}
 .modal .input { width: 100%; }
 
 /* template picker */
@@ -424,13 +439,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  height: 34px;
+  min-height: 34px;
   padding: 0 10px;
   border-bottom: 1px solid var(--hairline);
   color: var(--text-2);
   font-size: 12px;
   font-weight: 600;
   flex: none;
+  /* The preview pane is resizable and its toolbar is the widest thing in it.
+     Wrapping keeps every control reachable; without this the row overflows the
+     pane and widens the whole page, which scrolls the app toolbar off-screen. */
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .sidebar { width: 230px; flex: none; background: var(--bg-inset); }

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -58,6 +58,14 @@ export default function Editor() {
   const [tab, setTab] = useState<'files' | 'history' | string>('files');
   const [compile, setCompile] = useState<{ status: CompileStatus; result: CompileResult | null; wallMs?: number }>({ status: 'idle', result: null });
   const [pdfWidth, setPdfWidth] = useState(() => Math.max(360, Math.round(window.innerWidth * 0.4)));
+  // The pane keeps an absolute width, so shrinking the window would otherwise
+  // leave a preview wider than the room for it and squeeze the editor away.
+  // Same bound as the resizer's.
+  useEffect(() => {
+    const fit = () => setPdfWidth((w) => Math.min(w, Math.max(280, window.innerWidth - 500)));
+    window.addEventListener('resize', fit);
+    return () => window.removeEventListener('resize', fit);
+  }, []);
   const [users, setUsers] = useState<PresenceUser[]>([]);
   const [pluginPanels, setPluginPanels] = useState<PluginPanel[]>([]);
   const [auto, setAuto] = useState(() => localStorage.getItem('aldine.autoTypeset') !== '0');

--- a/e2e/tests/30-dialog-fit.spec.ts
+++ b/e2e/tests/30-dialog-fit.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures';
+import { createPaperProject, openProject, cleanup, expectTypesetOk } from './helpers';
+
+/**
+ * Two things a laptop-sized window used to break, both invisible to a suite
+ * that only ran at one large size: a dialog taller than its 70vh cap hid its
+ * own action row, and the preview toolbar widened the page instead of fitting
+ * the pane. Neither shows up in `toBeVisible` — a control clipped by an
+ * ancestor's overflow still reports visible — so both assert geometry.
+ */
+
+/** Is the element clipped by the scroll box of the dialog it lives in? */
+async function clippedByModal(page: import('@playwright/test').Page, selector: string): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement;
+    const modal = el.closest('.modal') as HTMLElement;
+    const m = modal.getBoundingClientRect();
+    const r = el.getBoundingClientRect();
+    return r.bottom > m.bottom + 1 || r.top < m.top - 1;
+  }, selector);
+}
+
+const SIZES = [
+  { w: 1440, h: 900, name: 'laptop' },
+  { w: 1280, h: 800, name: 'small laptop' },
+  { w: 1180, h: 700, name: 'short window' },
+  { w: 1024, h: 640, name: 'very short window' },
+];
+
+test.describe('a dialog never hides its own actions', () => {
+  for (const s of SIZES) {
+    test(`New project keeps Create in view at ${s.name} (${s.w}x${s.h})`, async ({ page, request }) => {
+      await page.setViewportSize({ width: s.w, height: s.h });
+      await page.goto('/');
+      await page.getByTestId('new-project').click();
+      await expect(page.getByTestId('create-project')).toBeVisible();
+      expect(await clippedByModal(page, '[data-testid="create-project"]')).toBe(false);
+
+      // and it works from where it sits, without scrolling the dialog first
+      await page.getByTestId('new-project-name').fill(`Fit ${s.w}`);
+      await page.getByTestId('create-project').click();
+      await expect(page.getByTestId('editor-shell')).toBeVisible();
+      await cleanup(request, page.url().split('/p/')[1].split('?')[0]);
+    });
+  }
+
+  test('project settings keeps Close in view in a short window', async ({ page, request }) => {
+    const id = await createPaperProject(request, 'Settings Fit');
+    try {
+      await page.setViewportSize({ width: 1180, height: 640 });
+      await openProject(page, id);
+      await page.getByTestId('project-settings-open').click();
+      await expect(page.getByTestId('settings-close')).toBeVisible();
+      expect(await clippedByModal(page, '[data-testid="settings-close"]')).toBe(false);
+    } finally { await cleanup(request, id); }
+  });
+});
+
+test.describe('the editor never scrolls sideways', () => {
+  for (const s of [{ w: 1440, h: 900 }, { w: 1280, h: 800 }, { w: 1100, h: 700 }, { w: 900, h: 700 }]) {
+    test(`no horizontal overflow at ${s.w}x${s.h}`, async ({ page, request }) => {
+      // A typeset project is the wide case: the toolbar only grows its status
+      // and its Download button once there is a PDF.
+      const id = await createPaperProject(request, `Overflow ${s.w}`);
+      try {
+        await page.setViewportSize({ width: s.w, height: s.h });
+        await openProject(page, id);
+        await expectTypesetOk(page);
+        const over = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+        expect(over).toBeLessThanOrEqual(0);
+        for (const t of ['engine-select', 'zoom-controls', 'pdf-status']) {
+          const b = await page.getByTestId(t).boundingBox();
+          if (b) expect(b.x + b.width).toBeLessThanOrEqual(s.w);
+        }
+      } finally { await cleanup(request, id); }
+    });
+  }
+
+  test('shrinking the window pulls the preview pane back in', async ({ page, request }) => {
+    const id = await createPaperProject(request, 'Resize Fit');
+    try {
+      await page.setViewportSize({ width: 1600, height: 900 });
+      await openProject(page, id);
+      await expectTypesetOk(page);
+      await page.setViewportSize({ width: 1000, height: 700 });
+      await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)).toBeLessThanOrEqual(0);
+    } finally { await cleanup(request, id); }
+  });
+});


### PR DESCRIPTION
Two layout bugs that only appear on a laptop-sized window, which is why the suite never saw them — it ran at one large viewport.

## The dialog hides its own buttons

`.modal` caps at `70vh` and scrolls. The action row scrolled with the content, so any dialog taller than the cap showed no way to finish: the New project gallery lost **Create**, project settings lost **Close**. Reported from a real window; reproduced at 1280x800, 1180x700 and 1024x640.

The row is `position: sticky; bottom` now, so it stays at the bottom of the panel while the body scrolls under it. One rule, every dialog. The typesetting log already did the equivalent by scrolling only its `<pre>` and leaving the footer alone.

## The editor scrolls sideways

The preview toolbar (status, engine picker, zoom, Download, Auto) needs about 486px. The preview pane is frequently narrower than that, and `.pane__header` had no `flex-wrap` and no `min-width: 0`, so it overflowed the pane and widened the whole document — the app toolbar slid off the right edge and took the Auto switch with it.

The header wraps instead. Separately, `pdfWidth` was computed once at mount from `window.innerWidth` and never revisited, so shrinking the window left an over-wide preview pane; it is re-clamped on resize with the same bound the drag handle uses.

## Tests

`e2e/tests/30-dialog-fit.spec.ts`, asserting geometry rather than visibility — a control clipped by an ancestor's overflow still reports visible to Playwright, which is exactly why nothing caught either bug. Five of its ten cases fail on the previous build.

Full suite green: 101 e2e, 26 web unit, typecheck.