### PR TITLE
ci: hosted deploy keeps full TeX Live, refreshes its role, names its target

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -26,7 +26,7 @@ on:
         description: Service to roll
         type: choice
         options: [production, staging]
-        default: production
+        required: true
 
 env:
   # Task-definition family and service share a name per target.
@@ -66,16 +66,29 @@ jobs:
             ${{ steps.ecr.outputs.registry }}/papyr-server:${{ github.sha }}
             ${{ steps.ecr.outputs.registry }}/papyr-server:latest
 
+      # The hosted instance runs all of TeX Live; the Dockerfile's default is
+      # the medium scheme the published images use.
       - name: Build & push compiler
         uses: docker/build-push-action@v6
         with:
           context: apps/compiler
           file: apps/compiler/Dockerfile
           platforms: linux/arm64
+          build-args: TEXLIVE_SCHEME=full
           push: true
           tags: |
             ${{ steps.ecr.outputs.registry }}/papyr-compiler:${{ github.sha }}
             ${{ steps.ecr.outputs.registry }}/papyr-compiler:latest
+
+      # The full TeX Live compiler build runs about an hour under emulation,
+      # which is the OIDC session's lifetime: the roll below failed with an
+      # expired token after the images were already pushed. Assume the role
+      # again so the roll and the wait for stability start with a fresh hour.
+      - name: Refresh AWS credentials for the roll
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Register SHA-pinned task definition & roll the service
         run: |

--- a/.github/workflows/rollback-aws.yml
+++ b/.github/workflows/rollback-aws.yml
@@ -18,7 +18,7 @@ on:
         description: Service to roll back
         type: choice
         options: [production, staging]
-        default: production
+        required: true
 
 env:
   SERVICE: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
@@ -38,12 +38,18 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Roll the service back
+        # The revision is free text; it reaches the script through the
+        # environment, never by interpolation into the script body, and only
+        # digits are accepted.
+        env:
+          REVISION: ${{ inputs.revision }}
         run: |
           set -euo pipefail
           CURRENT=$(aws ecs describe-services --cluster papyr --services "$SERVICE" \
             --query 'services[0].taskDefinition' --output text --region "${{ vars.AWS_REGION }}")
           CUR_REV="${CURRENT##*:}"
-          REV="${{ inputs.revision }}"
+          REV="$REVISION"
+          case "$REV" in *[!0-9]*) echo "revision must be a number, got '$REV'"; exit 1;; esac
           if [ -z "$REV" ]; then REV=$((CUR_REV - 1)); fi
           if [ "$REV" -lt 1 ] || [ "$REV" = "$CUR_REV" ]; then
             echo "Nothing to do (current revision: $CUR_REV, requested: $REV)"; exit 1
@@ -57,6 +63,6 @@ jobs:
             --task-definition "$SERVICE:$REV" --region "${{ vars.AWS_REGION }}"
           aws ecs wait services-stable --cluster papyr --services "$SERVICE" \
             --region "${{ vars.AWS_REGION }}"
-          echo "## Rolled back (${{ inputs.target || 'production' }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Rolled back (${{ inputs.target }})" >> "$GITHUB_STEP_SUMMARY"
           echo "- from: \`$SERVICE:$CUR_REV\` → to: \`$SERVICE:$REV\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- server image: \`$IMG\`" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,13 @@ All notable changes to Aldine are documented here. The format follows
   want your instance indexed.
 
 ### Fixed
+- The hosted deploy (`deploy-aws.yml`) pins the compiler build to full TeX
+  Live now that the Dockerfile defaults to medium, assumes its AWS role
+  again before rolling the service (the hour-long compiler build outlived
+  the first session's token, so the roll failed after the images were
+  pushed), and no longer defaults its target to production; the rollback
+  workflow reads its revision input from the environment and accepts only
+  digits.
 - Switching the main document and back no longer shows the other document
   as a clean typeset. The remembered preview URL was keyed on the branch
   only, so a typeset of an unchanged `main.tex` after a spell on `arxiv.tex`


### PR DESCRIPTION
Follow-up from tonight's staging deploy (run 33941756512), which pushed both images and rolled the service but failed on `aws ecs wait services-stable` with `ExpiredTokenException`, and from the September review's deploy findings.

- **`deploy-aws.yml`**: `build-args: TEXLIVE_SCHEME=full` on the compiler build. Since #32 the Dockerfile defaults to medium for the published images, and this workflow passed nothing, so staging now reports `scheme: medium`. The hosted instance is ours and should stay on full.
- **`deploy-aws.yml`**: a second `configure-aws-credentials` step right before the roll. The full-scheme compiler build under arm64 emulation takes about the OIDC session's one-hour lifetime.
- **`deploy-aws.yml` and `rollback-aws.yml`**: `target` is required with no `production` default (review R13's workflow half; the IAM split is separate and needs Terraform).
- **`rollback-aws.yml`**: `revision` reaches the script through `env:` and is checked to be digits only, instead of `REV="${{ inputs.revision }}"` inside the script body (the finding that lost quorum in the review).

actionlint clean. Not run: an actual deploy from this branch; the next staging dispatch after merge is the test.
