### PR TITLE
server: five regressions from the September review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,26 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- Switching the main document and back no longer shows the other document
+  as a clean typeset. The remembered preview URL was keyed on the branch
+  only, so a typeset of an unchanged `main.tex` after a spell on `arxiv.tex`
+  handed back the URL that still named `arxiv.pdf`. The URL now stands only
+  for the PDF the current main document produces. In the same place: with
+  "stop on first error" on, a halted run deletes the PDF, and the preview
+  kept linking it; a previous PDF is offered only while its file exists.
+- Two scans in ZIP import were quadratic on a crafted archive: an upload of
+  unterminated `\usepackage{` runs held the server for ten seconds at 256 KB
+  and without bound at the 40 MB per-file cap, with no login needed on a
+  default install. Both scans are bounded now (190 ms on the same input).
+- A ZIP with more than 20 000 entries is refused up front. ZIP64 support
+  lifted the old 65 535-entry ceiling, and every entry costs a write and a
+  git add whatever its size, so a 60 MB archive of empty entries meant
+  hundreds of thousands of them.
+- A compiler that is slow to answer its first catalog probe no longer
+  empties the venue gallery for the life of the process, and a failed
+  refresh on the server keeps the last list it had instead of an empty one
+  (which made a tile the gallery had just shown fail with "unknown
+  template" on create).
 - A project whose main document is `MAIN.TEX` (any capitalisation but
   `.tex`) typesets again. The root picker accepted it, latexmk wrote
   `MAIN.pdf`, and the compiler looked for `MAIN.TEX.pdf`, so every typeset

--- a/apps/compiler/catalog.js
+++ b/apps/compiler/catalog.js
@@ -77,10 +77,11 @@ function run(cmd, args, timeoutMs = PROBE_TIMEOUT_MS) {
  * kpsewhich prints one line per argument — the resolved path, or empty when the
  * file is not installed — so the answers line up with the queries positionally.
  */
+/** null when kpsewhich itself did not run (missing, killed, timed out): not the same as "nothing installed". */
 async function locate(files) {
   if (!files.length) return {};
   const { ok, out } = await run('kpsewhich', files);
-  if (!ok) return {};
+  if (!ok) return null;
   const lines = out.split('\n');
   const found = {};
   files.forEach((f, i) => {
@@ -175,6 +176,7 @@ async function build() {
   const wanted = [];
   for (const v of VENUES) for (const f of v.files) wanted.push(f);
   const found = await locate(wanted);
+  if (found === null) return { ok: false, generatedAt: new Date().toISOString(), classes: [] };
   const classes = [];
   if (Object.keys(found).length) {
     const pkgs = await packageData();
@@ -200,19 +202,26 @@ async function build() {
 
 let cached = null;
 let inflight = null;
+let failedUntil = 0;
+const RETRY_MS = 30_000;
 
 /**
- * Cached for the life of the process: the TeX installation cannot change under
- * it, and installing a package needs a restart anyway. There is deliberately no
- * refresh switch — the port is unauthenticated, and a caller that could drop the
- * cache could make every request spawn its own kpsewhich and tlmgr sweep.
+ * A good catalog is cached for the life of the process: the TeX installation
+ * cannot change under it, and installing a package needs a restart anyway.
+ * There is deliberately no refresh switch — the port is unauthenticated, and a
+ * caller that could drop the cache could make every request spawn its own
+ * kpsewhich and tlmgr sweep. A probe that did not run (ok:false) is held for
+ * RETRY_MS instead, so a slow first boot does not become an empty gallery for
+ * the life of the process.
  */
 function getCatalog() {
   if (cached) return Promise.resolve(cached);
+  const failed = () => ({ ok: false, generatedAt: new Date().toISOString(), classes: [] });
+  if (Date.now() < failedUntil) return Promise.resolve(failed());
   if (!inflight) {
     inflight = build()
-      .then((c) => { cached = c; inflight = null; return c; })
-      .catch(() => { inflight = null; return { ok: true, generatedAt: new Date().toISOString(), classes: [] }; });
+      .then((c) => { if (c.ok) cached = c; else failedUntil = Date.now() + RETRY_MS; inflight = null; return c; })
+      .catch(() => { failedUntil = Date.now() + RETRY_MS; inflight = null; return failed(); });
   }
   return inflight;
 }

--- a/apps/server/src/catalog.ts
+++ b/apps/server/src/catalog.ts
@@ -176,9 +176,14 @@ let inflight: Promise<CatalogClass[]> | null = null;
 /** Bumped by resetVenueCache so an orphaned fetch cannot write over the new state. */
 let generation = 0;
 
-/** The last catalog the compiler actually answered with, however stale. */
+/**
+ * The last catalog the compiler actually answered with, however stale. A
+ * failed fetch keeps these rows under its short TTL rather than replacing
+ * them with an empty list: a tile the gallery showed a moment ago must not
+ * turn into "unknown template" at create time because the compiler blinked.
+ */
 function lastGoodClasses(): CatalogClass[] {
-  return cache && cache.ttl === CACHE_OK_MS ? cache.classes : [];
+  return cache ? cache.classes : [];
 }
 
 /**
@@ -204,14 +209,19 @@ function fetchClasses(): Promise<CatalogClass[]> {
     try {
       const res = await fetch(`${config.compilerUrl}/catalog`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
       if (!res.ok) throw new Error(`catalog HTTP ${res.status}`);
-      const body = (await res.json()) as { classes?: CatalogClass[] };
+      const body = (await res.json()) as { ok?: boolean; classes?: CatalogClass[] };
+      // ok:false is a probe that did not run (kpsewhich missing or timed out),
+      // not an installation with no classes.
+      if (body.ok === false) throw new Error('catalog probe failed');
       const classes = Array.isArray(body.classes) ? body.classes.filter((c) => c && typeof c.id === 'string' && typeof c.cls === 'string') : [];
       if (gen === generation) cache = { at: Date.now(), ttl: CACHE_OK_MS, classes };
       return classes;
     } catch {
-      // A compiler that is still booting must not poison the cache for long.
-      if (gen === generation) cache = { at: Date.now(), ttl: CACHE_FAIL_MS, classes: [] };
-      return [];
+      // A compiler that is still booting must not poison the cache for long,
+      // and one that answered before keeps its answer on the books meanwhile.
+      const kept = lastGoodClasses();
+      if (gen === generation) cache = { at: Date.now(), ttl: CACHE_FAIL_MS, classes: kept };
+      return kept;
     } finally {
       if (gen === generation) inflight = null;
     }

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { config } from './config.js';
 import { branchDir, readMeta, writeMeta } from './store.js';
@@ -25,6 +26,12 @@ export interface CompileResult {
   error?: string;
 }
 
+/** The PDF the compiler writes for a root, relative to the branch dir (the compiler's `pdf` field). */
+function expectedPdfRel(rootFile: string): string {
+  const base = path.posix.basename(rootFile).replace(/\.tex$/i, '');
+  return path.posix.join(path.posix.dirname(rootFile), '.aldine-out', `${base}.pdf`);
+}
+
 /** projectDir sent to the compiler is relative to the shared data volume root. */
 function relProjectDir(projectId: string, branch: string): string {
   return path.relative(config.dataDir, branchDir(projectId, branch));
@@ -44,7 +51,7 @@ const compileChain = new Map<string, Promise<unknown>>();
  * and misalign SyncTeX with the source. In-memory: after a restart the first
  * failed compile reports no PDF rather than an unknown one.
  */
-const lastGoodPdfUrl = new Map<string, { url: string; compileId: number }>();
+const lastGoodPdfUrl = new Map<string, { url: string; compileId: number; pdf: string }>();
 
 /** compileId of the run whose SyncTeX file is on disk, per project::branch. */
 const lastSynctexId = new Map<string, number>();
@@ -166,10 +173,16 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   // end, so the document is complete and the errors sit in the list beside
   // it. With stopOnFirstError the PDF on disk is truncated at the first error,
   // so only an error-free run is shown and the previous one stays on screen.
-  const previous = lastGoodPdfUrl.get(key) ?? null;
+  // The remembered URL names a PDF path. It stands for this run only when
+  // that path is the one this root produces: switching the main document and
+  // back would otherwise serve the other document as a clean success.
+  const remembered = lastGoodPdfUrl.get(key) ?? null;
+  const expectedPdf = body.pdf ?? expectedPdfRel(meta.rootFile);
+  const previous = remembered && remembered.pdf === expectedPdf ? remembered : null;
+  if (!previous && remembered) lastGoodPdfUrl.delete(key);
   if (body.pdf && pdfFresh && (body.ok || !meta.stopOnFirstError)) {
     const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${compileId}`;
-    lastGoodPdfUrl.set(key, { url: pdfUrl, compileId });
+    lastGoodPdfUrl.set(key, { url: pdfUrl, compileId, pdf: body.pdf });
     return { ...body, pdfUrl, compileId };
   }
   // latexmk found nothing to redo: the PDF on disk is this run's result even
@@ -179,11 +192,16 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   if (body.ok && body.pdf) {
     const id = previous?.compileId ?? compileId;
     const pdfUrl = previous?.url ?? `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${id}`;
-    if (!previous) lastGoodPdfUrl.set(key, { url: pdfUrl, compileId: id });
+    if (!previous) lastGoodPdfUrl.set(key, { url: pdfUrl, compileId: id, pdf: body.pdf });
     if (!lastSynctexId.has(key) && body.synctex) lastSynctexId.set(key, id);
     return { ...body, pdfUrl, compileId: id };
   }
-  return { ...body, pdfUrl: previous?.url ?? null, pdfStale: previous !== null, compileId: previous?.compileId };
+  // No PDF from this run. The previous one is offered only while its file is
+  // still there: a halted run under stopOnFirstError deletes the output, and
+  // a URL to a deleted file is worse than no URL.
+  const kept = previous && fs.existsSync(path.join(branchDir(projectId, branch), previous.pdf)) ? previous : null;
+  if (!kept) lastGoodPdfUrl.delete(key);
+  return { ...body, pdfUrl: kept?.url ?? null, pdfStale: kept !== null, compileId: kept?.compileId };
 }
 
 /** `{ stale: true }` when the caller's preview (compileId) is not the run whose SyncTeX is on disk. */

--- a/apps/server/src/detect.ts
+++ b/apps/server/src/detect.ts
@@ -16,15 +16,30 @@ export interface EngineDetection {
 // person wrote, and the 200 MB archive bound must stay cheap to honour.
 const SNIFF_BYTES = 256 * 1024;
 
-/** \usepackage or \RequirePackage naming any of the packages, outside a comment (an escaped \% opens none). */
-const packageRe = (names: string[]) =>
-  new RegExp(`^(?:[^%\\\\\\n]|\\\\.)*\\\\(?:usepackage|RequirePackage)\\s*(?:\\[[^\\]]*\\]\\s*)?\\{[^}]*\\b(${names.join('|')})\\b[^}]*\\}`, 'm');
+/**
+ * A \usepackage or \RequirePackage call, options and argument bounded. The
+ * text it runs on has had its comments stripped line by line first, so the
+ * regex never has to look behind a match for an unescaped %, and never
+ * rescans: an import made of unterminated \usepackage{ runs (one 256 KB line)
+ * used to hold the event loop for ten seconds.
+ */
+const PACKAGE_CALL_RE = /\\(?:usepackage|RequirePackage)\s*(?:\[[^\]]{0,500}\]\s*)?\{([^}]{0,2000})\}/g;
+/** The line up to its first unescaped %: an escaped \% opens no comment. */
+const CODE_RE = /^(?:[^%\\]|\\.)*/;
+const stripComments = (text: string) => text.split('\n').map((l) => (l.includes('%') ? CODE_RE.exec(l)![0] : l)).join('\n');
+/** The first of `names` that a package call in `text` loads, or null. */
+function packageIn(text: string, names: string[]): string | null {
+  const nameRe = new RegExp(`\\b(${names.join('|')})\\b`);
+  for (const m of stripComments(text).matchAll(PACKAGE_CALL_RE)) {
+    const hit = nameRe.exec(m[1]);
+    if (hit) return hit[1];
+  }
+  return null;
+}
 const LUA_PACKAGES = ['luacode', 'luatexbase', 'luaotfload', 'lualatex-math', 'luatextra', 'luamplib'];
 // fontspec and unicode-math run on both engines; XeLaTeX is the one Overleaf
 // picks for them and the one bidi/xepersian require outright.
 const XE_PACKAGES = ['fontspec', 'unicode-math', 'polyglossia', 'xepersian', 'bidi', 'xeCJK', 'xltxtra', 'xunicode'];
-const LUA_RE = packageRe(LUA_PACKAGES);
-const XE_RE = packageRe(XE_PACKAGES);
 // "% !TEX program = xelatex" (TeXShop/TeXworks/VS Code), "TS-program" is the TeXShop spelling.
 const MAGIC_RE = /^%\s*!\s*TEX\s+(?:TS-)?program\s*=\s*(\w+)/im;
 
@@ -73,10 +88,10 @@ export function engineFromSource(text: string): { engine: Engine; reason: string
     const e = engineFromProgram(magic[1]);
     if (e) return { engine: e, reason: `the "!TEX program" line in the main document` };
   }
-  const lua = text.match(LUA_RE);
-  if (lua) return { engine: 'lualatex', reason: `the ${lua[1]} package in the main document` };
-  const xe = text.match(XE_RE);
-  if (xe) return { engine: 'xelatex', reason: `the ${xe[1]} package in the main document` };
+  const lua = packageIn(text, LUA_PACKAGES);
+  if (lua) return { engine: 'lualatex', reason: `the ${lua} package in the main document` };
+  const xe = packageIn(text, XE_PACKAGES);
+  if (xe) return { engine: 'xelatex', reason: `the ${xe} package in the main document` };
   return null;
 }
 
@@ -110,7 +125,9 @@ const CP1252_C1 = '\u20AC\u0081\u201A\u0192\u201E\u2026\u2020\u2021\u02C6\u2030\
   + '\u0090\u2018\u2019\u201C\u201D\u2022\u2013\u2014\u02DC\u2122\u0161\u203A\u0153\u009D\u017E\u0178';
 const decodeCp1252 = (data: Buffer) => data.toString('latin1').replace(/[\x80-\x9f]/g, (c) => CP1252_C1[c.charCodeAt(0) - 0x80]);
 
-const INPUTENC_RE = /(\\usepackage\s*\[)([^\]]*)(\]\s*\{inputenc\})/g;
+// Options never span a line; unbounded [^\]]* rescanned a whole file per
+// unterminated "\usepackage[" (quadratic, and this runs on every import).
+const INPUTENC_RE = /(\\usepackage\s*\[)([^\]\n]{0,200})(\]\s*\{inputenc\})/g;
 /** inputenc options the transcode understands; each is replaced by utf8 afterwards. */
 const LEGACY_OPTION_RE = /\b(latin1|latin9|ansinew|cp1252|applemac)\b/g;
 // Windows-1252 is a superset of Latin-1 for every printable byte, so a

--- a/apps/server/src/unzip.ts
+++ b/apps/server/src/unzip.ts
@@ -9,6 +9,10 @@ import zlib from 'node:zlib';
  */
 const MAX_ENTRY_BYTES = 40 * 1024 * 1024;   // 40 MB per file
 const MAX_TOTAL_BYTES = 200 * 1024 * 1024;  // 200 MB inflated total
+// Every entry costs a synchronous write and a git add, whatever its size;
+// with ZIP64 the directory can declare millions of empty ones inside the
+// upload limit. A real project has hundreds of files, a large one thousands.
+const MAX_ENTRIES = 20_000;
 
 const SIG_LOCAL = 0x04034b50;
 const SIG_CENTRAL = 0x02014b50;
@@ -125,6 +129,7 @@ export function unzip(buf: Buffer): Record<string, Buffer> {
   let total = 0;
   const { count, offset } = readDirectory(buf);
   const fail = (msg: string) => new ZipError(msg, count);
+  if (count > MAX_ENTRIES) throw fail(`the archive has ${count} entries; the limit is ${MAX_ENTRIES}`);
   let off = offset;
 
   for (let n = 0; n < count; n++) {

--- a/apps/server/test/compile-stale.test.mjs
+++ b/apps/server/test/compile-stale.test.mjs
@@ -40,6 +40,11 @@ const gitops = await import('../src/gitops.ts');
 
 await initDb();
 const meta = await store.createProject('Stale test');
+// The mock compiler writes nothing; a previous PDF is offered only while its
+// file is still on disk, so stage one where the compiler would have put it.
+const pdfOnDisk = path.join(store.branchDir(meta.id, 'main'), '.aldine-out', 'main.pdf');
+fs.mkdirSync(path.dirname(pdfOnDisk), { recursive: true });
+fs.writeFileSync(pdfOnDisk, '%PDF-1.5 placeholder');
 const good = { ok: true, pdf: '.aldine-out/main.pdf', pdfFresh: true, synctex: '.aldine-out/main.synctex.gz', synctexFresh: true, log: 'ok', errors: [], durationMs: 5 };
 // Errors, but TeX ran to the end: the PDF and SyncTeX on disk are this run's.
 const errorsFull = { ok: false, exitCode: 12, pdf: '.aldine-out/main.pdf', pdfFresh: true, synctex: '.aldine-out/main.synctex.gz', synctexFresh: true, log: '! Undefined control sequence.', errors: [{ type: 'error', line: 3, message: 'Undefined control sequence' }], durationMs: 5 };
@@ -124,6 +129,33 @@ try {
   r = await compileProject(meta.id, 'main');
   eq(r.ok, true, 'recovered');
   check(r.pdfUrl !== withErrors, 'a new success mints a new URL');
+  const recovered = r.pdfUrl;
+
+  // Switching the main document: the remembered URL names main.pdf and must
+  // not stand in for other.tex, nor, when switching back, the other way round
+  // (the "nothing to redo" branch used to hand back whatever URL was remembered).
+  meta.rootFile = 'other.tex';
+  await store.writeMeta(meta);
+  queue.push({ ...good, pdf: '.aldine-out/other.pdf', synctex: '.aldine-out/other.synctex.gz' });
+  r = await compileProject(meta.id, 'main');
+  check(r.pdfUrl.includes('other.pdf'), `the other document gets its own URL: ${r.pdfUrl}`);
+  meta.rootFile = 'main.tex';
+  await store.writeMeta(meta);
+  queue.push({ ...good, pdfFresh: false, synctexFresh: false });
+  r = await compileProject(meta.id, 'main');
+  check(r.pdfUrl.includes('main.pdf'), `switching back does not serve the other document: ${r.pdfUrl}`);
+  check(r.pdfUrl !== recovered, 'and it is a fresh URL, not the one remembered from before the switch');
+  eq(r.pdfStale, undefined, 'not stale: the PDF on disk is this root\'s');
+
+  // The previous PDF is gone from disk (a halted run under stop-on-first-error
+  // deletes the output): nothing to show, rather than a URL that 404s.
+  queue.push({ ...good });
+  r = await compileProject(meta.id, 'main');
+  fs.rmSync(pdfOnDisk);
+  queue.push({ ...fatal });
+  r = await compileProject(meta.id, 'main');
+  eq(r.pdfUrl, null, 'no URL to a PDF that no longer exists');
+  eq(r.pdfStale, false, 'and nothing is flagged stale');
 } finally {
   await closeDb();
   mock.close();

--- a/apps/server/test/unzip.test.mjs
+++ b/apps/server/test/unzip.test.mjs
@@ -86,4 +86,17 @@ await throws(() => unzip(buildZip({ 'zeros.bin': { data: Buffer.alloc(41 * 1024 
 files = unzip(buildZip({ 'blob.bin': Buffer.alloc(41 * 1024 * 1024) }));
 eq(files['blob.bin'].length, 41 * 1024 * 1024, 'a stored entry has no per-file cap (bounded by the archive)');
 
+
+// ---- entry-count cap ----
+// Every entry costs a write and a git add; ZIP64 lifted the 65 535 ceiling
+// and a 60 MB upload of empty entries would mean hundreds of thousands.
+{
+  const many = {};
+  for (let i = 0; i < 20_001; i++) many[`f${i}`] = '';
+  await throws(() => unzip(buildZip(many, { zip64: true })), 'has 20001 entries; the limit is 20000', 'an archive over the entry cap is refused before any entry is read');
+  const some = {};
+  for (let i = 0; i < 50; i++) some[`f${i}`] = 'x';
+  eq(Object.keys(unzip(buildZip(some))).length, 50, 'an ordinary archive is unaffected');
+}
+
 console.log('unzip: all checks passed');


### PR DESCRIPTION
Second batch from the September regression review (follows #33).

- **Preview serves the other document after switching main document and back** (reviewer reproduced end-to-end). The per-branch remembered URL now carries its PDF path and stands only for a root that produces that path. Also: with stop-on-first-error, a halted run deletes the PDF and the preview linked a 404; a previous PDF is offered only while its file exists.
- **Two quadratic scans in import detection** (unauthenticated on a default install). Package sniff: comments stripped once per line, then a bounded regex over package calls. inputenc option scan bounded to one line. Reviewer's inputs: 256 KB unterminated `\usepackage{` went from 8.3 s to 190 ms; 240 KB unterminated `\usepackage[` from 7 s to 30 ms.
- **ZIP64 removed the 65 535-entry ceiling.** Archives over 20 000 entries are refused before any entry is read (every entry costs a write and a git add).
- **Venue gallery emptied by a transient compiler blip.** Compiler: a probe that did not run reports `ok:false` and is retried after 30 s instead of being cached as an empty catalog forever. Server: a failed refresh keeps the last good class list instead of replacing it with `[]`.

## Tests

- `compile-stale.test.mjs` gains the main-document switch and the deleted-PDF cases (both failed before the fix, pass after).
- `unzip.test.mjs` gains the entry cap.
- Server unit suite 19/19; server and web typecheck clean.
