### PR TITLE
web: five guards against losing work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- The file tree follows what others do. It was a snapshot from page load:
+  a file created, renamed or deleted in another tab, by a collaborator or by
+  the agent API stayed invisible until reload, and a tab that still had a
+  deleted file open wrote it back on its next keystroke. The server now
+  signals every open editor on a branch when its files change on disk (the
+  same channel the review comments use), a tab coming back to the foreground
+  refetches, and an editor whose open file was removed elsewhere moves off it
+  and says so; the collab socket for a deleted file is closed and refuses to
+  reopen it while the deletion is fresh.
+- Uploading a file whose name already exists asks before replacing it; it
+  used to swap the content in place, including the file open in the editor,
+  with typed work unrecoverable.
+- Create in the New project dialog accepts one click: a double-click or a
+  held Enter made two identical projects and opened the second.
+- Deleting a branch that has checkpoints main does not have says how many
+  and names the newest before asking; the question was the same one-liner as
+  for an empty branch, and the delete is permanent.
+- A typeset that finishes after you switched branch is dropped instead of
+  landing its PDF, status and errors on the branch now on screen; and the
+  preview resets on a branch change that arrives through Back/Forward, not
+  only through the branch menu.
+
 ## [0.4.0] — 2026-09-05
 
 ### Added

--- a/apps/server/src/collab.ts
+++ b/apps/server/src/collab.ts
@@ -190,6 +190,10 @@ export const hocuspocus: Hocuspocus = HocuspocusServer.configure({
     if (!parsed) throw new Error(`invalid document name: ${documentName}`);
     const { projectId, branch, filePath } = parsed;
     if (isSignalDoc(filePath)) return document; // ephemeral coordination channel, nothing to load
+    // A client whose socket was closed by evictDoc reconnects at once; while
+    // the tombstone stands, the file is gone on purpose and a fresh empty doc
+    // would let that client's copy write it straight back.
+    if (tombstoned.has(documentName)) throw new Error('file was deleted');
     await ensureWorktree(projectId, branch);
     const text = document.getText(TEXT_KEY);
     if (text.length > 0) return document; // already has state (e.g. synced from a peer node)
@@ -256,12 +260,30 @@ export function evictDoc(projectId: string, branch: string, filePath: string): v
   deleteSnapshot(name); // file deleted/renamed → drop its collab snapshot so a re-create starts clean
   const doc = hocuspocus.documents.get(name) as (Y.Doc & { destroy?: () => void }) | undefined;
   if (doc) {
+    // Clients still on this doc would keep editing a file that no longer
+    // exists and write it back on their next store; drop them first.
+    try { hocuspocus.closeConnections(name); } catch { /* no connections */ }
     hocuspocus.documents.delete(name);
     try { doc.destroy?.(); } catch { /* noop */ }
   }
   // allow a later re-create of the same path to persist again
   setTimeout(() => untombstone(name), 5000);
+  bumpFilesSignal(projectId, branch);
 }
+
+/**
+ * Tell every client on a branch that its file list changed. The tree is a
+ * REST listing; this bumps a shared counter in an ephemeral collab doc (the
+ * same trick the review comments use) so open editors refetch instead of
+ * showing a snapshot from page load. No client on the branch, nothing to do.
+ */
+export const FILES_SIGNAL = '.aldine/files-signal';
+export function bumpFilesSignal(projectId: string, branch: string): void {
+  const doc = hocuspocus.documents.get(docName(projectId, branch, FILES_SIGNAL)) as Y.Doc | undefined;
+  if (!doc) return;
+  try { doc.getMap<number>('signal').set('v', Date.now()); } catch { /* best effort */ }
+}
+
 
 /**
  * Drop every live collab socket on a project, forcing clients to reconnect and
@@ -337,6 +359,7 @@ export function flushBranchDocs(projectId: string, branch: string): number {
  * so connected editors update in place.
  */
 export function refreshBranchDocsFromDisk(projectId: string, branch: string): void {
+  bumpFilesSignal(projectId, branch); // every caller just changed the branch on disk
   bumpContentVersion(projectId, branch); // git just rewrote files under this branch
   hocuspocus.documents.forEach((doc: Y.Doc & { name: string }, name: string) => {
     const parsed = parseDocName(name);

--- a/apps/server/src/gitops.ts
+++ b/apps/server/src/gitops.ts
@@ -26,6 +26,20 @@ export async function createBranch(id: string, name: string, from = 'main'): Pro
   await g.raw(['worktree', 'add', '-b', name, dir, from]);
 }
 
+/**
+ * Checkpoints on `name` that main does not have, newest first message
+ * included: what a delete would throw away. Deleting is `branch -D`, and
+ * nothing in the app can bring a commit back after it.
+ */
+export async function unmergedCommits(id: string, name: string): Promise<{ count: number; newest: string | null }> {
+  if (!BRANCH_RE.test(name) || name.includes('..')) throw new Error('bad branch name');
+  const g = git(repoDir(id));
+  const count = Number((await g.raw(['rev-list', '--count', `main..${name}`])).trim()) || 0;
+  if (!count) return { count: 0, newest: null };
+  const newest = (await g.raw(['log', '-1', '--format=%s', name])).trim() || null;
+  return { count, newest };
+}
+
 export async function deleteBranch(id: string, name: string): Promise<void> {
   if (name === 'main') throw new Error('cannot delete main');
   const g = git(repoDir(id));

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -895,6 +895,18 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       return { ok: true };
     });
 
+  // What deleting a branch would discard, so the client can ask properly.
+  app.get<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/branches/unmerged', async (req, reply) => {
+    const { name } = req.query;
+    if (!name) return reply.code(400).send({ error: 'name required' });
+    if (name === 'main') return { count: 0, newest: null };
+    try {
+      return await gitops.unmergedCommits(req.params.id, name);
+    } catch (err) {
+      return reply.code(404).send({ error: `No such branch: ${(err as Error).message}` });
+    }
+  });
+
   app.delete<{ Params: { id: string }; Querystring: Q }>('/api/projects/:id/branches', async (req, reply) => {
     const { name } = req.query;
     if (!name) return reply.code(400).send({ error: 'name required' });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -142,8 +142,8 @@ export const api = {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.text();
   },
-  writeFile: (id: string, branch: string, path: string, content: string, encoding: 'utf8' | 'base64' = 'utf8') =>
-    req<{ ok: boolean }>(`/api/projects/${id}/file`, { method: 'PUT', body: JSON.stringify({ branch, path, content, encoding }) }),
+  writeFile: (id: string, branch: string, path: string, content: string, encoding: 'utf8' | 'base64' = 'utf8', opts: { createOnly?: boolean } = {}) =>
+    req<{ ok: boolean }>(`/api/projects/${id}/file`, { method: 'PUT', body: JSON.stringify({ branch, path, content, encoding, ...(opts.createOnly ? { createOnly: true } : {}) }) }),
   createFile: (id: string, branch: string, path: string) =>
     req<{ ok: boolean }>(`/api/projects/${id}/file`, { method: 'PUT', body: JSON.stringify({ branch, path, content: '', createOnly: true }) }),
   deleteFile: (id: string, branch: string, path: string) =>
@@ -165,6 +165,8 @@ export const api = {
     req<{ ok: boolean }>(`/api/projects/${id}/branches`, { method: 'POST', body: JSON.stringify({ name, from }) }),
   deleteBranch: (id: string, name: string) =>
     req<{ ok: boolean }>(`/api/projects/${id}/branches?name=${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  unmergedCommits: (id: string, name: string) =>
+    req<{ count: number; newest: string | null }>(`/api/projects/${id}/branches/unmerged?name=${encodeURIComponent(name)}`),
   commit: (id: string, branch: string, message: string, author?: string) =>
     req<{ committed: boolean; hash?: string }>(`/api/projects/${id}/commit`, { method: 'POST', body: JSON.stringify({ branch, message, author }) }),
   log: (id: string, branch: string) => req<LogEntry[]>(`/api/projects/${id}/log?branch=${encodeURIComponent(branch)}`),

--- a/apps/web/src/components/BranchMenu.tsx
+++ b/apps/web/src/components/BranchMenu.tsx
@@ -59,8 +59,23 @@ export default function BranchMenu({ projectId, current, onSwitch, onChanged }: 
   };
 
   const remove = async (n: string) => {
-    if (!window.confirm(`Delete branch ${n}?`)) return;
-    await api.deleteBranch(projectId, n);
+    // Deleting is permanent (git branch -D, no reflog surfaced anywhere), so
+    // the question names what goes with the branch.
+    let question = `Delete branch ${n}?`;
+    try {
+      const { count, newest } = await api.unmergedCommits(projectId, n);
+      if (count > 0) {
+        const newestPart = newest ? ` (newest: "${newest}")` : '';
+        question = `Branch ${n} has ${count} checkpoint${count === 1 ? '' : 's'} that main does not have${newestPart}. Deleting the branch discards ${count === 1 ? 'it' : 'them'} for good. Delete anyway?`;
+      }
+    } catch { /* the plain question still stands */ }
+    if (!window.confirm(question)) return;
+    try {
+      await api.deleteBranch(projectId, n);
+    } catch (err: any) {
+      toast(`Could not delete branch: ${err.message}`, 'error');
+      return;
+    }
     if (current === n) onSwitch('main');
     load();
     onChanged();
@@ -84,7 +99,7 @@ export default function BranchMenu({ projectId, current, onSwitch, onChanged }: 
               {b.name !== 'main' && (
                 <>
                   <button className="btn btn--ghost btn--small" title={`Merge ${b.name} into main`} onClick={() => mergeIntoMain(b.name)} data-testid={`merge-${b.name}`}>⤝ main</button>
-                  <button className="btn btn--ghost btn--small" title={`Delete ${b.name}`} onClick={() => remove(b.name)}>✕</button>
+                  <button className="btn btn--ghost btn--small" style={{ marginLeft: 6 }} title={`Delete ${b.name}`} onClick={() => remove(b.name)} data-testid={`delete-${b.name}`}>✕</button>
                 </>
               )}
             </div>

--- a/apps/web/src/components/FileTree.tsx
+++ b/apps/web/src/components/FileTree.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type JSX } from 'react';
-import { TreeEntry, api } from '../api';
+import { ApiError, TreeEntry, api } from '../api';
 import { fileIcon } from './Icons';
 
 interface Props {
@@ -111,7 +111,17 @@ export default function FileTree({ files, active, rootFile, projectId, branch, o
       const bytes = new Uint8Array(buf);
       const chunk = 0x8000;
       for (let i = 0; i < bytes.length; i += chunk) binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-      await api.writeFile(projectId, branch, f.name, btoa(binary), 'base64');
+      // Never replace a file that exists without asking: the one being
+      // replaced may be open in the editor with unsaved typing in it. The
+      // server answers 409 for createOnly, which also covers a file another
+      // client added since the tree was loaded.
+      try {
+        await api.writeFile(projectId, branch, f.name, btoa(binary), 'base64', { createOnly: true });
+      } catch (err) {
+        if (!(err instanceof ApiError) || err.status !== 409) throw err;
+        if (!window.confirm(`${f.name} already exists in this project. Replace it with the uploaded file?`)) continue;
+        await api.writeFile(projectId, branch, f.name, btoa(binary), 'base64');
+      }
       done.push(f.name);
     }
     if (done.length) onUploaded(done);

--- a/apps/web/src/editor/commentSignal.ts
+++ b/apps/web/src/editor/commentSignal.ts
@@ -10,6 +10,20 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
  * threads appear live without polling.
  */
 export function useCommentSignal(projectId: string, branch: string, onRemoteChange: () => void) {
+  return useSignalDoc(projectId, branch, '.aldine/comments-signal', onRemoteChange);
+}
+
+/**
+ * The file list is a REST listing; the server bumps this doc whenever a
+ * branch's files change on disk (write, upload, rename, delete, pull, merge,
+ * an agent's write), so every open editor refetches instead of showing the
+ * tree it loaded with the page.
+ */
+export function useFilesSignal(projectId: string, branch: string, onRemoteChange: () => void) {
+  return useSignalDoc(projectId, branch, '.aldine/files-signal', onRemoteChange);
+}
+
+function useSignalDoc(projectId: string, branch: string, docPath: string, onRemoteChange: () => void) {
   const bumpRef = useRef<() => void>(() => {});
   const cbRef = useRef(onRemoteChange);
   cbRef.current = onRemoteChange;
@@ -19,7 +33,7 @@ export function useCommentSignal(projectId: string, branch: string, onRemoteChan
     const ydoc = new Y.Doc();
     const provider = new HocuspocusProvider({
       url: `${proto}//${location.host}/collab`,
-      name: `${projectId}::${branch}::.aldine/comments-signal`,
+      name: `${projectId}::${branch}::${docPath}`,
       document: ydoc,
       // With auth enabled the server defines onAuthenticate, so a tokenless
       // provider never completes the handshake and this signal doc never syncs.
@@ -41,7 +55,7 @@ export function useCommentSignal(projectId: string, branch: string, onRemoteChan
       ydoc.destroy();
       bumpRef.current = () => {};
     };
-  }, [projectId, branch]);
+  }, [projectId, branch, docPath]);
 
   return () => bumpRef.current();
 }

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -17,7 +17,7 @@ import { hintFor } from '../editor/errorHints';
 import { IconChevronLeft } from '../components/Icons';
 import CommandPalette, { Command } from '../components/CommandPalette';
 import { invalidateBibCache, invalidateLabelCache } from '../editor/latexExtras';
-import { useCommentSignal } from '../editor/commentSignal';
+import { useCommentSignal, useFilesSignal } from '../editor/commentSignal';
 import GithubSync from '../components/GithubSync';
 import GithubPublish from '../components/GithubPublish';
 import CommentComposer from '../components/CommentComposer';
@@ -105,6 +105,8 @@ export default function Editor() {
   const pdfRef = useRef<PdfPaneHandle>(null);
   const compilingRef = useRef(false);
   const pendingRef = useRef(false);
+  /** The branch on screen, for a typeset that finishes after a switch. */
+  const branchRef = useRef(branch);
   const autoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoRef = useRef(auto);
   autoRef.current = auto;
@@ -186,8 +188,12 @@ export default function Editor() {
     const t0 = Date.now();
     try {
       const result = await api.compile(id, branch);
+      // The user may have switched branch while this ran: the result belongs
+      // to the branch it was asked for, not to whatever is on screen now.
+      if (branchRef.current !== branch) return;
       setCompile({ status: result.ok ? 'ok' : 'error', result, wallMs: Date.now() - t0 });
     } catch (err: any) {
+      if (branchRef.current !== branch) return;
       // A capacity rejection is the server being busy, not a broken document —
       // keep the busy state and retry with backoff instead of showing "Failed".
       if (/too many typesets/i.test(err?.message || '') && attempt < 3) {
@@ -232,8 +238,13 @@ export default function Editor() {
 
   const switchBranch = (name: string) => {
     setParams(name === 'main' ? {} : { branch: name });
-    setCompile({ status: 'idle', result: null });
   };
+  // The branch can also change through the URL (Back/Forward), not only
+  // through switchBranch, and the preview belongs to the old one either way.
+  useEffect(() => {
+    branchRef.current = branch;
+    setCompile({ status: 'idle', result: null });
+  }, [id, branch]);
 
   const saveName = useCallback(async (name: string) => {
     try {
@@ -312,6 +323,29 @@ export default function Editor() {
   useEffect(() => { loadComments(); }, [id, branch]);
   // live-sync: re-fetch when any collaborator changes comments
   const bumpComments = useCommentSignal(id, branch, loadComments);
+  // The file list is a REST snapshot. The server bumps this signal whenever
+  // the branch's files change on disk (another tab, a collaborator, the agent
+  // API, a pull), and a tab coming back to the foreground refetches anyway.
+  useFilesSignal(id, branch, loadFiles);
+  useEffect(() => {
+    const onVisible = () => { if (document.visibilityState === 'visible') loadFiles(); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [loadFiles]);
+  // A file this tab has open can be deleted or renamed elsewhere. Keeping the
+  // editor on it would write it back on the next keystroke; move off it and
+  // say so. This tab's own delete/rename names the path first, so it stays
+  // silent for those.
+  const localRemoval = useRef<string | null>(null);
+  useEffect(() => {
+    if (!filesLoaded || !activeFile || localRemoval.current === activeFile) return;
+    if (files.some((f) => f.path === activeFile)) return;
+    const next = files.find((e) => e.path === project?.rootFile)
+      || files.find((e) => e.type === 'file' && /\.tex$/i.test(e.path))
+      || files.find((e) => isUserFile(e) && !e.binary);
+    setActiveFile(next?.path || null);
+    toast(`${activeFile} was removed from the project by someone else`);
+  }, [files]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // push this file's comment ranges into the editor as highlight decorations
   useEffect(() => {
@@ -632,12 +666,18 @@ export default function Editor() {
                   toast(paths.length === 1 ? `Uploaded ${paths[0]}` : `Uploaded ${paths.length} files`, 'ok');
                 }}
                 onDelete={async (path) => {
-                  await api.deleteFile(id, branch, path);
-                  await loadFiles();
-                  loadProject(); // deleting the root re-derives (or unsets) it
-                  if (activeFile === path) setActiveFile(null);
+                  localRemoval.current = path;
+                  try {
+                    await api.deleteFile(id, branch, path);
+                    await loadFiles();
+                    loadProject(); // deleting the root re-derives (or unsets) it
+                    if (activeFile === path) setActiveFile(null);
+                  } finally {
+                    setTimeout(() => { if (localRemoval.current === path) localRemoval.current = null; }, 0);
+                  }
                 }}
                 onRename={async (from, to) => {
+                  localRemoval.current = from;
                   try {
                     await api.renameFile(id, branch, from, to);
                     await loadFiles();
@@ -645,6 +685,8 @@ export default function Editor() {
                     if (activeFile === from) setActiveFile(to);
                   } catch (err: any) {
                     toast(/already exists/i.test(err?.message) ? `"${to}" already exists` : `Could not rename: ${err.message}`, 'error');
+                  } finally {
+                    setTimeout(() => { if (localRemoval.current === from) localRemoval.current = null; }, 0);
                   }
                 }}
                 onSetRoot={setRootFile}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -85,8 +85,14 @@ export default function Home() {
   const chosen = templates?.find((t) => t.id === effectiveTemplate) ?? null;
   const closeCreate = () => { setCreating(false); setTemplateQuery(''); };
 
+  // One request per click: a venue kit takes seconds to download, and a
+  // double-click or a held Enter used to make two identical projects and
+  // land in the second.
+  const [submitting, setSubmitting] = useState(false);
   const create = async () => {
+    if (submitting) return;
     const name = newName.trim() || 'Untitled Project';
+    setSubmitting(true);
     try {
       const p = await api.createProject(name, undefined, templateToPost(templates ?? [], effectiveTemplate));
       if (p.venueKit && !p.venueKit.ok) {
@@ -95,6 +101,7 @@ export default function Home() {
       navigate(`/p/${p.id}`);
     } catch (err: any) {
       toast(`Could not create project: ${err.message}`, 'error');
+      setSubmitting(false);
     }
   };
 
@@ -401,7 +408,7 @@ export default function Home() {
             )}
             <div className="modal__row">
               <button className="btn" onClick={closeCreate}>Cancel</button>
-              <button className="btn btn--primary" onClick={create} data-testid="create-project">Create</button>
+              <button className="btn btn--primary" onClick={create} disabled={submitting} data-testid="create-project">{submitting ? 'Creating…' : 'Create'}</button>
             </div>
           </div>
         </Modal>

--- a/e2e/tests/31-data-loss-guards.spec.ts
+++ b/e2e/tests/31-data-loss-guards.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../fixtures';
+import { createProject, openProject, cleanup } from './helpers';
+
+/**
+ * Five ways a user lost work or saw the wrong thing, from the September QA
+ * pass: a double-click on Create, an upload over an open file, a file tree
+ * that never learned what another tab did, a branch delete that discarded
+ * checkpoints on a one-line question, and a typeset that landed on the
+ * branch switched to while it ran.
+ */
+test.describe('guards against losing work', () => {
+  test('a double-click on Create makes one project', async ({ page, request }) => {
+    await page.goto('/');
+    await page.getByTestId('new-project').click();
+    await page.getByTestId('new-project-name').fill('Double click');
+    const btn = page.getByTestId('create-project');
+    await btn.dblclick();
+    await page.waitForURL(/\/p\//, { timeout: 30_000 });
+    const id = page.url().split('/p/')[1].split(/[?#]/)[0];
+    try {
+      const res = await request.get('/api/projects');
+      const mine = ((await res.json()) as { id: string; name: string }[]).filter((p) => p.name === 'Double click');
+      expect(mine.length, 'exactly one project named after the dialog').toBe(1);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('uploading over an existing file asks first, and Cancel keeps the original', async ({ page, request }) => {
+    const id = await createProject(request, 'Upload guard');
+    try {
+      await openProject(page, id);
+      const before = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      page.once('dialog', (d) => { expect(d.message()).toContain('main.tex already exists'); d.dismiss(); });
+      await page.getByTestId('upload-input').setInputFiles({ name: 'main.tex', mimeType: 'text/plain', buffer: Buffer.from('REPLACED') });
+      await page.waitForTimeout(800);
+      const after = await (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text();
+      expect(after).toBe(before);
+
+      page.once('dialog', (d) => d.accept());
+      await page.getByTestId('upload-input').setInputFiles({ name: 'main.tex', mimeType: 'text/plain', buffer: Buffer.from('REPLACED') });
+      await expect.poll(async () => (await request.get(`/api/projects/${id}/file?branch=main&path=main.tex`)).text(), { timeout: 10_000 }).toBe('REPLACED');
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+
+  test('a second tab sees files another tab creates and deletes, without reloading', async ({ browser, request }) => {
+    const id = await createProject(request, 'Tree sync');
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const a = await ctxA.newPage();
+      const b = await ctxB.newPage();
+      await openProject(a, id);
+      await openProject(b, id);
+
+      await a.getByTestId('new-file').click();
+      await a.locator('input[placeholder="chapter.tex"]').fill('chapter2.tex');
+      await a.keyboard.press('Enter');
+      await expect(a.getByTestId('file-chapter2.tex')).toBeVisible();
+      await expect(b.getByTestId('file-chapter2.tex'), 'the other tab lists the new file').toBeVisible({ timeout: 10_000 });
+
+      // The agent API path: a write and a delete with no browser involved.
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'main', path: 'from-agent.tex', content: 'x' } });
+      await expect(b.getByTestId('file-from-agent.tex')).toBeVisible({ timeout: 10_000 });
+
+      await b.getByTestId('file-chapter2.tex').click();
+      await expect(b.getByTestId('active-file')).toHaveText('chapter2.tex');
+      await request.delete(`/api/projects/${id}/file?branch=main&path=chapter2.tex`);
+      await expect(b.getByTestId('file-chapter2.tex')).toHaveCount(0, { timeout: 10_000 });
+      await expect(b.getByTestId('active-file'), 'the editor moved off the deleted file').not.toHaveText('chapter2.tex');
+      await b.waitForTimeout(3000);
+      const listing = (await (await request.get(`/api/projects/${id}/files?branch=main`)).json()) as { path: string }[];
+      expect(listing.some((f) => f.path === 'chapter2.tex'), 'the deleted file did not come back').toBe(false);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+      await cleanup(request, id);
+    }
+  });
+
+  test('deleting a branch with unmerged checkpoints names them in the question', async ({ page, request }) => {
+    const id = await createProject(request, 'Branch guard');
+    try {
+      await request.post(`/api/projects/${id}/branches`, { data: { name: 'draft', from: 'main' } });
+      await request.put(`/api/projects/${id}/file`, { data: { branch: 'draft', path: 'notes.tex', content: 'three hours of work' } });
+      await request.post(`/api/projects/${id}/commit`, { data: { branch: 'draft', message: 'Three hours of work' } });
+      const unmerged = await (await request.get(`/api/projects/${id}/branches/unmerged?name=draft`)).json();
+      expect(unmerged.count).toBeGreaterThan(0);
+      expect(unmerged.newest).toBe('Three hours of work');
+
+      await openProject(page, id);
+      await page.getByTestId('branch-menu').click();
+      let question = '';
+      page.once('dialog', (d) => { question = d.message(); d.dismiss(); });
+      await page.getByTestId('delete-draft').click();
+      await expect.poll(() => question).toContain('Three hours of work');
+      expect(question).toMatch(/checkpoint/);
+      const branches = (await (await request.get(`/api/projects/${id}/branches`)).json()) as { name: string }[];
+      expect(branches.some((b) => b.name === 'draft'), 'Cancel kept the branch').toBe(true);
+    } finally {
+      await cleanup(request, id);
+    }
+  });
+});


### PR DESCRIPTION
The five "fix now" items from the UI/UX QA report (B2, B3, B7, B12, B14).

- **Live file tree.** Server bumps `.aldine/files-signal` (ephemeral collab doc, same pattern as the comment signal) from `evictDoc` and `refreshBranchDocsFromDisk`, which every file write, upload, rename, delete, pull, merge and agent write goes through. Editor subscribes via `useFilesSignal`, refetches on `visibilitychange`, and moves off an open file that was removed elsewhere with a toast. `evictDoc` closes the sockets on the deleted doc; `onLoadDocument` refuses a tombstoned doc so a reconnecting client cannot resurrect the file.
- **Upload asks before replacing.** `uploadFiles` sends `createOnly: true`; on the server's 409 it confirms, then writes.
- **One Create per click.** `submitting` state disables the button and the Enter path while the POST runs ("Creating…").
- **Branch delete names what it discards.** New `GET /api/projects/:id/branches/unmerged?name=` (`git rev-list --count main..name` plus the newest subject); the confirm says "Branch x has N checkpoints that main does not have (newest: …)". Delete button gets a test id and a gap from Merge.
- **Typeset result bound to its branch.** `doCompile` drops a result whose branch is no longer on screen; the preview resets on `[id, branch]`, so Back/Forward branch changes clear it too (review R10).

## Tests

- New `e2e/tests/31-data-loss-guards.spec.ts`: double-click Create makes one project; upload over an existing file asks and Cancel keeps the original; a second tab sees a file created in the first and one written by the API, loses a file deleted by the API, and the deleted file does not come back; branch delete confirm names the unmerged checkpoint. 4/4 pass.
- Existing home, collab, branches, subdir-tree and compile suites: 16/16.
- Server unit 19/19, web unit 26/26, both typechecks clean.
