### PR TITLE
changelog: cut 0.4.1; unambiguous digest artifacts per image variant

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -107,9 +107,13 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ steps.slug.outputs.value }}"
+      # The variant sits between two fixed delimiters so the merge job's glob
+      # cannot pick up another variant's files ("digests-compiler-*" matched
+      # "digests-compiler-full-…" and stitched the medium index from all four
+      # manifests; the smoke job caught it, the 0.4.0 tag was burned).
       - uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.VARIANT }}-${{ steps.slug.outputs.value }}
+          name: digests-${{ env.VARIANT }}--${{ steps.slug.outputs.value }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -123,7 +127,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ env.VARIANT }}-*
+          pattern: digests-${{ env.VARIANT }}--*
           merge-multiple: true
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-09-05
+
+0.4.0 was built but never published: its medium compiler image had been
+stitched from the full variant's manifests as well as its own, the release
+smoke test refused it, and version tags are never rewritten. 0.4.1 is the
+first published 0.4 release and carries everything listed under 0.4.0.
+
 ### Fixed
+- The release pipeline's per-architecture digest artifacts are named with a
+  delimiter the variant cannot contain, so a variant's merge step only sees
+  its own manifests.
 - The file tree follows what others do. It was a snapshot from page load:
   a file created, renamed or deleted in another tab, by a collaborator or by
   the agent API stayed invisible until reload, and a tab that still had a
@@ -719,7 +729,8 @@ First public release. Everything below is new.
   timer, Terraform for a full serverless-ish AWS deployment (deploy/aws).
 - Templates: article, IAC conference paper, beamer, report/thesis.
 
-[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/trahloff/Aldine/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/trahloff/Aldine/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/trahloff/Aldine/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/trahloff/Aldine/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.1}
     ports:
       - "8080:3000"
     volumes:
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.1}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -154,7 +154,7 @@ fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
 - **You are pinned to a version.** The block above says
-  `${ALDINE_VERSION:-0.4.0}`, so a fresh copy installs the current release and
+  `${ALDINE_VERSION:-0.4.1}`, so a fresh copy installs the current release and
   nothing under a running install changes on its own. To upgrade, read the
   [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/server",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/web",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.1}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.1}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aldine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aldine",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
@@ -18,7 +18,7 @@
     },
     "apps/server": {
       "name": "@aldine/server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -46,7 +46,7 @@
     },
     "apps/web": {
       "name": "@aldine/web",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aldine",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Slim, fast, open-source LaTeX collaboration platform",
   "workspaces": [
     "apps/server",


### PR DESCRIPTION
The v0.4.0 release run (33956208561) built all images; `smoke (full)` passed and `smoke (medium)` failed with `scheme full, expected medium`. Root cause in `build-image.yml`: the merge job's `pattern: digests-compiler-*` also matched the full variant's `digests-compiler-full-linux-*` artifacts, so `aldine-compiler:0.4.0` was stitched from four manifests. Exactly what the per-variant scheme assertion was there to catch.

- Artifact names become `digests-<variant>--<platform>` and the glob is `digests-<variant>--*`.
- 0.4.0 stays as it is (never promoted, never `latest`); 0.4.1 carries the 0.4.0 notes plus the five QA guards from #37, with a note explaining the skipped number.
- Pins, lockfile, compose default and README block at 0.4.1; `check-release-pins.mjs --tag v0.4.1` passes.

After merge: tag `v0.4.1` on the merge commit.
