### PR TITLE
fix: a malformed cookie no longer turns every request into a 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,12 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- A cookie on the same host that is not valid percent-encoding (another
+  app's `x=100%`, a truncated `%E0%A4%A`) no longer turns every request into
+  `{"error":"Internal server error"}` until the user clears site cookies. Such
+  a value is now kept as-is and simply fails session lookup; the rest of the
+  Cookie header is parsed normally. (#26)
+
 - The preview toolbar fits on one line at ordinary pane widths again. It had
   outgrown the pane, so it wrapped to a second row and left the two pane
   headers at different heights. The pane's own "Preview" title now appears

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -143,9 +143,20 @@ export function parseCookies(header: string | undefined): Record<string, string>
   if (!header) return out;
   for (const part of header.split(';')) {
     const i = part.indexOf('=');
-    if (i > 0) out[part.slice(0, i).trim()] = decodeURIComponent(part.slice(i + 1).trim());
+    if (i > 0) out[part.slice(0, i).trim()] = decodeCookieValue(part.slice(i + 1).trim());
   }
   return out;
+}
+// The Cookie header carries every cookie on the host, not only ours: a
+// neighbouring app's `x=100%` or a truncated `%E0%A4%A` must not turn every
+// request into a 500. A value that is not valid percent-encoding is kept raw;
+// it will simply fail session lookup.
+function decodeCookieValue(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
 }
 export function sessionCookie(sid: string): string {
   return `${COOKIE}=${sid}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${SESSION_DAYS * 86400}${SECURE_COOKIES ? '; Secure' : ''}`;

--- a/apps/server/test/cookies.test.mjs
+++ b/apps/server/test/cookies.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * Cookie parsing must survive a Cookie header that is not valid
+ * percent-encoding (#26): the browser sends every cookie on the host, so a
+ * neighbouring app's `x=100%` used to throw URIError out of the onRequest
+ * hook and turn every request into a 500 until the user cleared cookies.
+ *
+ * Env must be set before any src import — AUTH_ENABLED and the data/meta
+ * roots are read at module load.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { check, eq } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-cookies-'));
+process.env.AUTH_ENABLED = '1';
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'meta');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+delete process.env.ALDINE_PROTECTED_PROJECTS;
+
+const { initDb } = await import('../src/db/index.ts');
+await initDb();
+const auth = await import('../src/auth.ts');
+const { registerRoutes } = await import('../src/routes.ts');
+const Fastify = (await import('fastify')).default;
+
+// ---- parser ----
+eq(auth.parseCookies(undefined), {}, 'no header parses to nothing');
+eq(auth.parseCookies('a=1; b=hello%20world'), { a: '1', b: 'hello world' }, 'valid percent-encoding is decoded');
+eq(auth.parseCookies('a=100%; b=2'), { a: '100%', b: '2' }, 'a bare % is kept raw and does not break its neighbours');
+eq(auth.parseCookies('a=%E0%A4%A; aldine_session=sid'), { a: '%E0%A4%A', aldine_session: 'sid' }, 'a truncated escape is kept raw');
+eq(auth.parseCookies('a=%zz'), { a: '%zz' }, 'non-hex escape is kept raw');
+eq(auth.parseCookies('aldine_session=100%'), { aldine_session: '100%' }, 'the session cookie itself may be malformed');
+
+// ---- end to end: the onRequest hook must not 500 ----
+const app = Fastify();
+await registerRoutes(app);
+
+const user = await auth.register('ada@example.com', 'password123', 'Ada');
+const sid = await auth.createSession(user.id);
+
+const anon = await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie: 'foreign=100%' } });
+eq(anon.statusCode, 200, 'a malformed foreign cookie does not 500');
+eq(anon.json().user, null, 'and the request is treated as anonymous');
+
+const withSession = await app.inject({
+  method: 'GET',
+  url: '/api/auth/me',
+  headers: { cookie: `foreign=100%; aldine_session=${sid}; other=%E0%A4%A` },
+});
+eq(withSession.statusCode, 200, 'a valid session next to malformed cookies still works');
+check(withSession.json().user?.id === user.id, 'and resolves to the signed-in user');
+
+const badSid = await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie: 'aldine_session=100%' } });
+eq(badSid.statusCode, 200, 'a malformed session cookie value does not 500');
+eq(badSid.json().user, null, 'and simply fails session lookup');
+
+await app.close();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('cookies: ok');

--- a/e2e/auth-tests/auth.spec.ts
+++ b/e2e/auth-tests/auth.spec.ts
@@ -372,6 +372,36 @@ test.describe('collab under auth', () => {
     // before the token fix this stayed blank (collab never authenticated)
     await expect(page.locator('.cm-content')).toContainText('LOADED-UNDER-AUTH-42', { timeout: 15_000 });
   });
+
+});
+
+test.describe('cookies', () => {
+  // #26: the browser sends every cookie on the host, so a neighbouring app's
+  // `x=100%` used to throw URIError in the onRequest hook and 500 every request.
+  test('a malformed cookie on the host does not break the session', async ({ page, context, baseURL }) => {
+    const email = uniq();
+    await register(page, email);
+    const url = new URL(baseURL!);
+    await context.addCookies([
+      { name: 'foreign', value: '100%', domain: url.hostname, path: '/' },
+      { name: 'truncated', value: '%E0%A4%A', domain: url.hostname, path: '/' },
+    ]);
+    const res = await page.goto('/');
+    expect(res?.status()).toBe(200);
+    // still signed in: the session cookie next to the malformed ones resolves
+    await expect(page.getByTestId('new-project')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('body')).not.toContainText('Internal server error');
+
+    // signed out with only the malformed cookies left: the login screen, not a 500
+    await page.getByTestId('logout').click();
+    await expect(page.getByTestId('auth-email')).toBeVisible();
+    const again = await page.goto('/');
+    expect(again?.status()).toBe(200);
+    await expect(page.getByTestId('auth-email')).toBeVisible();
+    const me = await page.request.get('/api/auth/me');
+    expect(me.status()).toBe(200);
+    expect((await me.json()).user).toBeNull();
+  });
 });
 
 test.describe('ownerless legacy projects', () => {


### PR DESCRIPTION
Fixes #26.

## Cause

`parseCookies` in `apps/server/src/auth.ts` ran `decodeURIComponent` on every cookie value. The browser sends every cookie on the host, not only ours, so a neighbouring app's `x=100%` or a truncated escape like `%E0%A4%A` threw `URIError: URI malformed` inside the `onRequest` hook. Every request then answered `{"error":"Internal server error"}` until the user cleared site cookies. Reproduced in Node with `parseCookies("aldine_session=abc; other=100%")`.

## Fix

A cookie value that is not valid percent-encoding is kept raw instead of aborting the request. It simply fails session lookup, and the rest of the Cookie header is parsed normally.

## Tests

- `apps/server/test/cookies.test.mjs` (wired into `test:unit`): parser cases plus Fastify inject on the real route table for `/api/auth/me` with a malformed foreign cookie, a malformed session cookie, and a valid session next to malformed cookies.
- `e2e/auth-tests/auth.spec.ts` › cookies: Playwright against the auth-enabled stack. Registers, adds `foreign=100%` and `truncated=%E0%A4%A` to the browser context, reloads and still sees the signed-in home; signs out and gets the login screen, not a 500. Verified to fail with `Expected: 200, Received: 500` on main's `auth.ts` and to pass with the fix.

Full auth e2e suite (21 tests) and the server unit suite pass locally.

https://claude.ai/code/session_01TRn9mstWXJTcbNeH5Mabj9
