### PR TITLE
compiler: publish medium as the default image and full as a -full variant

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,6 +29,16 @@ on:
         required: false
         type: boolean
         default: false
+      build-args:
+        description: Extra build args, one KEY=value per line
+        required: false
+        type: string
+        default: ''
+      tag-suffix:
+        description: Appended to the version and sha tags (e.g. -full for the full TeX Live variant)
+        required: false
+        type: string
+        default: ''
     outputs:
       digest:
         description: Digest of the pushed multi-arch index
@@ -40,6 +50,8 @@ permissions:
 
 env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-${{ inputs.name }}
+  VERSION_TAG: ${{ inputs.version }}${{ inputs.tag-suffix }}
+  VARIANT: ${{ inputs.name }}${{ inputs.tag-suffix }}
 
 jobs:
   build:
@@ -69,8 +81,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Refuse to overwrite a published version
         run: |
-          if docker manifest inspect "$IMAGE:${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::$IMAGE:${{ inputs.version }} already exists; version tags are immutable. Cut a new version instead."
+          if docker manifest inspect "$IMAGE:$VERSION_TAG" >/dev/null 2>&1; then
+            echo "::error::$IMAGE:$VERSION_TAG already exists; version tags are immutable. Cut a new version instead."
             exit 1
           fi
       - name: Platform slug
@@ -85,18 +97,19 @@ jobs:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           platforms: ${{ matrix.platform }}
+          build-args: ${{ inputs.build-args }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ inputs.name }}-${{ steps.slug.outputs.value }}
+          cache-from: type=gha,scope=${{ env.VARIANT }}-${{ steps.slug.outputs.value }}
           # mode=max of a full TeX Live layer set exceeds the 10 GB repo cache
           # and evicts itself every run; min keeps only the final layers.
-          cache-to: type=gha,scope=${{ inputs.name }}-${{ steps.slug.outputs.value }},mode=min
+          cache-to: type=gha,scope=${{ env.VARIANT }}-${{ steps.slug.outputs.value }},mode=min
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ steps.slug.outputs.value }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.name }}-${{ steps.slug.outputs.value }}
+          name: digests-${{ env.VARIANT }}-${{ steps.slug.outputs.value }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -110,7 +123,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ inputs.name }}-*
+          pattern: digests-${{ env.VARIANT }}-*
           merge-multiple: true
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
@@ -123,16 +136,16 @@ jobs:
         id: index
         run: |
           set -e
-          if docker manifest inspect "$IMAGE:${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::$IMAGE:${{ inputs.version }} appeared while building; version tags are immutable."
+          if docker manifest inspect "$IMAGE:$VERSION_TAG" >/dev/null 2>&1; then
+            echo "::error::$IMAGE:$VERSION_TAG appeared while building; version tags are immutable."
             exit 1
           fi
           refs=()
           for f in /tmp/digests/*; do refs+=("$IMAGE@$(cat "$f")"); done
           docker buildx imagetools create \
-            -t "$IMAGE:${{ inputs.version }}" \
-            -t "$IMAGE:sha-${GITHUB_SHA::7}" \
+            -t "$IMAGE:$VERSION_TAG" \
+            -t "$IMAGE:sha-${GITHUB_SHA::7}${{ inputs.tag-suffix }}" \
             "${refs[@]}"
-          digest=$(docker buildx imagetools inspect "$IMAGE:${{ inputs.version }}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          digest=$(docker buildx imagetools inspect "$IMAGE:$VERSION_TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
-          echo "Pushed $IMAGE:${{ inputs.version }} = $digest" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pushed $IMAGE:$VERSION_TAG = $digest" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -55,16 +55,20 @@ jobs:
             *[!0-9.]*|'') echo "::error::version must look like 0.4.0, got '$VERSION'"; exit 1 ;;
           esac
           minor="${VERSION%.*}"
-          for name in app compiler; do
-            image="ghcr.io/${{ github.repository_owner }}/aldine-$name"
+          owner="ghcr.io/${{ github.repository_owner }}"
+          # image:suffix pairs; the compiler ships a medium (default) and a
+          # -full variant, promoted together so latest and latest-full agree.
+          targets=("aldine-app:" "aldine-compiler:" "aldine-compiler:-full")
+          for t in "${targets[@]}"; do
+            image="$owner/${t%%:*}"; suffix="${t#*:}"
             # A version that was never built (or never finished building) must
             # not become latest.
-            docker buildx imagetools inspect "$image:$VERSION" >/dev/null
+            docker buildx imagetools inspect "$image:$VERSION$suffix" >/dev/null
           done
-          for name in app compiler; do
-            image="ghcr.io/${{ github.repository_owner }}/aldine-$name"
-            docker buildx imagetools create -t "$image:latest" -t "$image:$minor" "$image:$VERSION"
-            echo "$image:latest -> $VERSION ($(docker buildx imagetools inspect "$image:latest" --format '{{json .Manifest.Digest}}'))" >> "$GITHUB_STEP_SUMMARY"
+          for t in "${targets[@]}"; do
+            image="$owner/${t%%:*}"; suffix="${t#*:}"
+            docker buildx imagetools create -t "$image:latest$suffix" -t "$image:$minor$suffix" "$image:$VERSION$suffix"
+            echo "$image:latest$suffix -> $VERSION$suffix ($(docker buildx imagetools inspect "$image:latest$suffix" --format '{{json .Manifest.Digest}}'))" >> "$GITHUB_STEP_SUMMARY"
           done
       - name: Publish the GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
       version: ${{ needs.preflight.outputs.version }}
     secrets: inherit
 
+  # The published default: scheme medium (curated packages, publisher classes,
+  # most scripts). What `aldine-compiler:<version>` and `:latest` point at.
   build-compiler:
     needs: [preflight, verify]
     uses: ./.github/workflows/build-image.yml
@@ -70,15 +72,39 @@ jobs:
       context: apps/compiler
       dockerfile: apps/compiler/Dockerfile
       version: ${{ needs.preflight.outputs.version }}
+      build-args: TEXLIVE_SCHEME=medium
+    secrets: inherit
+
+  # All of TeX Live, published as `<version>-full` / `latest-full`; a
+  # self-hoster opts in with ALDINE_TEXLIVE=-full.
+  build-compiler-full:
+    needs: [preflight, verify]
+    uses: ./.github/workflows/build-image.yml
+    with:
+      name: compiler
+      context: apps/compiler
+      dockerfile: apps/compiler/Dockerfile
+      version: ${{ needs.preflight.outputs.version }}
+      build-args: TEXLIVE_SCHEME=full
+      tag-suffix: -full
       free-disk: true
     secrets: inherit
 
   smoke:
-    needs: [preflight, build-app, build-compiler]
+    needs: [preflight, build-app, build-compiler, build-compiler-full]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: medium
+            compiler: ${{ needs.build-compiler.outputs.digest }}
+          - variant: full
+            compiler: ${{ needs.build-compiler-full.outputs.digest }}
+    name: smoke (${{ matrix.variant }})
     env:
       ALDINE_APP_IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-app@${{ needs.build-app.outputs.digest }}
-      ALDINE_COMPILER_IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-compiler@${{ needs.build-compiler.outputs.digest }}
+      ALDINE_COMPILER_IMAGE: ghcr.io/${{ github.repository_owner }}/aldine-compiler@${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -92,7 +118,7 @@ jobs:
         run: node scripts/smoke-image.mjs
         env:
           ALDINE_URL: http://localhost:8080
-          EXPECT_SCHEME: full
+          EXPECT_SCHEME: ${{ matrix.variant }}
       - name: Container logs
         if: failure()
         run: docker compose -f docker-compose.yml -f deploy/docker-compose.smoke.yml logs --no-color | tail -200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,12 +180,15 @@ All notable changes to Aldine are documented here. The format follows
   on screen as before.
 
 
-- The compiler image defaults to full TeX Live (`TEXLIVE_SCHEME=full`): every
-  script and language compiles out of the box. The `medium` scheme stays for
-  constrained hosts and now includes the publisher classes and the Arabic/Persian,
-  Cyrillic, Greek and other-script collections (Persian via xepersian or
-  polyglossia verified). Self-hosters: rebuild the compiler image; expect ~9 GB
-  on disk for the default.
+- The compiler image is published in two variants. `aldine-compiler:<version>`
+  is the `medium` scheme, which now includes the publisher classes and the
+  Arabic/Persian, Cyrillic, Greek and other-script collections (Persian via
+  xepersian or polyglossia verified), about 3.7 GB on disk.
+  `aldine-compiler:<version>-full` is all of TeX Live (about 9 GB on disk):
+  every script and language, CJK included. Pick it with `ALDINE_TEXLIVE=-full`
+  next to `ALDINE_VERSION` in the compose environment; `latest-full` tracks
+  `latest`. A missing-package error hint names that switch. Building from
+  source (`docker-compose.full.yml`) still takes `ALDINE_TEXLIVE_SCHEME`.
 - The compiler image installs `collection-publishers` (elsarticle, IEEEtran,
   acmart, revtex4-2, agujournal, copernicus, and the other journal and
   conference classes) on the medium scheme, and the full scheme's base image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,5 +119,7 @@ To roll back, run "Promote to latest" by hand (Actions tab) with the previous
 version: it re-tags the digests that already exist, no rebuild. The same
 command is the way to re-promote a version whose approval you let expire.
 
-Budget about an hour for the build: the full TeX Live compiler image is
-around 2.8 GB compressed per architecture.
+Budget about an hour for the build: the compiler is built twice, as the
+default `medium` scheme and as `-full`, and the full TeX Live image is around
+2.8 GB compressed per architecture. Both variants are smoked and promoted
+together, so `latest` and `latest-full` always name the same release.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -173,10 +173,16 @@ what `deploy/backup.sh` looks for.
   security fixes: per [SECURITY.md](SECURITY.md), only the latest release
   gets them.
 - **The first pull is big.** TeX Live lives in the compiler image: about
-  1 GB compressed for 0.3.0, and about 2.8 GB (around 9 GB on disk) from
-  0.4.0 on, which switches to full TeX Live so every script and language
-  typesets out of the box. After the first pull, starts take seconds. Ready
-  when `curl localhost:8080/api/health` returns `{"ok":true,"name":"aldine"}`.
+  1 GB compressed, 3.7 GB on disk. It carries a curated package set, the
+  publisher classes, and the Arabic, Persian, Cyrillic and Greek scripts;
+  the one family it leaves out is CJK. After the first pull, starts take
+  seconds. Ready when `curl localhost:8080/api/health` returns
+  `{"ok":true,"name":"aldine"}`.
+- **Need a package it does not have?** Every release from 0.4.0 also ships
+  all of TeX Live as `-full` (about 2.8 GB compressed, 9 GB on disk). Add
+  `ALDINE_TEXLIVE=-full` next to `ALDINE_VERSION` and pull again; the
+  missing-package error in the editor tells you the same thing. Project
+  settings show which one you are on.
 - **Port 8080 taken?** Change the left side of `ports:`.
 - **Everything beyond the minimum**: building from source (latest `main`,
   not a release), auth/SSO/AI/email options, TLS, Postgres/Redis. All of it
@@ -184,10 +190,7 @@ what `deploy/backup.sh` looks for.
   the same compiler sandbox and the same volumes, so you can switch without
   losing data: `docker compose -f docker-compose.full.yml up -d --build`.
   The first build pulls TeX Live; expect 15–40 minutes.
-- **Constrained host?** Build the compiler yourself with the slimmer
-  `medium` scheme (curated packages and publisher classes, no CJK, about
-  1.3 GB of packages):
-  `ALDINE_TEXLIVE_SCHEME=medium docker compose -f docker-compose.full.yml up -d --build`
+  `ALDINE_TEXLIVE_SCHEME=full` builds the all-of-TeX-Live variant instead.
 
 ## How Aldine compares
 
@@ -201,7 +204,7 @@ what `deploy/backup.sh` looks for.
 | Zotero | Whole library **or one collection**, free | Premium, whole library | Via Better BibTeX, manual |
 | Warm recompile | ~2s (persistent latexmk cache) | Comparable | Fastest (local) |
 | Templates gallery | 4 built-in | Huge community gallery | CTAN / your own |
-| Package coverage | **All of TeX Live** by default (`ALDINE_TEXLIVE_SCHEME=medium` for a curated slim image) | All of TeX Live | Whatever you install |
+| Package coverage | Curated TeX Live by default (publisher classes, most scripts); **all of TeX Live** with `ALDINE_TEXLIVE=-full` | All of TeX Live | Whatever you install |
 | Rich-text / visual editing | ✅ experimental: byte-stable, WYSIWYG math, editable tables, tracked changes | ✅ (rewrites your source) | ❌ |
 | Maturity | Young (v0.x, 2026) | A decade in production | Very mature |
 | License | AGPL-3.0 | AGPL | MIT/varies |

--- a/apps/compiler/Dockerfile
+++ b/apps/compiler/Dockerfile
@@ -1,13 +1,15 @@
 # Two selectable TeX Live schemes (build arg TEXLIVE_SCHEME=medium|full):
 #
-#   full (default) — everything on CTAN preinstalled (~9 GB on disk). Every
-#     script and language TeX Live supports compiles out of the box; this is what
-#     an Overleaf user expects.
-#   medium — ~1.3 GB of packages plus a pinned set of extras real papers commonly
-#     need, the publisher classes, and the Arabic/Persian, Cyrillic, Greek and
-#     "other" script collections (CJK is the one family left to full). For
-#     constrained hosts:
-#       ALDINE_TEXLIVE_SCHEME=medium docker compose up -d --build
+#   medium (default) — ~1.3 GB of packages plus a pinned set of extras real
+#     papers commonly need, the publisher classes, and the Arabic/Persian,
+#     Cyrillic, Greek and "other" script collections. CJK is the one family
+#     left to full. About 3.7 GB on disk; this is the published
+#     aldine-compiler:<version> image.
+#   full — everything on CTAN preinstalled (~9 GB on disk). Every script and
+#     language TeX Live supports compiles out of the box. Published as
+#     aldine-compiler:<version>-full (ALDINE_TEXLIVE=-full in compose), or
+#     built locally:
+#       ALDINE_TEXLIVE_SCHEME=full docker compose -f docker-compose.full.yml up -d --build
 #
 # Both bases are pinned by digest. For medium the pin keeps tlmgr revisions
 # reproducible (a floating tag makes the snapshot-repository date below drift
@@ -17,7 +19,7 @@
 # index digest reported by
 #   docker buildx imagetools inspect texlive/texlive:<tag>
 # (the top-level "Digest:" line, not a per-platform manifest).
-ARG TEXLIVE_SCHEME=full
+ARG TEXLIVE_SCHEME=medium
 
 FROM texlive/texlive:latest-medium@sha256:0a5aa82d0d9d6e3b3a25f87e221ef61d7c077e83639ab5065cf298b1a01ec00c AS texlive-medium
 

--- a/apps/web/src/editor/errorHints.ts
+++ b/apps/web/src/editor/errorHints.ts
@@ -3,8 +3,8 @@
 const HINTS: Array<{ re: RegExp; hint: string }> = [
   { re: /Undefined control sequence/i, hint: 'A command isn’t defined — check its spelling, or add the \\usepackage that provides it.' },
   { re: /Missing \$ inserted/i, hint: 'Math content outside math mode — wrap symbols like _ ^ \\alpha in $…$.' },
-  { re: /File `?([^']+?)\.sty'? not found/i, hint: 'The package “$1” isn’t in this server’s TeX Live image (or is misspelled in \\usepackage). Self-hosting? Rebuild with ALDINE_TEXLIVE_SCHEME=full to include all of CTAN.' },
-  { re: /File `?([^']+?)\.cls'? not found/i, hint: 'The document class “$1” isn’t in this server’s TeX Live image — upload the .cls into the project, or rebuild with ALDINE_TEXLIVE_SCHEME=full to include all of CTAN.' },
+  { re: /File `?([^']+?)\.sty'? not found/i, hint: 'The package “$1” isn’t in this server’s TeX Live image (or is misspelled in \\usepackage). Self-hosting? Set ALDINE_TEXLIVE=-full and pull again to get all of TeX Live (ALDINE_TEXLIVE_SCHEME=full when building from source).' },
+  { re: /File `?([^']+?)\.cls'? not found/i, hint: 'The document class “$1” isn’t in this server’s TeX Live image — upload the .cls into the project, or set ALDINE_TEXLIVE=-full and pull again to get all of TeX Live.' },
   { re: /File `?([^']+?)'? not found/i, hint: 'The file isn’t in the project — check the path in \\input, \\include, or \\includegraphics.' },
   { re: /Environment .* undefined/i, hint: 'The \\begin{…} environment isn’t defined — load the package that provides it.' },
   { re: /\\begin\{.*\} on input line .* ended by \\end\{.*\}/i, hint: 'Mismatched \\begin/\\end pair — every \\begin{x} must close with \\end{x}.' },

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -247,5 +247,6 @@ Everything is env-gated; blank/unset means "off" or the listed default.
 | `RL_COMPILE_CONCURRENCY` | Max concurrent compiles the app forwards (default 2) |
 | `COMPILE_TIMEOUT_MS`, `MAX_CONCURRENT_COMPILES` | Compiler-container limits: per-compile timeout (default 120000 ms) and compiles in flight (default 2). `docker-compose.full.yml` passes both through from `.env` |
 | `ALDINE_PROJECT` | Compose project name for `backup.sh`/`restore.sh` (default `aldine`) |
-| `ALDINE_TEXLIVE_SCHEME` | Compiler image build: `full` (default, all of TeX Live, ~9 GB on disk) or `medium` (curated set + publisher classes + Arabic/Cyrillic/Greek scripts, no CJK, ~3 GB) |
+| `ALDINE_TEXLIVE_SCHEME` | Compiler image build (`docker-compose.full.yml`): `medium` (default; curated set + publisher classes + Arabic/Cyrillic/Greek scripts, no CJK, ~3.7 GB on disk) or `full` (all of TeX Live, ~9 GB). Prebuilt images: set `ALDINE_TEXLIVE=-full` instead |
+| `ALDINE_VERSION`, `ALDINE_TEXLIVE` | Prebuilt images (`docker-compose.yml`): the release to run (default: the current release, pinned in the file) and the compiler variant, empty (curated TeX Live) or `-full` (all of TeX Live, from 0.4.0) |
 | `ALDINE_TRASH_DAYS` | Days deleted projects stay restorable in the trash before the daily sweep purges them (default `30`) |

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -80,8 +80,8 @@ services:
       context: apps/compiler
       args:
         # medium (default, ~1 GB + pinned extras) or full (all of CTAN, ~9 GB on disk):
-        #   ALDINE_TEXLIVE_SCHEME=medium docker compose up -d --build
-        TEXLIVE_SCHEME: ${ALDINE_TEXLIVE_SCHEME:-full}
+        #   ALDINE_TEXLIVE_SCHEME=full docker compose up -d --build
+        TEXLIVE_SCHEME: ${ALDINE_TEXLIVE_SCHEME:-medium}
     environment:
       DATA_DIR: /data
       COMPILE_TIMEOUT_MS: ${COMPILE_TIMEOUT_MS:-120000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -71,7 +71,7 @@ flag; everything else works in the default single-tenant deploy.
 - **COMP-6** — SyncTeX: double-clicking the PDF jumps the editor to the source
   line; ⌘J jumps the PDF to my cursor with a flash.
 - **COMP-7** — A missing-package error names the package and points at
-  `ALDINE_TEXLIVE_SCHEME=full`.
+  `ALDINE_TEXLIVE=-full`.
 
 ## Collaboration (COLLAB)
 


### PR DESCRIPTION
Follows #31. Decision: the published default compiler image stays the curated `medium` scheme; all of TeX Live ships alongside it as an opt-in variant.

## What changes

- `apps/compiler/Dockerfile`: `ARG TEXLIVE_SCHEME=medium` again (it was flipped to `full` on 2026-09-02, after v0.3.0). Header comment rewritten to describe both variants and where each is published.
- `release.yml` builds the compiler twice via `build-image.yml` (new `build-args` and `tag-suffix` inputs): `aldine-compiler:<version>` (medium) and `aldine-compiler:<version>-full`. Smoke runs as a two-variant matrix with `EXPECT_SCHEME` asserted per variant, so a build arg going missing cannot ship medium under the `-full` name or vice versa.
- `promote.yml` re-tags `latest`/`<minor>` and `latest-full`/`<minor>-full` together, after checking all three images exist for the version.
- `docker-compose.yml` and the README block: `aldine-compiler:${ALDINE_VERSION:-0.3.0}${ALDINE_TEXLIVE:-}`. Opt in with `ALDINE_TEXLIVE=-full`. `docker-compose.full.yml` keeps `ALDINE_TEXLIVE_SCHEME` for source builds, now defaulting to `medium`.
- Error hints for a missing `.sty`/`.cls` name `ALDINE_TEXLIVE=-full` (and the build-time var for source builds).
- README, CONTRIBUTING, deploy/README, docs/USER_STORIES, CHANGELOG updated. The hosted AWS deploy (`deploy/aws/push-images.sh`) keeps building `full`; that instance is ours.

## Why

About 9 GB on disk versus 3.7 GB, and an upgrade holds both copies. The scheme reported in project settings makes "this needs full" a diagnosable state, and the hint now says what to do.

## Verified

- `check-release-pins.mjs` still passes (the regex tolerates the trailing `${ALDINE_TEXLIVE:-}`).
- `docker compose config`: default resolves to `aldine-compiler:0.3.0`; `ALDINE_TEXLIVE=-full ALDINE_VERSION=0.4.0` resolves to `aldine-compiler:0.4.0-full`; the full compose file defaults `TEXLIVE_SCHEME: medium`.
- actionlint clean; web typecheck and vitest pass.
- Not verified here: a medium build on the runner. It is the same Dockerfile path v0.3.0 was built with; only the default changed.

## Note

There is no `0.3.0-full` image, so `ALDINE_TEXLIVE=-full` only resolves from 0.4.0 on. The README says so.
