### PR TITLE
web: a theme control in settings, and a preview toolbar that fits one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- A theme control in project settings, under Appearance. Dark and light were
+  only switchable from the home screen or the command palette, so once you
+  were in a project there was no visible way back. It says it applies to this
+  browser, like the auto-typeset switch beside it.
 - Venue kits fetched from the publisher: 25 more venues in the template
   gallery (NeurIPS, ICLR, ICML, AISTATS, AAAI, IJCAI, ECAI, ACL/EMNLP/NAACL,
   COLING, CVPR, ICCV, ECCV, USENIX and USENIX Security, SIAM, MDPI,
@@ -179,6 +183,11 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- The preview toolbar fits on one line at ordinary pane widths again. It had
+  outgrown the pane, so it wrapped to a second row and left the two pane
+  headers at different heights. The pane's own "Preview" title now appears
+  only when the pane is wide enough to spare it, and the download button says
+  "Download"; the wrap stays as the backstop for narrower panes.
 - A dialog taller than the window no longer hides its own buttons. The panel
   caps at 70% of the window height and scrolls; the action row scrolled away
   with the content, so on a laptop-sized window the New project dialog showed

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -435,6 +435,16 @@
    positioned pane they cover the sidebar and toolbar too. */
 .pane--editor { position: relative; }
 
+/* The preview toolbar is the widest row in the app and its pane is resizable,
+   so the pane's own title is the first thing to drop: the PDF beside it and
+   the typeset status already say which pane this is, and keeping the row on
+   one line matters more than repeating it. The query is on the pane, not the
+   window — a wide window can still hold a narrow preview. `.pane__header`
+   wraps as the backstop below even this. */
+.pane--preview { container-type: inline-size; }
+.pane__title { display: none; }
+@container (min-width: 470px) { .pane__title { display: inline; } }
+
 .pane__header {
   display: flex;
   align-items: center;

--- a/apps/web/src/components/ProjectSettings.tsx
+++ b/apps/web/src/components/ProjectSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { api, CompilerInfo, ProjectSummary, TreeEntry } from '../api';
 import Modal from './Modal';
 import { ENGINES, texliveLabel } from '../util/engines';
+import { getTheme, setTheme, Theme } from '../theme';
 
 interface Props {
   project: Pick<ProjectSummary, 'id' | 'name' | 'rootFile' | 'engine' | 'stopOnFirstError'>;
@@ -25,6 +26,7 @@ interface Props {
  */
 export default function ProjectSettings({ project, files, autoTypeset, importNote, onClose, onRename, onSetRoot, onSetEngine, onSetStopOnFirstError, onToggleAutoTypeset }: Props) {
   const [name, setName] = useState(project.name);
+  const [theme, setThemeChoice] = useState<Theme>(getTheme());
   const [compiler, setCompiler] = useState<CompilerInfo | null>(null);
   useEffect(() => {
     let live = true;
@@ -135,6 +137,27 @@ export default function ProjectSettings({ project, files, autoTypeset, importNot
                 data-testid="settings-auto-typeset"
               />
               <span className="settings__hint">{autoTypeset ? 'Typesets shortly after you stop typing, on this browser' : 'Typeset by hand only, on this browser'}</span>
+            </span>
+          </div>
+        </section>
+
+        <section data-testid="appearance-settings">
+          <div className="menu__label" style={{ margin: '18px 0 4px', padding: 0 }}>Appearance</div>
+
+          <div className="settings__row">
+            <label className="settings__label" htmlFor="settings-theme">Theme</label>
+            <span className="settings__control settings__control--check">
+              <select
+                id="settings-theme"
+                className="input"
+                value={theme}
+                onChange={(e) => { const t = e.target.value as Theme; setTheme(t); setThemeChoice(t); }}
+                data-testid="settings-theme"
+              >
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
+              <span className="settings__hint">Applies to this browser</span>
             </span>
           </div>
         </section>

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -799,9 +799,9 @@ export default function Editor() {
           }}
         />
 
-        <section className="pane" style={{ width: pdfWidth, flex: 'none' }}>
+        <section className="pane pane--preview" style={{ width: pdfWidth, flex: 'none' }}>
           <div className="pane__header">
-            <span>Preview</span>
+            <span className="pane__title">Preview</span>
             <span className="pdf-status" data-testid="pdf-status" style={{ marginLeft: 10 }}>
               {compile.status === 'compiling' && hasPdf && <><span className="dot dot--busy" /> Typesetting…</>}
               {compile.status === 'ok' && compile.result && <><span className="dot dot--ok" /> Typeset in {((compile.wallMs ?? compile.result.durationMs) / 1000).toFixed(1)}s</>}
@@ -831,7 +831,7 @@ export default function Editor() {
                 title="Download the compiled PDF"
                 data-testid="download-pdf"
               >
-                Download PDF
+                Download
               </a>
             )}
             <button

--- a/e2e/tests/27-compiler-settings.spec.ts
+++ b/e2e/tests/27-compiler-settings.spec.ts
@@ -127,6 +127,15 @@ test.describe('compiler settings panel', () => {
       await expect.poll(() => page.evaluate(() => window.localStorage.getItem('aldine.autoTypeset'))).toBe('1');
       await expect(page.getByTestId('auto-toggle')).toHaveClass(/auto-toggle--on/);
 
+      // Theme lives here too: the editor has no visible theme control, and
+      // outside the command palette this dialog is the only way back to dark.
+      await expect(page.getByTestId('settings-theme')).toHaveValue('dark');
+      await page.getByTestId('settings-theme').selectOption('light');
+      await expect.poll(() => page.evaluate(() => document.documentElement.dataset.theme)).toBe('light');
+      await expect.poll(() => page.evaluate(() => window.localStorage.getItem('aldine.theme'))).toBe('light');
+      await page.getByTestId('settings-theme').selectOption('dark');
+      await expect.poll(() => page.evaluate(() => document.documentElement.dataset.theme)).toBe('dark');
+
       await page.getByTestId('settings-root-file').selectOption('other.tex');
       await expect.poll(async () => (await meta(request, id)).rootFile).toBe('other.tex');
       await expect(page.locator('.toast').filter({ hasText: 'Main document is now other.tex' })).toBeVisible();


### PR DESCRIPTION
Two follow-ups from a screenshot pass over the merged September work.

## No way back to dark inside a project

Dark and light were switchable from the home screen and from the command palette, and nowhere else. A reader who switched to light and then opened a project had no visible control to switch back — which is exactly how it was reported.

Theme now sits under a new **Appearance** section in project settings, next to auto-typeset, and says it applies to this browser the same way that one does. Deliberately not another toolbar button: the editor toolbar is already the widest row in the app.

## The preview toolbar wrapped during ordinary use

The wrap added in #25 stops the page scrolling sideways, but the toolbar had outgrown its pane by enough that the wrap fired at normal window sizes — leaving the editor and preview headers at different heights and the Auto switch alone on a second row. It prevented the bug and looked broken doing it.

The pane's own "Preview" title now appears only when the pane can spare the width, via a container query on the pane rather than a window media query — a wide window can still hold a narrow preview — and the download button says "Download". The wrap stays as the backstop for panes narrower than that.

## Tests

The theme control is asserted in `27-compiler-settings` (value, `data-theme` on the root, and the persisted `aldine.theme`). `30-dialog-fit` still passes at all four window sizes. 15 tests across both specs green.