### PR TITLE
compiler: refuse a main document latexmk could read as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,25 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- A project whose main document is `MAIN.TEX` (any capitalisation but
+  `.tex`) typesets again. The root picker accepted it, latexmk wrote
+  `MAIN.pdf`, and the compiler looked for `MAIN.TEX.pdf`, so every typeset
+  came back as a failure with no error to show and a second full rebuild each
+  time. The editor's auto-typeset and empty state now recognise it too.
+- A `latexmkrc` with `$pdf_mode = 4` now selects LuaLaTeX and `= 5` XeLaTeX,
+  which is what latexmk means by them (`-pdflua` sets 4, `-pdfxe` sets 5);
+  they were swapped, so an archive that named its engine that way imported
+  with the other one and failed its first typeset.
+- A bibliography error stays visible on the typesets that follow it. latexmk
+  does not re-run bibtex or biber until the `.bib` changes, and only reports
+  that the rule "gave an error in previous invocation"; the located error
+  from that run (file and line in the `.bib`) was dropped as stale, leaving
+  a row with no file to click.
+- A failing typeset no longer pays a second full rebuild. The stale-aux
+  recovery matched the word "undefined" in any error and the `.aux` mention
+  in any log, so nearly every failed compile ran twice; with runs to
+  completion, that doubled the wait. It now fires only for an error located
+  in the `.aux`/`.bcf` next to one of that file's own macros.
 - A cookie on the same host that is not valid percent-encoding (another
   app's `x=100%`, a truncated `%E0%A4%A`) no longer turns every request into
   `{"error":"Internal server error"}` until the user clears site cookies. Such
@@ -448,6 +467,17 @@ All notable changes to Aldine are documented here. The format follows
   seconds"; the README says ~2s, so the page does now too.
 
 ### Security
+- The main document's name could carry latexmk options. A root file such as
+  `-pdflatex=<command>` landed bare on the compiler's command line, and
+  latexmk ran the command; with auth off, or as any project member with it
+  on, that was command execution inside the compiler container, which mounts
+  every project. The compiler and the settings route now refuse a path
+  segment starting with `-`, and the compiler passes the root file as
+  `./<name>` so it can never be read as an option. Reported by the September
+  regression review; present since the compiler was written.
+- A SyncTeX lookup could name another project's directory in its body and
+  read that project's SyncTeX records (file names and line numbers). Only the
+  lookup fields cross to the compiler now.
 - The minimal `docker-compose.yml` carries the compiler sandbox again: an
   `internal: true` network with no route to the internet, `cap_drop: [ALL]`,
   `no-new-privileges`, and memory/PID bounds. The 0.3.0 split had left all of it

--- a/apps/compiler/server.js
+++ b/apps/compiler/server.js
@@ -192,10 +192,23 @@ async function compile(body) {
   }
 }
 
+/**
+ * A root file is a relative path inside the project. A segment starting with
+ * "-" is refused because the name ends up on a latexmk command line, and
+ * latexmk reads "-pdflatex=<program>" as an option that runs <program>: with
+ * it, whoever can name the main document runs commands in this container.
+ * The "./" prefix in mkArgs is the second lock on the same door.
+ */
+function invalidRootFile(rootFile) {
+  if (typeof rootFile !== 'string' || !rootFile) return true;
+  if (rootFile.includes('..') || path.isAbsolute(rootFile)) return true;
+  return rootFile.split(/[\\/]/).some((seg) => seg.startsWith('-'));
+}
+
 async function compileInner(body) {
   const { projectDir, rootFile = 'main.tex', engine = 'pdf', haltOnError = false } = body;
   if (!projectDir || projectDir.includes('..')) throw new Error('invalid projectDir');
-  if (!rootFile || rootFile.includes('..') || path.isAbsolute(rootFile)) throw new Error('invalid rootFile');
+  if (invalidRootFile(rootFile)) throw new Error('invalid rootFile');
   const absDir = path.resolve(DATA_DIR, projectDir);
   if (!absDir.startsWith(path.resolve(DATA_DIR))) throw new Error('projectDir escapes DATA_DIR');
   if (!fs.existsSync(path.join(absDir, rootFile))) throw new Error(`root file not found: ${rootFile}`);
@@ -230,9 +243,11 @@ async function compileInner(body) {
     '-synctex=1',
     '-cd', // chdir to the root file's directory before compiling
     `-outdir=${OUT_SUBDIR}`,
-    rootFile,
+    `./${rootFile}`, // never bare: a name starting with "-" must stay a file, not an option
   ];
-  const base = path.basename(rootFile).replace(/\.tex$/, '');
+  // Case-insensitive: the root picker accepts MAIN.TEX, and latexmk writes
+  // MAIN.pdf for it; stripping only ".tex" would look for MAIN.TEX.pdf.
+  const base = path.basename(rootFile).replace(/\.tex$/i, '');
   const rel = (f) => path.join(rootDir, OUT_SUBDIR, f); // path relative to the project dir
   const outAbs = path.join(absDir, rootDir, OUT_SUBDIR);
   const pdfPath = path.join(outAbs, `${base}.pdf`);
@@ -260,7 +275,13 @@ async function compileInner(body) {
   // leftover .aux/.bcf artifacts make an otherwise-valid document fail with an
   // undefined-control-sequence in the .aux (\abx@aux@…, \bibcite, …). Wipe the
   // regenerable aux files once and rebuild — the .aux is not source of truth.
-  if (code !== 0 && !timedOut && /(\\abx@aux@|\\bibcite|\\@writefile|undefined)/i.test(readLog(out)) && /\.(aux|bcf)\b/i.test(readLog(out))) {
+  // The bare word "undefined" and a mention of the .aux are in nearly every
+  // failing log; only an error located in the .aux/.bcf next to one of its own
+  // macros is the stale-artifact case. Otherwise every failing compile would
+  // pay a second full -g build (each invocation is a complete multi-pass run
+  // under -f).
+  const staleAux = (l) => /\.(aux|bcf):\d+:/i.test(l) && /(\\abx@aux@|\\bibcite|\\@writefile)/.test(l);
+  if (code !== 0 && !timedOut && staleAux(readLog(out))) {
     for (const ext of ['aux', 'bcf', 'bbl', 'blg', 'run.xml', 'toc', 'out', 'fls', 'fdb_latexmk']) {
       try { fs.rmSync(path.join(outAbs, `${base}.${ext}`), { force: true }); } catch { /* best effort */ }
     }
@@ -275,9 +296,13 @@ async function compileInner(body) {
   const isFresh = (f) => { try { return fs.statSync(f).mtimeMs >= freshSince; } catch { return false; } };
   const bibLogPath = path.join(outAbs, `${base}.blg`);
   const errors = parseLog(log);
-  // Only this run's .blg: a stale one from before the user fixed the .bib
-  // would report errors that no longer exist.
-  if (isFresh(bibLogPath)) {
+  // This run's .blg, or an older one that latexmk still holds against the
+  // document: latexmk does not re-run bibtex/biber until the .bib changes, and
+  // until then reports "gave an error in previous invocation", whose located
+  // errors are the ones in that older .blg. A stale .blg from a .bib the user
+  // already fixed cannot reach here, because fixing the .bib re-runs the rule.
+  const bibRuleFailed = /\b(bibtex|biber)\b[^\n]*gave an error/i.test(out);
+  if (isFresh(bibLogPath) || bibRuleFailed) {
     try { errors.push(...parseBibLog(fs.readFileSync(bibLogPath, 'utf8'))); } catch { /* unreadable is not an error */ }
   }
   // -file-line-error paths are relative to the compile dir (the root file's
@@ -334,11 +359,11 @@ async function compileInner(body) {
 async function synctex(body) {
   const { projectDir, rootFile = 'main.tex', direction, line, column = 0, page, x, y } = body;
   if (!projectDir || projectDir.includes('..')) throw new Error('invalid projectDir');
-  if (!rootFile || rootFile.includes('..') || path.isAbsolute(rootFile)) throw new Error('invalid rootFile');
+  if (invalidRootFile(rootFile)) throw new Error('invalid rootFile');
   const absDir = path.resolve(DATA_DIR, projectDir);
   if (!absDir.startsWith(path.resolve(DATA_DIR))) throw new Error('projectDir escapes DATA_DIR');
   const rootDir = path.dirname(rootFile);
-  const base = path.basename(rootFile).replace(/\.tex$/, '');
+  const base = path.basename(rootFile).replace(/\.tex$/i, '');
   const pdf = path.join(rootDir, OUT_SUBDIR, `${base}.pdf`);
   let args;
   if (direction === 'forward') {
@@ -400,7 +425,7 @@ const server = http.createServer(async (req, res) => {
 
 // The log parsers are pure and worth testing without a TeX Live image; the
 // server only starts when this file is run directly (the image's CMD).
-module.exports = { parseLog, parseBibLog, latexmkFailure };
+module.exports = { parseLog, parseBibLog, latexmkFailure, invalidRootFile };
 
 if (require.main === module) {
   probeTexLive().finally(() => {

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -196,14 +196,17 @@ export async function synctexLookup(projectId: string, branch: string, payload: 
       return { ok: false, stale: true, error: 'The preview and the typeset output are from different runs — typeset again to jump accurately' };
     }
   }
-  payload = rest;
+  // Only the lookup fields cross to the compiler: projectDir and rootFile are
+  // the server's to set, and a body that carried its own would read another
+  // project's SyncTeX records.
+  const { direction, file, line, column, page, x, y } = rest;
   const res = await fetch(`${config.compilerUrl}/synctex`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       projectDir: relProjectDir(projectId, branch),
       rootFile: meta.rootFile,
-      ...payload,
+      direction, file, line, column, page, x, y,
     }),
   });
   return res.json();

--- a/apps/server/src/detect.ts
+++ b/apps/server/src/detect.ts
@@ -37,8 +37,8 @@ function engineFromProgram(name: string): Engine | null {
 }
 
 /**
- * latexmk's own precedence, reduced: $pdf_mode selects the engine (4 = xelatex,
- * 5 = lualatex, 1 = pdflatex); without it, a $pdflatex command naming xelatex
+ * latexmk's own precedence, reduced: $pdf_mode selects the engine (4 = lualatex,
+ * 5 = xelatex, 1 = pdflatex: latexmk -pdflua sets 4 and -pdfxe sets 5); without it, a $pdflatex command naming xelatex
  * or lualatex (the pre-4.51 idiom); without either, a bare $xelatex or
  * $lualatex assignment is the only remaining hint, and only when it stands
  * alone: an rc that assigns both (the idiom that hands -shell-escape to
@@ -49,8 +49,8 @@ export function engineFromLatexmkrc(text: string): Engine | null {
   const code = text.split('\n').map((l) => l.replace(/#.*$/, '')).join('\n');
   const mode = code.match(/\$pdf_mode\s*=\s*['"]?(\d)/);
   if (mode) {
-    if (mode[1] === '4') return 'xelatex';
-    if (mode[1] === '5') return 'lualatex';
+    if (mode[1] === '4') return 'lualatex';
+    if (mode[1] === '5') return 'xelatex';
     if (mode[1] === '1') return 'pdf';
   }
   const cmd = code.match(/\$pdflatex\s*=\s*['"]\s*(\S+)/);

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -27,7 +27,7 @@ import * as oauth from './oauth.js';
 import * as email from './email.js';
 import { canAccess, isListed, isMember, isOwner, ownerName } from './authz.js';
 import { loginLimiter, registerLimiter, aiLimiter, refLimiter, compileGate, compileLimiter, clientKey } from './ratelimit.js';
-import { safeJoin, isTextFile, importPath, isHiddenPath, overlongPath, pathConflict, seedError, newId, BRANCH_RE } from './util.js';
+import { safeJoin, isTextFile, importPath, isHiddenPath, overlongPath, pathConflict, seedError, newId, BRANCH_RE, invalidRootFile } from './util.js';
 
 type Q = { branch?: string; path?: string; name?: string; force?: string };
 
@@ -572,7 +572,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
         if (trimmed.length > 200) return reply.code(400).send({ error: 'Project name is too long (max 200 characters)' });
         meta.name = trimmed;
       }
-      if (rootFile) meta.rootFile = rootFile;
+      if (rootFile) {
+        const bad = invalidRootFile(rootFile);
+        if (bad) return reply.code(400).send({ error: bad });
+        meta.rootFile = rootFile;
+      }
       if (engine !== undefined) {
         if (!(ENGINES as readonly string[]).includes(engine as string)) {
           return reply.code(400).send({ error: `Unknown engine "${String(engine)}" — use one of ${ENGINES.join(', ')}` });

--- a/apps/server/src/util.ts
+++ b/apps/server/src/util.ts
@@ -39,6 +39,19 @@ export function importPath(entry: string): string | null {
  *  Windows `.GIT/config` and `.git./config` open `.git/config`, and the
  *  initial commit runs git on whatever the seed wrote there. `.gitignore` is
  *  not hidden. */
+/**
+ * Why a value cannot be the project's main document, or null when it can. The
+ * compiler puts this name on latexmk's command line; a segment starting with
+ * "-" would be read as an option there ("-pdflatex=<program>" runs the
+ * program), so it is refused here as well as in the compiler.
+ */
+export function invalidRootFile(rootFile: unknown): string | null {
+  if (typeof rootFile !== 'string' || !rootFile.trim()) return 'Main document cannot be empty';
+  if (rootFile.includes('..') || rootFile.startsWith('/') || rootFile.startsWith('\\')) return 'Main document must be a path inside the project';
+  if (rootFile.split(/[\\/]/).some((seg) => seg.startsWith('-'))) return 'Main document name cannot start with "-"';
+  return null;
+}
+
 export function isHiddenName(seg: string): boolean {
   const s = seg.toLowerCase().replace(/[. ]+$/, '');
   return s === '.git' || s.startsWith('.aldine');

--- a/apps/server/test/detect.test.mjs
+++ b/apps/server/test/detect.test.mjs
@@ -11,21 +11,21 @@ const B = (s) => Buffer.from(s);
 const doc = (preamble = '') => `\\documentclass{article}\n${preamble}\\begin{document}\nHello\n\\end{document}\n`;
 
 // ---- latexmkrc ----
-eq(engineFromLatexmkrc('$pdf_mode = 4;'), 'xelatex', '$pdf_mode 4');
-eq(engineFromLatexmkrc('$pdf_mode = 5;'), 'lualatex', '$pdf_mode 5');
+eq(engineFromLatexmkrc('$pdf_mode = 4;'), 'lualatex', '$pdf_mode 4 is -pdflua');
+eq(engineFromLatexmkrc('$pdf_mode = 5;'), 'xelatex', '$pdf_mode 5 is -pdfxe');
 eq(engineFromLatexmkrc('$pdf_mode = 1;'), 'pdf', '$pdf_mode 1 is an explicit pdflatex');
-eq(engineFromLatexmkrc('$pdf_mode = "4";'), 'xelatex', 'quoted value');
+eq(engineFromLatexmkrc('$pdf_mode = "4";'), 'lualatex', 'quoted value');
 eq(engineFromLatexmkrc("$pdflatex = 'xelatex -synctex=1 %O %S';"), 'xelatex', 'pre-4.51 idiom: $pdflatex names xelatex');
 eq(engineFromLatexmkrc("$pdflatex = 'lualatex %O %S';"), 'lualatex', '$pdflatex names lualatex');
 eq(engineFromLatexmkrc("$pdflatex = '/usr/bin/xelatex %O %S';"), 'xelatex', 'absolute command path');
 eq(engineFromLatexmkrc("$pdflatex = 'pdflatex -shell-escape %O %S';"), null, '$pdflatex naming pdflatex only passes flags: no choice');
 eq(engineFromLatexmkrc("$xelatex = 'xelatex -interaction=nonstopmode %O %S';"), 'xelatex', 'a bare $xelatex assignment is the last hint');
 eq(engineFromLatexmkrc("$lualatex = 'lualatex %O %S';"), 'lualatex', 'a bare $lualatex assignment');
-eq(engineFromLatexmkrc("$pdf_mode = 5;\n$xelatex = 'xelatex %O %S';"), 'lualatex', '$pdf_mode wins over a command assignment');
+eq(engineFromLatexmkrc("$pdf_mode = 4;\n$xelatex = 'xelatex %O %S';"), 'lualatex', '$pdf_mode wins over a command assignment');
 const allThree = "$pdflatex = 'pdflatex -shell-escape %O %S';\n$xelatex = 'xelatex -shell-escape %O %S';\n$lualatex = 'lualatex -shell-escape %O %S';";
 eq(engineFromLatexmkrc(allThree), null, 'flags handed to all three engines choose none');
 eq(engineFromLatexmkrc("$xelatex = 'xelatex %O %S';\n$lualatex = 'lualatex %O %S';"), null, 'both bare assignments together are no hint either');
-eq(engineFromLatexmkrc("$pdf_mode = 4;\n" + allThree), 'xelatex', '$pdf_mode still decides beside all three');
+eq(engineFromLatexmkrc("$pdf_mode = 5;\n" + allThree), 'xelatex', '$pdf_mode still decides beside all three');
 eq(engineFromLatexmkrc("$pdflatex = 'xelatex %O %S';\n$lualatex = 'lualatex %O %S';"), 'xelatex', 'a $pdflatex naming xelatex beats a bare $lualatex');
 eq(engineFromLatexmkrc('# $pdf_mode = 4;\n$bibtex_use = 2;'), null, 'commented-out setting is ignored');
 eq(engineFromLatexmkrc('$bibtex_use = 2;'), null, 'no engine setting at all');
@@ -49,11 +49,11 @@ eq(engineFromSource(doc('\\newcommand{\\pct}{\\%}\\usepackage{fontspec}\n')).eng
 eq(engineFromSource(doc('\\newcommand{\\pct}{\\%} % \\usepackage{fontspec}\n')), null, 'a real comment after an escaped \\% still hides it');
 
 // ---- archive-level precedence ----
-const files = { 'latexmkrc': B('$pdf_mode = 4;'), 'main.tex': B(doc('\\usepackage{luacode}\n')) };
+const files = { 'latexmkrc': B('$pdf_mode = 5;'), 'main.tex': B(doc('\\usepackage{luacode}\n')) };
 eq(detectEngine(files, 'main.tex'), { engine: 'xelatex', reason: 'latexmkrc in the archive' }, 'latexmkrc beats the package sniff');
-eq(detectEngine({ '.latexmkrc': B('$pdf_mode = 5;'), 'main.tex': B(doc()) }, 'main.tex').engine, 'lualatex', 'dotfile spelling');
-eq(detectEngine({ 'paper/latexmkrc': B('$pdf_mode = 4;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'latexmkrc beside a nested root');
-eq(detectEngine({ 'latexmkrc': B('$pdf_mode = 5;'), 'paper/latexmkrc': B('$pdf_mode = 4;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'the latexmkrc beside the root wins over the top-level one');
+eq(detectEngine({ '.latexmkrc': B('$pdf_mode = 4;'), 'main.tex': B(doc()) }, 'main.tex').engine, 'lualatex', 'dotfile spelling');
+eq(detectEngine({ 'paper/latexmkrc': B('$pdf_mode = 5;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'latexmkrc beside a nested root');
+eq(detectEngine({ 'latexmkrc': B('$pdf_mode = 4;'), 'paper/latexmkrc': B('$pdf_mode = 5;'), 'paper/main.tex': B(doc()) }, 'paper/main.tex').engine, 'xelatex', 'the latexmkrc beside the root wins over the top-level one');
 eq(detectEngine({ 'latexmkrc': B('$bibtex_use = 2;'), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'silent latexmkrc falls through to the root');
 eq(detectEngine({ 'latexmkrc': B("$pdflatex = 'pdflatex -synctex=1 %O %S';"), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'a flags-only $pdflatex line does not override a root that needs XeLaTeX');
 eq(detectEngine({ 'latexmkrc': B(allThree), 'main.tex': B(doc('\\usepackage{xepersian}\n')) }, 'main.tex'), { engine: 'xelatex', reason: 'the xepersian package in the main document' }, 'an rc that flags all three engines leaves the root to decide');

--- a/apps/server/test/import-route.test.mjs
+++ b/apps/server/test/import-route.test.mjs
@@ -188,7 +188,7 @@ try {
   eq((await store.readMeta(id)).engine, 'xelatex', 'engine untouched by a name-only patch');
 
   // ---- engine detection on import ----
-  res = await importZip({ 'latexmkrc': '$pdf_mode = 4;\n', 'main.tex': doc });
+  res = await importZip({ 'latexmkrc': '$pdf_mode = 5;\n', 'main.tex': doc });
   eq(res.statusCode, 200, 'latexmkrc archive imports');
   eq(res.json().engine, 'xelatex', 'engine set from latexmkrc');
   eq(res.json().import, { engine: 'xelatex', engineReason: 'latexmkrc in the archive', transcoded: [] }, 'response says why');

--- a/apps/server/test/rootfile-guard.test.mjs
+++ b/apps/server/test/rootfile-guard.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * The main document's name ends up on latexmk's command line. Both guards,
+ * the server's (settings route) and the compiler's, must refuse anything
+ * latexmk could read as an option, and accept the ordinary shapes.
+ */
+import { createRequire } from 'node:module';
+import { check, eq } from './assert.mjs';
+
+const { invalidRootFile: serverGuard } = await import('../src/util.ts');
+const { invalidRootFile: compilerGuard, parseLog } = createRequire(import.meta.url)('../../compiler/server.js');
+
+const accepted = ['main.tex', 'paper/main.tex', 'MAIN.TEX', 'my-paper.tex', 'src/v2-final.tex', 'thesis.ltx'];
+const refused = [
+  '-pdflatex=touch /tmp/x #.tex',
+  '--version',
+  'paper/-main.tex',
+  '-',
+  '../main.tex',
+  'a/../../b.tex',
+  '/etc/main.tex',
+  '',
+];
+
+for (const p of accepted) {
+  eq(serverGuard(p), null, `server accepts ${p}`);
+  eq(compilerGuard(p), false, `compiler accepts ${p}`);
+}
+for (const p of refused) {
+  check(typeof serverGuard(p) === 'string', `server refuses ${JSON.stringify(p)}`);
+  eq(compilerGuard(p), true, `compiler refuses ${JSON.stringify(p)}`);
+}
+check(typeof serverGuard(undefined) === 'string', 'server refuses a missing value');
+eq(compilerGuard(42), true, 'compiler refuses a non-string');
+check(typeof parseLog === 'function', 'the compiler module still exports its parsers');
+
+console.log('rootfile-guard: ok');

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -112,7 +112,7 @@ export default function Editor() {
   // so they neither open on load nor count against the empty state.
   const isUserFile = (f: TreeEntry) => f.type === 'file' && !f.path.split('/').pop()!.startsWith('.');
   const hasFiles = files.some(isUserFile);
-  const hasTex = files.some((f) => f.type === 'file' && f.path.endsWith('.tex'));
+  const hasTex = files.some((f) => f.type === 'file' && /\.tex$/i.test(f.path));
   const hasTexRef = useRef(hasTex);
   hasTexRef.current = hasTex;
 

--- a/e2e/fixtures/import-latexmkrc/latexmkrc
+++ b/e2e/fixtures/import-latexmkrc/latexmkrc
@@ -1,3 +1,3 @@
-# Overleaf-style build settings: $pdf_mode 4 selects XeLaTeX.
-$pdf_mode = 4;
+# Overleaf-style build settings: $pdf_mode 5 selects XeLaTeX (4 is LuaLaTeX).
+$pdf_mode = 5;
 $bibtex_use = 2;

--- a/e2e/tests/27-compiler-settings.spec.ts
+++ b/e2e/tests/27-compiler-settings.spec.ts
@@ -34,7 +34,7 @@ async function importFile(page: import('@playwright/test').Page, file: string, s
 }
 
 test.describe('engine detection on import', () => {
-  test('a latexmkrc with $pdf_mode 4 selects XeLaTeX and the import typesets with it', async ({ page, request }) => {
+  test('a latexmkrc with $pdf_mode 5 selects XeLaTeX and the import typesets with it', async ({ page, request }) => {
     const { dir, file, stem } = zipFixture('import-latexmkrc');
     let id: string | null = null;
     try {


### PR DESCRIPTION
From the September regression review (multi-agent, e52c4a0..main). Fixes the one critical item and four of the high regressions; the rest come in a follow-up.

## Security

- **Argument injection via the main document name (pre-existing, live).** `rootFile` landed bare on latexmk's argv and the guard only refused `..`, empty and absolute. `-pdflatex=<command>` ran the command inside the compiler container, which mounts every project. Unauthenticated with auth off (the default, and the demo). Now refused by the compiler and by `PATCH /api/projects/:id` for any segment starting with `-`, and the compiler passes `./<root>` so the name can never be read as an option. Verified against a local latexmk: the payload gets `400 invalid rootFile`, nothing is executed.
- **SyncTeX body could name another project's directory.** `synctexLookup` spread the client payload after the server-computed `projectDir`/`rootFile`. Only the lookup fields cross now.

## Regressions fixed

- `MAIN.TEX` as main document failed every typeset with no error (compiler stripped `.tex` case-sensitively; root picker did not). Verified locally: typesets to `MAIN.pdf`. `Editor.tsx`'s `hasTex` fixed the same way.
- `$pdf_mode = 4` / `= 5` mapped to xelatex/lualatex; latexmk means lualatex/xelatex (`-pdflua` sets 4, `-pdfxe` sets 5). Unit tests, the import-route test and the e2e fixture pinned the inverted mapping and are corrected.
- Bibliography errors vanished on the typesets after the first: latexmk reports the bibtex/biber rule "gave an error in previous invocation" without re-running it, and the located `.blg` rows were dropped as stale. They are kept whenever latexmk names the rule as failed.
- Nearly every failing compile paid a second full `-g` rebuild: the stale-aux guard matched the bare word `undefined` plus any `.aux` mention. It now needs an error located in the `.aux`/`.bcf` next to one of that file's own macros.

## Checks

- Server and web typecheck; server unit suite 19/19 files including the new `rootfile-guard.test.mjs` (both guards, accepted and refused shapes).
- Not run here: the e2e suite (the latexmkrc import test's fixture and title changed with the mapping).
