### PR TITLE
changelog: cut 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-09-05
+
 ### Added
 - A theme control in project settings, under Appearance. Dark and light were
   only switchable from the home screen or the command palette, so once you
@@ -694,7 +696,8 @@ First public release. Everything below is new.
   timer, Terraform for a full serverless-ish AWS deployment (deploy/aws).
 - Templates: article, IAC conference paper, beamer, report/thesis.
 
-[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/trahloff/Aldine/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/trahloff/Aldine/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/trahloff/Aldine/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/trahloff/Aldine/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.3.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.0}
     ports:
       - "8080:3000"
     volumes:
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -154,7 +154,7 @@ fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
 - **You are pinned to a version.** The block above says
-  `${ALDINE_VERSION:-0.3.0}`, so a fresh copy installs the current release and
+  `${ALDINE_VERSION:-0.4.0}`, so a fresh copy installs the current release and
   nothing under a running install changes on its own. To upgrade, read the
   [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/server",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
@@ -28,12 +28,12 @@
     "typescript": "^5.8.3"
   },
   "optionalDependencies": {
-    "@sentry/node": "^8.55.0",
-    "pg": "^8.13.1",
-    "ioredis": "^5.4.1",
-    "@hocuspocus/extension-redis": "^2.15.2",
     "@aws-sdk/client-sesv2": "^3.658.0",
-    "nodemailer": "^6.9.15"
+    "@hocuspocus/extension-redis": "^2.15.2",
+    "@sentry/node": "^8.55.0",
+    "ioredis": "^5.4.1",
+    "nodemailer": "^6.9.15",
+    "pg": "^8.13.1"
   },
   "license": "AGPL-3.0-only"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.3.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.0}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.3.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aldine",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aldine",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
@@ -18,7 +18,7 @@
     },
     "apps/server": {
       "name": "@aldine/server",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -46,7 +46,7 @@
     },
     "apps/web": {
       "name": "@aldine/web",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aldine",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Slim, fast, open-source LaTeX collaboration platform",
   "workspaces": [
     "apps/server",


### PR DESCRIPTION
Release commit for 0.4.0. No code changes: the CHANGELOG heading, the version in the three `package.json` files and the lockfile (which still said 0.1.0), and the `${ALDINE_VERSION:-0.4.0}` defaults in `docker-compose.yml` and the README block.

`node scripts/check-release-pins.mjs --tag v0.4.0` passes on this tree. After merge: `git tag v0.4.0 && git push origin v0.4.0` starts the release pipeline, which pauses at promote.
