### PR TITLE
ci: a version tag builds and waits; latest moves only on approval

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# What the app image build must never see from a developer's checkout. The
+# Dockerfiles install from the lockfile and build dist/ themselves; a host
+# node_modules copied over the top (COPY apps/web apps/web) breaks the build
+# or ships whatever was installed locally, and .data holds real projects.
+.git
+**/node_modules
+**/dist
+.data*
+.env
+.env.*
+e2e
+site
+docs
+deploy
+*.log

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,138 @@
+name: Build image
+
+# Reusable: builds one image per platform on a native runner, pushes each by
+# digest, then stitches them into a multi-arch index tagged with the version
+# and the commit. Called by release.yml for the app and the compiler.
+#
+# A version tag is immutable: the merge job refuses to overwrite one that
+# already resolves. The only tag that ever moves is `latest`, and only
+# promote.yml touches it.
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: Image name suffix (app | compiler)
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      version:
+        description: Version to tag, without the leading v
+        required: true
+        type: string
+      free-disk:
+        description: Remove unused toolchains from the runner first (the full TeX Live image needs the space)
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      digest:
+        description: Digest of the pushed multi-arch index
+        value: ${{ jobs.merge.outputs.digest }}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-${{ inputs.name }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free runner disk
+        if: ${{ inputs.free-disk }}
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          docker system prune -af >/dev/null
+          df -h / | tail -1
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Refuse to overwrite a published version
+        run: |
+          if docker manifest inspect "$IMAGE:${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::$IMAGE:${{ inputs.version }} already exists; version tags are immutable. Cut a new version instead."
+            exit 1
+          fi
+      - name: Platform slug
+        id: slug
+        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ inputs.name }}-${{ steps.slug.outputs.value }}
+          # mode=max of a full TeX Live layer set exceeds the 10 GB repo cache
+          # and evicts itself every run; min keeps only the final layers.
+          cache-to: type=gha,scope=${{ inputs.name }}-${{ steps.slug.outputs.value }},mode=min
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ steps.slug.outputs.value }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.name }}-${{ steps.slug.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.index.outputs.digest }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ inputs.name }}-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create the multi-arch index (version + commit tags only)
+        id: index
+        run: |
+          set -e
+          if docker manifest inspect "$IMAGE:${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::$IMAGE:${{ inputs.version }} appeared while building; version tags are immutable."
+            exit 1
+          fi
+          refs=()
+          for f in /tmp/digests/*; do refs+=("$IMAGE@$(cat "$f")"); done
+          docker buildx imagetools create \
+            -t "$IMAGE:${{ inputs.version }}" \
+            -t "$IMAGE:sha-${GITHUB_SHA::7}" \
+            "${refs[@]}"
+          digest=$(docker buildx imagetools inspect "$IMAGE:${{ inputs.version }}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "Pushed $IMAGE:${{ inputs.version }} = $digest" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # release.yml runs this suite on the tagged commit before building images:
+  # a tag push does not trigger the push/pull_request events above.
+  workflow_call:
 
 jobs:
   check:
@@ -56,6 +59,13 @@ jobs:
         run: npm run templates:check
       - name: Server unit tests
         run: npm run test:unit -w apps/server
+      - name: Web unit tests
+        run: npm run test -w apps/web
+      # package.json versions, the compose default and the README block all
+      # name the release by hand; a tag whose pins disagree is refused by
+      # release.yml, so catch the drift on the PR instead.
+      - name: Release pins agree
+        run: node scripts/check-release-pins.mjs
 
   compose:
     name: docker compose config is valid

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,74 @@
+name: Promote to latest
+
+# The only workflow that moves `latest`. Re-tags the digests already published
+# under a version tag (no rebuild), then publishes the GitHub Release for it.
+# The same command pointed at the previous version is the rollback.
+#
+# The job runs in the `latest` environment. Give that environment a required
+# reviewer (Settings → Environments → latest) and every run pauses here until
+# a human approves; without one, this runs unattended.
+#
+# Called by release.yml after the smoke test, and runnable by hand:
+#   Actions → Promote to latest → Run workflow → version: 0.4.0
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published version to point latest at (e.g. 0.4.0 or, to roll back, 0.3.0)
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: write   # the GitHub Release
+  packages: write   # re-tag on GHCR
+
+concurrency:
+  group: promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment:
+      name: latest
+      url: https://github.com/${{ github.repository }}/pkgs/container/aldine-app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Move latest (and the minor alias) to the version's digests
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -e
+          case "$VERSION" in
+            *[!0-9.]*|'') echo "::error::version must look like 0.4.0, got '$VERSION'"; exit 1 ;;
+          esac
+          minor="${VERSION%.*}"
+          for name in app compiler; do
+            image="ghcr.io/${{ github.repository_owner }}/aldine-$name"
+            # A version that was never built (or never finished building) must
+            # not become latest.
+            docker buildx imagetools inspect "$image:$VERSION" >/dev/null
+          done
+          for name in app compiler; do
+            image="ghcr.io/${{ github.repository_owner }}/aldine-$name"
+            docker buildx imagetools create -t "$image:latest" -t "$image:$minor" "$image:$VERSION"
+            echo "$image:latest -> $VERSION ($(docker buildx imagetools inspect "$image:latest" --format '{{json .Manifest.Digest}}'))" >> "$GITHUB_STEP_SUMMARY"
+          done
+      - name: Publish the GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          make_latest: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,63 +1,114 @@
 name: Release
 
-# Build and publish the app + compiler images to GHCR on a version tag.
-# Usage:  git tag v0.4.0 && git push origin v0.4.0
+# A version tag builds; it does not publish to anyone.
+#
+#   git push origin v0.4.0
+#     preflight  the tag is on main, and every version pin agrees with it
+#     verify     the full CI suite, on the tagged commit (tags skip ci.yml's own triggers)
+#     build      aldine-app and aldine-compiler as 0.4.0 + sha-<commit>, immutable
+#     smoke      boot those exact digests with the user-facing compose file and
+#                typeset a document with a bibliography inside the sandbox
+#     promote    waits for approval in the `latest` environment, then moves
+#                `latest` to the same digests and publishes the GitHub Release
+#
+# Until promote is approved nothing a self-hoster pulls has changed. To roll
+# back, run "Promote to latest" by hand with the previous version.
 on:
   push:
     tags: ['v*']
 
 permissions:
-  contents: write   # create the GitHub Release
-  packages: write   # push to GHCR
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  images:
+  preflight:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: app
-            context: .
-            dockerfile: apps/server/Dockerfile
-          - name: compiler
-            context: apps/compiler
-            dockerfile: apps/compiler/Dockerfile
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3   # arm64 builds via emulation
-      - uses: docker/setup-buildx-action@v3
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/aldine-${{ matrix.name }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
-      - name: Build & push
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64   # x86 servers + Apple Silicon/Pi/Graviton
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          fetch-depth: 0
+      - name: The tag must point at a commit on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::$GITHUB_REF_NAME points at $GITHUB_SHA, which is not on main. Merge first, then tag."
+            exit 1
+          fi
+      - name: Version pins agree with the tag
+        id: version
+        run: |
+          node scripts/check-release-pins.mjs --tag "$GITHUB_REF_NAME"
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-  release:
-    needs: images
+  verify:
+    needs: preflight
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  build-app:
+    needs: [preflight, verify]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      name: app
+      context: .
+      dockerfile: apps/server/Dockerfile
+      version: ${{ needs.preflight.outputs.version }}
+    secrets: inherit
+
+  build-compiler:
+    needs: [preflight, verify]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      name: compiler
+      context: apps/compiler
+      dockerfile: apps/compiler/Dockerfile
+      version: ${{ needs.preflight.outputs.version }}
+      free-disk: true
+    secrets: inherit
+
+  smoke:
+    needs: [preflight, build-app, build-compiler]
     runs-on: ubuntu-latest
+    env:
+      ALDINE_APP_IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-app@${{ needs.build-app.outputs.digest }}
+      ALDINE_COMPILER_IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-compiler@${{ needs.build-compiler.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - uses: actions/setup-node@v4
         with:
-          generate_release_notes: true
+          node-version: 22
+      - name: Free runner disk for the compiler image
+        run: sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+      - name: Start the stack from the published digests
+        run: docker compose -f docker-compose.yml -f deploy/docker-compose.smoke.yml up -d --quiet-pull
+      - name: Smoke test
+        run: node scripts/smoke-image.mjs
+        env:
+          ALDINE_URL: http://localhost:8080
+          EXPECT_SCHEME: full
+      - name: Container logs
+        if: failure()
+        run: docker compose -f docker-compose.yml -f deploy/docker-compose.smoke.yml logs --no-color | tail -200
+      - name: Summary
+        run: |
+          {
+            echo "Smoke passed against:"
+            echo "- $ALDINE_APP_IMAGE"
+            echo "- $ALDINE_COMPILER_IMAGE"
+            echo
+            echo "Next: approve the promote job to move \`latest\` here, or leave it and nothing changes for users."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  promote:
+    needs: [preflight, smoke]
+    uses: ./.github/workflows/promote.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,13 @@ lacks packages); everything else passes locally. Two checkouts side by side
   (the compiler can read project dirs).
 - Playwright `webServer` timeouts are long on purpose; kill stray
   `tsx watch` processes if local ports hang.
+- Image tags: a version tag builds immutable `x.y.z` images and stops;
+  `latest` moves only in `promote.yml` after a human approves.
+  `build-image.yml` tags the index by hand for that reason; if you ever swap
+  in `docker/metadata-action`, set `flavor: latest=false` or it re-adds
+  `latest` for every release semver. `docker-compose.yml` pins
+  `${ALDINE_VERSION:-x.y.z}` on purpose. Do not "simplify" either back to
+  `latest`.
+- `test:unit` discovers `apps/server/test/*.test.mjs`; never enumerate test
+  files in package.json again (two branches adding tests conflicted on that
+  line and the merge silently dropped one side's tests).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,27 @@ All notable changes to Aldine are documented here. The format follows
   deploy and rollback workflows take a `target` input (production or staging).
 
 ### Changed
+- Releases no longer move `:latest` on their own. A version tag now runs the
+  full CI suite on the tagged commit, builds `aldine-app` and
+  `aldine-compiler` as immutable `x.y.z` (and `sha-<commit>`) images, boots
+  those exact digests with the user-facing compose file and typesets a
+  document with a bibliography inside the sandbox, then waits for a human to
+  approve the promote step before `:latest` and the GitHub Release follow.
+  The same "Promote to latest" workflow, run by hand with an older version,
+  is the rollback: it re-tags what already exists, no rebuild. The compose
+  file and the README block pin `${ALDINE_VERSION:-0.3.0}` instead of
+  `:latest`, so a running install never changes under you; upgrading is
+  `ALDINE_VERSION=x.y.z docker compose pull && docker compose up -d`, and
+  rolling back is the same line with the previous version. CI now also runs
+  the web unit tests, checks that every place naming the version agrees, and
+  discovers the server unit test files instead of listing them (two branches
+  each adding a test used to conflict on that line, and the merge dropped one
+  side's tests without anything noticing). The server image installs from
+  the lockfile (`npm ci`), so the shipped dependency tree is the one CI
+  tested; a `.dockerignore` keeps a checkout's `node_modules`, `.git` and
+  `.data` out of the build context (a local `--build` used to copy the host's
+  `node_modules` over the installed one); and `deploy/backup.sh` and
+  `deploy/restore.sh` pin the `alpine` image by digest.
 - `POST /api/projects/import` accepts `multipart/form-data` with a `zip` file
   part (and an optional `name` field); the web client uploads the file that
   way, so the browser holds one copy of a 60 MB archive instead of four (file,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,16 +94,30 @@ disagree about.
 
 ## Releasing
 
-Pushing a version tag runs `.github/workflows/release.yml`, which builds the
-`aldine-app` and `aldine-compiler` images, pushes them to GHCR, and **publishes**
-a GitHub release straight away. There is no draft step to catch mistakes, so do
-the three local steps first:
+A version tag ships to nobody. Pushing one runs `.github/workflows/release.yml`,
+which checks the tag is on main and every version pin agrees with it, runs the
+full CI suite on that commit, builds `aldine-app` and `aldine-compiler` as
+immutable `x.y.z` and `sha-<commit>` tags, boots those exact digests with the
+user-facing compose file and typesets a document with a bibliography inside
+the sandbox. Then it waits. `:latest` moves, and the GitHub Release appears,
+only when you approve the `promote` job (the `latest` environment) in that
+same run. Until then nothing a self-hoster pulls has changed.
 
 ```bash
 # 1. move the CHANGELOG's [Unreleased] entries under a new [x.y.z] heading,
 #    and add the compare link at the bottom of the file
-# 2. match the manifests to the tag you are about to push
+# 2. match every pin to the tag you are about to push
 npm pkg set version=0.4.0 --workspaces --include-workspace-root
-# 3. commit both, then tag
+#    and the ${ALDINE_VERSION:-…} default in docker-compose.yml and the README
+#    block (scripts/check-release-pins.mjs tells you which one you missed)
+# 3. commit, then tag
 git tag v0.4.0 && git push origin main v0.4.0
+# 4. when the run pauses at "promote", try 0.4.0 somewhere real, then approve
 ```
+
+To roll back, run "Promote to latest" by hand (Actions tab) with the previous
+version: it re-tags the digests that already exist, no rebuild. The same
+command is the way to re-promote a version whose approval you let expire.
+
+Budget about an hour for the build: the full TeX Live compiler image is
+around 2.8 GB compressed per architecture.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:latest
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.3.0}
     ports:
       - "8080:3000"
     volumes:
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:latest
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -153,20 +153,41 @@ docker compose up -d`. Keep the `name: aldine` line wherever you save it: it
 fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
-- **The first pull is big** (~2.5 GB; TeX Live is in the compiler image);
-  after that, starts take seconds. Ready when `curl localhost:8080/api/health`
-  returns `{"ok":true,"name":"aldine"}`. Images are published on release tags.
+- **You are pinned to a version.** The block above says
+  `${ALDINE_VERSION:-0.3.0}`, so a fresh copy installs the current release and
+  nothing under a running install changes on its own. To upgrade, read the
+  [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
+
+      ALDINE_VERSION=0.4.0 docker compose pull && docker compose up -d
+
+  To roll back, set `ALDINE_VERSION` to the previous release and run the same
+  command. Your projects live in the `aldine-data` and `aldine-secrets`
+  volumes and an image swap does not touch them. `:latest` still exists and
+  points at the newest release; pinning is what lets you choose when to move.
+- **Pre-1.0 stability.** Versions follow SemVer with one caveat: before 1.0
+  a minor bump (0.3 to 0.4) may change behaviour or on-disk layout, a patch
+  bump (0.4.0 to 0.4.1) will not. Every release is built from a commit that
+  passed CI, and its images are booted and made to typeset a real document
+  before `:latest` moves to them. Upgrades across a minor are not yet tested
+  against existing data, so back up first. Watch the repo's Releases for
+  security fixes: per [SECURITY.md](SECURITY.md), only the latest release
+  gets them.
+- **The first pull is big.** TeX Live lives in the compiler image: about
+  1 GB compressed for 0.3.0, and about 2.8 GB (around 9 GB on disk) from
+  0.4.0 on, which switches to full TeX Live so every script and language
+  typesets out of the box. After the first pull, starts take seconds. Ready
+  when `curl localhost:8080/api/health` returns `{"ok":true,"name":"aldine"}`.
 - **Port 8080 taken?** Change the left side of `ports:`.
-- **Everything beyond the minimum**: building from source (latest `main`),
-  auth/SSO/AI/email options, TLS, Postgres/Redis. All of it lives
-  in [`docker-compose.full.yml`](docker-compose.full.yml), which carries the
-  same compiler sandbox and the same volumes, so you can switch without
-  losing data:
-  `docker compose -f docker-compose.full.yml up -d --build`. The first build
-  installs LaTeX packages; expect 15–40 minutes.
-- **Need packages beyond the curated set?** Build the full file with all of
-  CTAN preinstalled (~9 GB on disk):
-  `ALDINE_TEXLIVE_SCHEME=medium docker compose -f docker-compose.full.yml up -d --build` for a slimmer image (curated packages, no CJK).
+- **Everything beyond the minimum**: building from source (latest `main`,
+  not a release), auth/SSO/AI/email options, TLS, Postgres/Redis. All of it
+  lives in [`docker-compose.full.yml`](docker-compose.full.yml), which carries
+  the same compiler sandbox and the same volumes, so you can switch without
+  losing data: `docker compose -f docker-compose.full.yml up -d --build`.
+  The first build pulls TeX Live; expect 15–40 minutes.
+- **Constrained host?** Build the compiler yourself with the slimmer
+  `medium` scheme (curated packages and publisher classes, no CJK, about
+  1.3 GB of packages):
+  `ALDINE_TEXLIVE_SCHEME=medium docker compose -f docker-compose.full.yml up -d --build`
 
 ## How Aldine compares
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -4,19 +4,19 @@
 # vite/tsc under QEMU emulation for hours. Only the runtime stage is per-arch.
 FROM --platform=$BUILDPLATFORM node:22-alpine AS webbuild
 WORKDIR /build
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/
 COPY apps/server/package.json apps/server/
-RUN npm install --workspace apps/web --include-workspace-root=false
+RUN npm ci --workspace apps/web --include-workspace-root=false
 COPY apps/web apps/web
 RUN npm run build -w apps/web
 
 # ---- build server (TS -> JS, so the container boots in seconds, not minutes) ----
 FROM --platform=$BUILDPLATFORM node:22-alpine AS serverbuild
 WORKDIR /build
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json ./
 COPY apps/server/package.json apps/server/
-RUN npm install --workspace apps/server --include-workspace-root=false
+RUN npm ci --workspace apps/server --include-workspace-root=false
 COPY apps/server apps/server
 RUN npm run build -w apps/server
 
@@ -24,9 +24,9 @@ RUN npm run build -w apps/server
 FROM node:22-alpine
 RUN apk add --no-cache git
 WORKDIR /srv
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json ./
 COPY apps/server/package.json apps/server/
-RUN npm install --workspace apps/server --include-workspace-root=false --omit=dev
+RUN npm ci --workspace apps/server --include-workspace-root=false --omit=dev
 COPY apps/server apps/server
 COPY --from=serverbuild /build/apps/server/dist apps/server/dist
 COPY plugins plugins

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test:github": "tsx test/github-sync.integration.mjs",
     "test:db": "tsx test/datastore.conformance.mjs",
-    "test:unit": "tsx test/redis-client.test.mjs && tsx test/wordcount.test.mjs && tsx test/import-path.test.mjs && tsx test/guess-root.test.mjs && tsx test/import-route.test.mjs && tsx test/compile-stale.test.mjs && tsx test/blank-project.test.mjs && tsx test/detect.test.mjs && tsx test/biblog.test.mjs && tsx test/compiler-info.test.mjs && tsx test/unzip.test.mjs && tsx test/multipart.test.mjs && tsx test/templates.test.mjs && tsx test/templates-check.test.mjs && tsx test/skeleton-compile.test.mjs && tsx test/venue-kits.test.mjs && tsx test/venue-registry.test.mjs"
+    "test:unit": "node test/run-unit.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/apps/server/test/run-unit.mjs
+++ b/apps/server/test/run-unit.mjs
@@ -1,0 +1,31 @@
+// Runs every test/*.test.mjs, each in its own process, in name order.
+//
+// The list is discovered rather than written into package.json: when two
+// branches each added a test file, the single "test:unit" line conflicted and
+// whoever resolved it kept one side's files. CI stayed green with fewer tests
+// and nothing reported the loss. Integration and conformance suites use other
+// suffixes on purpose (they need a network or a database) and are not run here.
+import { readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const files = readdirSync(dir).filter((f) => f.endsWith('.test.mjs')).sort();
+if (files.length === 0) {
+  console.error('run-unit: no *.test.mjs files found in', dir);
+  process.exit(1);
+}
+const tsx = fileURLToPath(import.meta.resolve('tsx/cli'));
+
+const failed = [];
+for (const file of files) {
+  console.log(`\n=== ${file}`);
+  const r = spawnSync(process.execPath, [tsx, path.join(dir, file)], { stdio: 'inherit' });
+  if (r.status !== 0) failed.push(file);
+}
+console.log(`\nrun-unit: ${files.length - failed.length}/${files.length} files passed`);
+if (failed.length) {
+  console.error('run-unit: failed:', failed.join(', '));
+  process.exit(1);
+}

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -23,7 +23,7 @@ docker run --rm \
   -v "${DATA_VOL}":/data:ro \
   -v "${SECRETS_VOL}":/secrets:ro \
   -v "${OUT_DIR}":/backup \
-  alpine tar czf "/backup/${OUT_FILE}" -C / data secrets
+  alpine@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce tar czf "/backup/${OUT_FILE}" -C / data secrets
 
 echo "Backup written: ${OUT_DIR}/${OUT_FILE}"
 echo "Contains: /data (projects + git repos) and /secrets (users, sessions, API keys, comments)."

--- a/deploy/docker-compose.smoke.yml
+++ b/deploy/docker-compose.smoke.yml
@@ -1,0 +1,12 @@
+# Overlay for the release smoke job: run the exact digests the build just
+# pushed, on the same sandbox the base file gives users. Nothing else changes,
+# so what passes here is what a self-hoster gets.
+#
+#   ALDINE_APP_IMAGE=ghcr.io/trahloff/aldine-app@sha256:... \
+#   ALDINE_COMPILER_IMAGE=ghcr.io/trahloff/aldine-compiler@sha256:... \
+#   docker compose -f docker-compose.yml -f deploy/docker-compose.smoke.yml up -d
+services:
+  app:
+    image: ${ALDINE_APP_IMAGE:?set ALDINE_APP_IMAGE to the app image digest to smoke}
+  compiler:
+    image: ${ALDINE_COMPILER_IMAGE:?set ALDINE_COMPILER_IMAGE to the compiler image digest to smoke}

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -24,6 +24,6 @@ docker run --rm \
   -v "${DATA_VOL}":/data \
   -v "${SECRETS_VOL}":/secrets \
   -v "${IN_DIR}":/backup:ro \
-  alpine sh -c "rm -rf /data/* /secrets/* && tar xzf /backup/${IN_FILE} -C /"
+  alpine@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce sh -c "rm -rf /data/* /secrets/* && tar xzf /backup/${IN_FILE} -C /"
 
 echo "Restored from ${IN_FILE}. Start the stack: docker compose up -d"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:latest
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.3.0}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:latest
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/scripts/check-release-pins.mjs
+++ b/scripts/check-release-pins.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Every place that names the release version must agree, because none of them
+// is generated from another:
+//   - package.json "version" at the root and in both workspaces
+//   - the ${ALDINE_VERSION:-x.y.z} default in docker-compose.yml, which is what
+//     a fresh `docker compose up` pulls
+//   - the same default in the README's copy-paste block (documented as the
+//     compose file "verbatim")
+// With --tag vX.Y.Z (the release preflight) the tag must match too, and the
+// CHANGELOG must already carry a "## [X.Y.Z]" heading.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => readFileSync(path.join(root, p), 'utf8');
+const version = (p) => JSON.parse(read(p)).version;
+
+const tagArg = process.argv.indexOf('--tag');
+const tag = tagArg >= 0 ? process.argv[tagArg + 1] : process.env.RELEASE_TAG;
+
+const found = [];
+found.push(['package.json', version('package.json')]);
+found.push(['apps/server/package.json', version('apps/server/package.json')]);
+found.push(['apps/web/package.json', version('apps/web/package.json')]);
+
+const pin = /aldine-(app|compiler):\$\{ALDINE_VERSION:-([^}]+)\}/g;
+for (const file of ['docker-compose.yml', 'README.md']) {
+  const text = read(file);
+  const seen = new Set();
+  for (const m of text.matchAll(pin)) {
+    if (seen.has(m[1])) continue;
+    seen.add(m[1]);
+    found.push([`${file} (${m[1]})`, m[2]]);
+  }
+  for (const image of ['app', 'compiler']) {
+    if (!seen.has(image)) found.push([`${file} (${image})`, `<no ${'${ALDINE_VERSION:-…}'} default>`]);
+  }
+}
+
+const expected = found[0][1];
+const problems = found.filter(([, v]) => v !== expected).map(([where, v]) => `${where}: ${v}`);
+
+if (tag) {
+  const m = /^v(\d+\.\d+\.\d+)$/.exec(tag);
+  if (!m) problems.push(`tag ${tag}: not of the form vX.Y.Z`);
+  else if (m[1] !== expected) problems.push(`tag ${tag}: version differs`);
+  if (m && !read('CHANGELOG.md').includes(`## [${m[1]}]`)) problems.push(`CHANGELOG.md: no "## [${m[1]}]" heading`);
+}
+
+if (problems.length) {
+  console.error(`check-release-pins: expected every pin to be ${expected} (from package.json), but:`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error('Fix: npm pkg set version=X.Y.Z --workspaces --include-workspace-root, then update the compose default and the README block.');
+  process.exit(1);
+}
+console.log(`check-release-pins: all ${found.length} pins say ${expected}${tag ? `, tag ${tag} matches` : ''}`);

--- a/scripts/smoke-image.mjs
+++ b/scripts/smoke-image.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Boots nothing itself: points at a running stack (ALDINE_URL, default
+// http://localhost:8080) and proves the published images work the way a
+// self-hoster will use them. This is the first time the emitted dist/ and the
+// compiler's package set are executed anywhere before a user does.
+//
+// Checks, in order: the app answers /api/health; the compiler is reachable
+// through it and reports a real TeX Live (and the scheme in EXPECT_SCHEME, if
+// set: the image reports "unknown" rather than failing when the build arg went
+// missing); the SPA and the template gallery are served; a biblatex document
+// typesets to a multi-page PDF with its citation resolved, under the compose
+// sandbox (no egress, caps dropped).
+const BASE = (process.env.ALDINE_URL || 'http://localhost:8080').replace(/\/$/, '');
+const EXPECT_SCHEME = process.env.EXPECT_SCHEME || '';
+const WAIT_MS = Number(process.env.SMOKE_WAIT_MS || 180_000);
+
+function fail(msg) {
+  console.error(`smoke: FAIL ${msg}`);
+  process.exit(1);
+}
+function ok(msg) {
+  console.log(`smoke: ok  ${msg}`);
+}
+
+async function json(path, init) {
+  const res = await fetch(BASE + path, init);
+  const text = await res.text();
+  let body;
+  try { body = JSON.parse(text); } catch { body = text; }
+  return { status: res.status, body };
+}
+
+async function waitForHealth() {
+  const until = Date.now() + WAIT_MS;
+  let last = '';
+  while (Date.now() < until) {
+    try {
+      const r = await json('/api/health');
+      if (r.status === 200 && r.body && r.body.ok === true) return r.body;
+      last = `${r.status} ${JSON.stringify(r.body)}`;
+    } catch (e) {
+      last = String(e);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  fail(`/api/health not ok after ${WAIT_MS / 1000}s (last: ${last})`);
+}
+
+const health = await waitForHealth();
+ok(`/api/health ${JSON.stringify(health)}`);
+
+// The compiler sits on the internal network, so it is only reachable via the
+// app, which caches a failed probe for 5 s; give it a few tries.
+let compiler;
+for (let i = 0; i < 20; i++) {
+  compiler = (await json('/api/compiler')).body;
+  if (compiler && compiler.ok) break;
+  await new Promise((r) => setTimeout(r, 3000));
+}
+if (!compiler || !compiler.ok) fail(`/api/compiler: compiler unreachable: ${JSON.stringify(compiler)}`);
+if (!compiler.texlive || compiler.texlive.release === 'unknown') fail(`/api/compiler: TeX Live release unknown: ${JSON.stringify(compiler)}`);
+if (EXPECT_SCHEME && compiler.texlive.scheme !== EXPECT_SCHEME) fail(`/api/compiler: scheme ${compiler.texlive.scheme}, expected ${EXPECT_SCHEME}`);
+ok(`/api/compiler TeX Live ${compiler.texlive.release} (${compiler.texlive.scheme})`);
+
+const index = await fetch(BASE + '/');
+const html = await index.text();
+if (index.status !== 200 || !/<div id="root"|<script/.test(html)) fail(`GET / returned ${index.status} without the SPA shell`);
+ok('GET / serves the SPA');
+
+const templates = await json('/api/templates');
+if (templates.status !== 200) fail(`/api/templates returned ${templates.status}`);
+ok('/api/templates responds');
+
+const mainTex = String.raw`\documentclass{article}
+\usepackage[backend=biber,style=numeric]{biblatex}
+\addbibresource{refs.bib}
+\begin{document}
+\title{Release smoke}\author{Aldine CI}\maketitle
+A citation that must resolve: \cite{smoke2026}.
+\newpage
+Second page, so the PDF has more than one.
+\printbibliography
+\end{document}
+`;
+const refsBib = `@article{smoke2026,
+  author  = {Smoke, Test},
+  title   = {A reference that only exists in this test},
+  journal = {Journal of Release Checks},
+  year    = {2026},
+}
+`;
+const created = await json('/api/projects', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ name: 'Release smoke', files: { 'main.tex': mainTex, 'refs.bib': refsBib } }),
+});
+if (created.status !== 200 && created.status !== 201) fail(`POST /api/projects returned ${created.status} ${JSON.stringify(created.body)}`);
+const id = created.body.id;
+if (!id) fail(`POST /api/projects returned no id: ${JSON.stringify(created.body)}`);
+ok(`project ${id} created`);
+
+const compiled = await json(`/api/projects/${id}/compile`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ branch: 'main' }),
+});
+const result = compiled.body;
+const log = typeof result?.log === 'string' ? result.log : '';
+if (compiled.status !== 200 || !result || !result.ok) {
+  console.error(log.slice(-4000));
+  fail(`compile returned ${compiled.status}, ok=${result?.ok}, errors=${JSON.stringify(result?.errors)}`);
+}
+if (!result.pdfUrl) fail('compile ok but no pdfUrl');
+if (/undefined (references|citations)|Citation .* undefined|Please \(re\)run Biber/i.test(log)) {
+  console.error(log.slice(-4000));
+  fail('the citation did not resolve (biber did not run through)');
+}
+ok(`compiled in ${result.durationMs} ms`);
+
+const pdfRes = await fetch(BASE + result.pdfUrl);
+const pdf = Buffer.from(await pdfRes.arrayBuffer());
+if (pdfRes.status !== 200 || pdf.subarray(0, 5).toString() !== '%PDF-') fail(`pdf fetch returned ${pdfRes.status}, ${pdf.length} bytes`);
+// pdfTeX compresses its object streams, so the page tree is not greppable in
+// the bytes; the engine's own "Output written on … (N pages" line is.
+const written = /Output written on [^\n]*\((\d+) pages?/.exec(log);
+const pages = written ? Number(written[1]) : 0;
+if (pages < 2) fail(`expected a multi-page PDF, log says ${written ? written[0] : 'nothing about pages'}`);
+ok(`PDF ${pdf.length} bytes, ${pages} pages`);
+
+console.log('smoke: all checks passed');


### PR DESCRIPTION
## What changes for a self-hoster

- `docker-compose.yml` and the README block pin `${ALDINE_VERSION:-0.3.0}` instead of `:latest`. A running install never changes on its own; upgrading is `ALDINE_VERSION=0.4.0 docker compose pull && docker compose up -d`, rolling back is the same line with the previous version.
- `:latest` still exists and keeps pointing at the newest release, but it moves only when a human approves the promote step.

## What changes for releasing

`git push origin v0.4.0` now runs:

1. **preflight**: the tag is on `main`; `scripts/check-release-pins.mjs` says the three `package.json` versions, the compose default, the README block and the CHANGELOG heading all agree with the tag.
2. **verify**: `ci.yml` on the tagged commit (tags never triggered CI before).
3. **build**: `build-image.yml` builds each image per platform on native runners (amd64 + `ubuntu-24.04-arm`), pushes by digest, and stitches an index tagged `0.4.0` and `sha-<commit>`. It refuses to overwrite an existing version tag.
4. **smoke**: boots those exact digests with the user-facing compose file plus `deploy/docker-compose.smoke.yml`, and `scripts/smoke-image.mjs` checks health, the compiler's TeX Live report (`scheme === full`), the SPA, the template list, and typesets a biblatex document to a two-page PDF with the citation resolved, inside the `cap_drop: ALL`/no-egress sandbox.
5. **promote**: pauses in the `latest` environment (required reviewer: @trahloff, already configured). Approving re-tags the digests to `:latest` and `0.4`, then publishes the GitHub Release.

`promote.yml` is also dispatchable by hand with any published version. That is the rollback.

## Also in here

- CI runs the web unit tests and the release-pin check on every PR.
- `test:unit` discovers `apps/server/test/*.test.mjs` instead of listing files. The enumerated line is in conflict right now between `main` and `agent-api`, and resolving it either way would have dropped tests with CI still green.
- Server image: `npm ci` from the lockfile; new `.dockerignore` (a local `--build` with `node_modules` present copied it over the installed one and failed).
- Compiler build cache `mode=min` (a full TeX Live layer set at `mode=max` exceeds the 10 GB repo cache); runner disk cleanup before the compiler build.
- `deploy/backup.sh` and `deploy/restore.sh` pin `alpine` by digest.
- README: the "~2.5 GB" first pull becomes the real numbers (about 1 GB at 0.3.0, about 2.8 GB from 0.4.0, which switches to full TeX Live); CONTRIBUTING describes cut-then-promote; AGENTS.md gets the two gotchas.

## Verified

- `check-release-pins.mjs`: passes on this tree, passes with `--tag v0.3.0`, fails with `--tag v0.4.0` naming both the version and the missing CHANGELOG heading.
- `npm run test:unit -w apps/server`: 17/17 files via the new runner. `npm run test -w apps/web`: 26 tests.
- `docker compose config` for base, full, `ALDINE_VERSION=0.4.1` override, and the smoke overlay (which refuses to start without the image variables).
- actionlint: clean on the four workflows.
- Built both images from this branch locally, booted them with the base compose file and the smoke overlay, ran `smoke-image.mjs`: all checks pass (TeX Live 2026 full, 2-page PDF, citation resolved).

## Not in here

- Playwright in CI (needs a `ci-medium` compiler image and tagging the two tests that need full TeX Live). Separate PR.
- `deploy-aws.yml` still defaults `target` to production. Separate one-line PR.
- The first `0.3.0 → 0.4.0` promote is still a 40-plus commit jump for anyone on `:latest`; this pipeline only guarantees it was tested and smoked first.
