### PR TITLE
deploy: isolate the hosted staging from production

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -14,11 +14,15 @@ name: Deploy to AWS
 # Manual trigger only (no surprise deploys/costs on every push). `target`
 # picks the service: production (papyr) or staging (papyr-staging — exists
 # only when Terraform's staging_domain_name is set; dispatch it on a feature
-# branch that github_deploy_branches allows). Requires:
-#   - vars.AWS_DEPLOY_ROLE_ARN : an IAM role trusting GitHub OIDC (see
-#     deploy/aws/github-oidc.tf — needs ECR push, task-def registration,
-#     PassRole for the task roles, and service update)
-#   - vars.AWS_REGION          : e.g. eu-west-1
+# branch that github_deploy_branches allows). Each target has its own IAM
+# role, ECR repositories and service, so a feature branch holding the staging
+# role cannot push a prod image or roll the prod service, whatever it puts in
+# this file. Requires:
+#   - vars.AWS_DEPLOY_ROLE_ARN         : the prod role (deploy/aws/github-oidc.tf;
+#     trusted by main only)
+#   - vars.AWS_STAGING_DEPLOY_ROLE_ARN : the staging role (trusted by main plus
+#     github_deploy_branches)
+#   - vars.AWS_REGION                  : e.g. eu-west-1
 on:
   workflow_dispatch:
     inputs:
@@ -29,8 +33,11 @@ on:
         required: true
 
 env:
-  # Task-definition family and service share a name per target.
+  # Task-definition family, service and ECR repository prefix share a name per
+  # target; the role is the one IAM trusts for that target.
   SERVICE: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
+  IMAGE_PREFIX: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
+  DEPLOY_ROLE_ARN: ${{ inputs.target == 'staging' && vars.AWS_STAGING_DEPLOY_ROLE_ARN || vars.AWS_DEPLOY_ROLE_ARN }}
 
 permissions:
   id-token: write # OIDC
@@ -45,7 +52,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to ECR
@@ -63,8 +70,8 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: |
-            ${{ steps.ecr.outputs.registry }}/papyr-server:${{ github.sha }}
-            ${{ steps.ecr.outputs.registry }}/papyr-server:latest
+            ${{ steps.ecr.outputs.registry }}/${{ env.IMAGE_PREFIX }}-server:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/${{ env.IMAGE_PREFIX }}-server:latest
 
       # The hosted instance runs all of TeX Live; the Dockerfile's default is
       # the medium scheme the published images use.
@@ -77,8 +84,8 @@ jobs:
           build-args: TEXLIVE_SCHEME=full
           push: true
           tags: |
-            ${{ steps.ecr.outputs.registry }}/papyr-compiler:${{ github.sha }}
-            ${{ steps.ecr.outputs.registry }}/papyr-compiler:latest
+            ${{ steps.ecr.outputs.registry }}/${{ env.IMAGE_PREFIX }}-compiler:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/${{ env.IMAGE_PREFIX }}-compiler:latest
 
       # The full TeX Live compiler build runs about an hour under emulation,
       # which is the OIDC session's lifetime: the roll below failed with an
@@ -87,7 +94,7 @@ jobs:
       - name: Refresh AWS credentials for the roll
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Register SHA-pinned task definition & roll the service
@@ -95,10 +102,20 @@ jobs:
           set -euo pipefail
           REG="${{ steps.ecr.outputs.registry }}"
           SHA="${{ github.sha }}"
-          # Current task def → swap both images to the SHA tags → register.
+          # Latest task def in the family → swap both images to the SHA tags →
+          # register. Registration cannot be scoped per family in IAM, so the
+          # staging role could have registered the latest prod revision (with
+          # any env or secret reference): refuse to build a prod deploy on one.
           aws ecs describe-task-definition --task-definition "$SERVICE" \
             --query taskDefinition --region "${{ vars.AWS_REGION }}" > td.json
-          jq --arg s "$REG/papyr-server:$SHA" --arg c "$REG/papyr-compiler:$SHA" '
+          BY=$(jq -r '.registeredBy // ""' td.json)
+          if [ "${{ inputs.target }}" = production ]; then
+            case "$BY" in *papyr-github-deploy-staging*)
+              echo "Refusing: the latest $SERVICE revision was registered by the staging deploy role ($BY)."
+              echo "Register a clean revision with terraform apply, then rerun."; exit 1;;
+            esac
+          fi
+          jq --arg s "$REG/$IMAGE_PREFIX-server:$SHA" --arg c "$REG/$IMAGE_PREFIX-compiler:$SHA" '
             .containerDefinitions |= map(
               if .name == "server" then .image = $s
               elif .name == "compiler" then .image = $c

--- a/.github/workflows/rollback-aws.yml
+++ b/.github/workflows/rollback-aws.yml
@@ -22,6 +22,7 @@ on:
 
 env:
   SERVICE: ${{ inputs.target == 'staging' && 'papyr-staging' || 'papyr' }}
+  DEPLOY_ROLE_ARN: ${{ inputs.target == 'staging' && vars.AWS_STAGING_DEPLOY_ROLE_ARN || vars.AWS_DEPLOY_ROLE_ARN }}
 
 permissions:
   id-token: write # OIDC
@@ -34,7 +35,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Roll the service back

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Security
+- The hosted staging deployment is isolated from production. It had shared
+  the task security group that alone authorises the production filesystem
+  (including the secrets directory), received every production SSM secret,
+  pushed to the ECR repositories production task definitions resolve, and
+  was rolled by the same IAM role a feature branch could assume. Staging now
+  has its own security groups, secrets under `/papyr/staging/`, execution
+  role, repositories and deploy role; feature branches listed in
+  `github_deploy_branches` can reach staging only, and the production deploy
+  refuses to build on a task definition the staging role registered.
+
+### Fixed
+- Staging no longer inherits `ALDINE_SSO_ONLY` from production, so password
+  sign-in works there as documented.
+- The demo box pulls `main` and rebuilds during its nightly wipe instead of
+  running the commit it was provisioned with.
+
 ## [0.4.1] — 2026-09-05
 
 0.4.0 was built but never published: its medium compiler image had been

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -100,21 +100,35 @@ Set `staging_domain_name` (a hostname in the same Route53 zone) and apply:
 ```hcl
 staging_domain_name    = "staging.latex.example.com"
 staging_env            = { ALDINE_MCP = "1" }   # anything you want to try before prod
+staging_secret_env     = { OPENROUTER_API_KEY = "..." }  # staging's own keys; prod's never reach it
 github_deploy_branches = ["my-feature"]         # branches CI may deploy to staging
 ```
 
 That adds a second certificate on the HTTPS listener, a host-header rule to a
 second target group, and a second Fargate Spot service (`papyr-staging`) with
-its own EFS filesystem and log group (`/papyr/staging`). It shares the VPC,
-roles, ECR repositories and SSM secrets with prod — so OAuth sign-in only works
-there if the providers also list the staging callback URL; password sign-in
-always works. Cost is roughly one extra Spot task plus a few GB of EFS.
+its own security groups, EFS filesystem, log group (`/papyr/staging`), ECR
+repositories (`papyr-staging-server`, `papyr-staging-compiler`), SSM secrets
+(`/papyr/staging/*`), execution role and deploy role. It shares only the VPC,
+the load balancer and the cluster with prod. Staging runs whatever a feature
+branch pushes, so nothing it can reach is a prod asset: its tasks are not in
+the security group the prod filesystem admits, its execution role can read
+only its own parameters, and the role a feature branch assumes can push and
+roll staging alone. OAuth sign-in works on staging only with OAuth apps of its
+own in `staging_secret_env`; password sign-in always works (`ALDINE_SSO_ONLY`
+is not inherited). Cost is roughly one extra Spot task plus a few GB of EFS.
 
-Deploy a branch to it from the Actions tab: **Deploy to AWS → branch: my-feature
-→ target: staging**. Roll back the same way with **Rollback AWS deploy →
-target: staging**. Scale the service to 0 in the console to pause it; unset
-`staging_domain_name` and apply to remove it entirely (the EFS filesystem goes
-with it — staging data is disposable by design).
+Set the repository variable `AWS_STAGING_DEPLOY_ROLE_ARN` to the
+`github_staging_deploy_role_arn` output, then deploy a branch from the Actions
+tab: **Deploy to AWS → branch: my-feature → target: staging**. Roll back the
+same way with **Rollback AWS deploy → target: staging**. Scale the service to
+0 in the console to pause it; unset `staging_domain_name` and apply to remove
+it entirely (the EFS filesystem goes with it — staging data is disposable by
+design).
+
+Upgrading a staging that predates the split: the apply moves the service into
+its own security group and registers a task definition on the new repositories
+and role, but the running task keeps the old revision until the next
+**Deploy to AWS → target: staging** run, which also fills the new repositories.
 
 ## Cost (eu-central-1, low traffic, ballpark)
 

--- a/deploy/aws/ecr.tf
+++ b/deploy/aws/ecr.tf
@@ -1,10 +1,18 @@
 locals {
-  ecr_repos = ["papyr-server", "papyr-compiler"]
+  # One repository pair per deployment. Staging (when enabled) gets its own so
+  # a feature-branch push can never overwrite a tag a prod task definition
+  # resolves, and staging churn never evicts the SHA-tagged images older prod
+  # revisions roll back to. `keep` is the lifecycle window: prod revisions are
+  # rollback targets, staging ones are disposable.
+  ecr_repos = merge(
+    { "papyr-server" = { keep = 30 }, "papyr-compiler" = { keep = 30 } },
+    local.staging_enabled ? { "papyr-staging-server" = { keep = 10 }, "papyr-staging-compiler" = { keep = 10 } } : {},
+  )
 }
 
 resource "aws_ecr_repository" "repos" {
-  for_each             = toset(local.ecr_repos)
-  name                 = each.value
+  for_each             = local.ecr_repos
+  name                 = each.key
   image_tag_mutability = "MUTABLE"
   force_delete         = true
 
@@ -36,11 +44,11 @@ resource "aws_ecr_lifecycle_policy" "repos" {
       },
       {
         rulePriority = 2
-        description  = "Keep the last 30 tagged images"
+        description  = "Keep the last ${local.ecr_repos[each.key].keep} tagged images"
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = 30
+          countNumber = local.ecr_repos[each.key].keep
         }
         action = { type = "expire" }
       },

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -34,14 +34,21 @@ locals {
   )
 
   # One container spec for every deployment (prod, and staging when enabled —
-  # see staging.tf), so the two can only differ in image tag, env and log
-  # destination. Anything else that diverges here is a drift bug.
+  # see staging.tf), so the two can only differ in image repositories and tag,
+  # env, secrets and log destination. Anything else that diverges here is a
+  # drift bug. Repositories and secrets are per deployment on purpose: a
+  # staging task must not be able to read a prod secret or run a prod tag.
   deployments = merge(
     {
       prod = {
         image_tag = var.image_tag
         env       = local.server_env
         log_group = aws_cloudwatch_log_group.app.name
+        repos = {
+          server   = aws_ecr_repository.repos["papyr-server"].repository_url
+          compiler = aws_ecr_repository.repos["papyr-compiler"].repository_url
+        }
+        secrets = aws_ssm_parameter.secret
       }
     },
     local.staging_enabled ? {
@@ -49,6 +56,11 @@ locals {
         image_tag = var.staging_image_tag
         env       = local.staging_server_env
         log_group = aws_cloudwatch_log_group.staging[0].name
+        repos = {
+          server   = aws_ecr_repository.repos["papyr-staging-server"].repository_url
+          compiler = aws_ecr_repository.repos["papyr-staging-compiler"].repository_url
+        }
+        secrets = aws_ssm_parameter.staging_secret
       }
     } : {},
   )
@@ -56,7 +68,7 @@ locals {
   container_definitions = { for name, d in local.deployments : name => jsonencode([
     {
       name            = "compiler"
-      image           = "${aws_ecr_repository.repos["papyr-compiler"].repository_url}:${d.image_tag}"
+      image           = "${d.repos.compiler}:${d.image_tag}"
       essential       = true
       linuxParameters = { initProcessEnabled = true } # reap orphaned pdflatex/biber
       environment     = [{ name = "DATA_DIR", value = "/data" }, { name = "PORT", value = "4020" }]
@@ -79,11 +91,11 @@ locals {
     },
     {
       name            = "server"
-      image           = "${aws_ecr_repository.repos["papyr-server"].repository_url}:${d.image_tag}"
+      image           = "${d.repos.server}:${d.image_tag}"
       essential       = true
       linuxParameters = { initProcessEnabled = true } # reap orphaned git children
       environment     = [for k, v in d.env : { name = k, value = tostring(v) }]
-      secrets         = [for k, p in aws_ssm_parameter.secret : { name = k, valueFrom = p.arn }]
+      secrets         = [for k, p in d.secrets : { name = k, valueFrom = p.arn }]
       dependsOn       = [{ containerName = "compiler", condition = "HEALTHY" }]
       # Give the shutdown hook time to flush open Yjs docs + autosave-commit.
       stopTimeout = 120

--- a/deploy/aws/github-oidc.tf
+++ b/deploy/aws/github-oidc.tf
@@ -16,13 +16,31 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 locals {
-  # infra = Terraform (admin) → main only. deploy = image roll → main plus any
-  # branch listed in github_deploy_branches, so a feature branch can ship to
-  # staging from CI. Anyone who can push those branches can roll a service.
+  # infra = Terraform (admin) → main only. deploy = the prod image roll → main
+  # only. deploy_staging = the staging roll → main plus any branch listed in
+  # github_deploy_branches. Each role can push to and roll exactly one
+  # deployment (below), so the widened trust for feature branches never reaches
+  # prod: the workflow picks the role by target, and IAM refuses the other.
   github_roles = { for k, v in {
-    infra  = { repo = var.github_infra_repo, branches = ["main"] }
-    deploy = { repo = var.github_deploy_repo, branches = distinct(concat(["main"], var.github_deploy_branches)) }
+    infra          = { repo = var.github_infra_repo, branches = ["main"] }
+    deploy         = { repo = var.github_deploy_repo, branches = ["main"] }
+    deploy_staging = { repo = local.staging_enabled ? var.github_deploy_repo : "", branches = distinct(concat(["main"], var.github_deploy_branches)) }
   } : k => v if v.repo != "" }
+
+  # What each deploy role may touch: its deployment's repositories, service and
+  # execution role, nothing of the other's.
+  github_deploy_scopes = { for k, v in {
+    deploy = {
+      repos      = [aws_ecr_repository.repos["papyr-server"].arn, aws_ecr_repository.repos["papyr-compiler"].arn]
+      service    = aws_ecs_service.app.id
+      pass_roles = [aws_iam_role.task.arn, aws_iam_role.execution.arn]
+    }
+    deploy_staging = {
+      repos      = local.staging_enabled ? [aws_ecr_repository.repos["papyr-staging-server"].arn, aws_ecr_repository.repos["papyr-staging-compiler"].arn] : []
+      service    = local.staging_enabled ? aws_ecs_service.staging[0].id : ""
+      pass_roles = local.staging_enabled ? [aws_iam_role.task.arn, aws_iam_role.staging_execution[0].arn] : []
+    }
+  } : k => v if contains(keys(local.github_roles), k) }
 }
 
 data "aws_iam_policy_document" "github_assume" {
@@ -67,15 +85,15 @@ resource "aws_iam_role_policy_attachment" "github_infra_admin" {
 }
 
 resource "aws_iam_role" "github_deploy" {
-  count              = var.github_deploy_repo != "" ? 1 : 0
-  name               = "papyr-github-deploy"
-  assume_role_policy = data.aws_iam_policy_document.github_assume["deploy"].json
+  for_each           = local.github_deploy_scopes
+  name               = each.key == "deploy" ? "papyr-github-deploy" : "papyr-github-deploy-staging"
+  assume_role_policy = data.aws_iam_policy_document.github_assume[each.key].json
 }
 
 resource "aws_iam_role_policy" "github_deploy" {
-  count = var.github_deploy_repo != "" ? 1 : 0
-  name  = "image-deploy"
-  role  = aws_iam_role.github_deploy[0].id
+  for_each = local.github_deploy_scopes
+  name     = "image-deploy"
+  role     = aws_iam_role.github_deploy[each.key].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -98,18 +116,20 @@ resource "aws_iam_role_policy" "github_deploy" {
           "ecr:PutImage",
           "ecr:UploadLayerPart",
         ]
-        Resource = [for r in aws_ecr_repository.repos : r.arn]
+        Resource = each.value.repos
       },
       {
         Sid      = "EcsRoll"
         Effect   = "Allow"
         Action   = ["ecs:UpdateService", "ecs:DescribeServices"]
-        Resource = concat([aws_ecs_service.app.id], local.staging_enabled ? [aws_ecs_service.staging[0].id] : [])
+        Resource = [each.value.service]
       },
       {
         # SHA-pinned deploys: CI reads the live task def, swaps the image tags,
         # and registers a new revision (these ECS actions don't support
-        # resource-level scoping).
+        # resource-level scoping, so the staging role can also register
+        # revisions in the prod family; deploy-aws.yml refuses to build on a
+        # revision the staging role registered).
         Sid      = "TaskDefPinning"
         Effect   = "Allow"
         Action   = ["ecs:DescribeTaskDefinition", "ecs:RegisterTaskDefinition"]
@@ -117,13 +137,25 @@ resource "aws_iam_role_policy" "github_deploy" {
       },
       {
         # Registering a task def that references the task/execution roles
-        # requires passing them — scoped to exactly those two, ECS only.
+        # requires passing them — scoped to this deployment's pair, ECS only.
         Sid       = "PassTaskRoles"
         Effect    = "Allow"
         Action    = "iam:PassRole"
-        Resource  = [aws_iam_role.task.arn, aws_iam_role.execution.arn]
+        Resource  = each.value.pass_roles
         Condition = { StringEquals = { "iam:PassedToService" = "ecs-tasks.amazonaws.com" } }
       },
     ]
   })
+}
+
+# The prod deploy role predates the staging one and lived at a count-indexed
+# address; keep its state entry (and the role's name and ARN) across the move.
+moved {
+  from = aws_iam_role.github_deploy[0]
+  to   = aws_iam_role.github_deploy["deploy"]
+}
+
+moved {
+  from = aws_iam_role_policy.github_deploy[0]
+  to   = aws_iam_role_policy.github_deploy["deploy"]
 }

--- a/deploy/aws/outputs.tf
+++ b/deploy/aws/outputs.tf
@@ -32,8 +32,13 @@ output "github_infra_role_arn" {
 }
 
 output "github_deploy_role_arn" {
-  description = "Assume this from the app repo's image-deploy workflow (empty github_deploy_repo → null)."
-  value       = try(aws_iam_role.github_deploy[0].arn, null)
+  description = "Assume this from the app repo's image-deploy workflow for target=production (GitHub variable AWS_DEPLOY_ROLE_ARN; empty github_deploy_repo → null)."
+  value       = try(aws_iam_role.github_deploy["deploy"].arn, null)
+}
+
+output "github_staging_deploy_role_arn" {
+  description = "Assume this for target=staging (GitHub variable AWS_STAGING_DEPLOY_ROLE_ARN; null without staging or github_deploy_repo)."
+  value       = try(aws_iam_role.github_deploy["deploy_staging"].arn, null)
 }
 
 output "staging_url" {

--- a/deploy/aws/ssm.tf
+++ b/deploy/aws/ssm.tf
@@ -3,6 +3,10 @@
 # or logs. Only non-empty entries in var.secret_env are provisioned.
 # The env-var NAMES are not secret (only the values are), so the key set can be
 # de-sensitised for use as for_each keys; values are still pulled sensitively.
+#
+# Staging has its own parameter set under /papyr/staging/ (see staging.tf):
+# nothing from the prod set reaches the staging task unless it is listed in
+# var.staging_secret_env too.
 locals {
   secret_keys = nonsensitive(toset([for k, v in var.secret_env : k if v != ""]))
 }

--- a/deploy/aws/staging.tf
+++ b/deploy/aws/staging.tf
@@ -1,22 +1,115 @@
 # Optional staging deployment on the SAME load balancer, enabled by setting
 # var.staging_domain_name. It gets its own certificate, target group, listener
-# rule, EFS filesystem, log group, task definition and service; it shares the
-# VPC, security groups, ECR repositories, IAM roles and SSM secrets with prod.
+# rule, security groups, EFS filesystem, log group, ECR repositories, SSM
+# secrets, execution role, task definition and service; it shares only the
+# VPC, the ALB, the task role (SES send) and the cluster with prod.
 #
-# The separate filesystem is not optional: collab is single-node and the
+# The separation is the point: staging runs unreviewed feature-branch images,
+# so nothing it can reach may be a prod asset. Its task security group is not
+# papyr-task (membership there is the only thing the prod EFS mount targets
+# check), its execution role can read only /papyr/staging/* parameters, and a
+# feature branch can only assume the staging deploy role (github-oidc.tf).
+#
+# The separate filesystem is also not optional: collab is single-node and the
 # datastore is last-atomic-rename-wins, so two services on one /data would
-# corrupt each other's projects. The shared secrets mean OAuth sign-in fails
-# on staging unless the providers also list the staging callback URLs —
-# password sign-in works regardless.
+# corrupt each other's projects. Staging secrets come from
+# var.staging_secret_env, so OAuth sign-in works there only if you register a
+# staging OAuth app; password sign-in always works because ALDINE_SSO_ONLY is
+# never inherited from prod.
 
 locals {
   staging_enabled = var.staging_domain_name != ""
 
   staging_server_env = merge(
-    local.server_env,
+    { for k, v in local.server_env : k => v if k != "ALDINE_SSO_ONLY" },
     { ALDINE_PUBLIC_URL = "https://${var.staging_domain_name}" },
     var.staging_env,
   )
+
+  staging_secret_keys = nonsensitive(toset([for k, v in var.staging_secret_env : k if v != ""]))
+}
+
+# ---- secrets and the execution role that may read them. A separate role is
+# what keeps a feature-branch task definition from listing a prod parameter:
+# the prod execution role is never passed to a staging task (github-oidc.tf
+# scopes iam:PassRole per deploy role).
+resource "aws_ssm_parameter" "staging_secret" {
+  for_each = local.staging_enabled ? local.staging_secret_keys : toset([])
+  name     = "/papyr/staging/${each.key}"
+  type     = "SecureString"
+  value    = var.staging_secret_env[each.key]
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_iam_role" "staging_execution" {
+  count              = local.staging_enabled ? 1 : 0
+  name               = "papyr-staging-ecs-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "staging_execution_managed" {
+  count      = local.staging_enabled ? 1 : 0
+  role       = aws_iam_role.staging_execution[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "staging_read_secrets" {
+  count = local.staging_enabled && length(local.staging_secret_keys) > 0 ? 1 : 0
+  statement {
+    actions   = ["ssm:GetParameters"]
+    resources = [for p in aws_ssm_parameter.staging_secret : p.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "staging_read_secrets" {
+  count  = local.staging_enabled && length(local.staging_secret_keys) > 0 ? 1 : 0
+  name   = "papyr-staging-read-secrets"
+  role   = aws_iam_role.staging_execution[0].id
+  policy = data.aws_iam_policy_document.staging_read_secrets[0].json
+}
+
+# ---- network: staging's own task and EFS security groups. The prod mount
+# targets admit NFS from papyr-task only, so a staging task in its own group
+# has no route to the prod filesystem, /secrets included.
+resource "aws_security_group" "staging_task" {
+  count       = local.staging_enabled ? 1 : 0
+  name        = "papyr-staging-task"
+  description = "Papyr staging Fargate task"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "App port from ALB only"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = { Name = "papyr-staging-task" }
+}
+
+resource "aws_security_group" "staging_efs" {
+  count       = local.staging_enabled ? 1 : 0
+  name        = "papyr-staging-efs"
+  description = "Papyr staging EFS mount targets"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "NFS from staging tasks"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.staging_task[0].id]
+  }
+  tags = { Name = "papyr-staging-efs" }
 }
 
 # ---- TLS: a second certificate on the HTTPS listener (SNI), so the prod
@@ -138,7 +231,7 @@ resource "aws_efs_mount_target" "staging" {
   count           = local.staging_enabled ? length(aws_subnet.public) : 0
   file_system_id  = aws_efs_file_system.staging[0].id
   subnet_id       = aws_subnet.public[count.index].id
-  security_groups = [aws_security_group.efs.id]
+  security_groups = [aws_security_group.staging_efs[0].id]
 }
 
 # Same uid/gid coupling as efs.tf: both images run as root.
@@ -185,7 +278,7 @@ resource "aws_ecs_task_definition" "staging" {
   network_mode             = "awsvpc"
   cpu                      = var.task_cpu
   memory                   = var.task_memory
-  execution_role_arn       = aws_iam_role.execution.arn
+  execution_role_arn       = aws_iam_role.staging_execution[0].arn
   task_role_arn            = aws_iam_role.task.arn
 
   runtime_platform {
@@ -234,7 +327,7 @@ resource "aws_ecs_service" "staging" {
 
   network_configuration {
     subnets          = aws_subnet.public[*].id
-    security_groups  = [aws_security_group.task.id]
+    security_groups  = [aws_security_group.staging_task[0].id]
     assign_public_ip = true
   }
 

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -112,7 +112,7 @@ variable "github_infra_repo" {
 }
 
 variable "github_deploy_repo" {
-  description = "GitHub repo (owner/name) whose main branch may assume the image-deploy role via OIDC. Empty = don't create GitHub OIDC resources for it."
+  description = "GitHub repo (owner/name) whose main branch may assume the image-deploy roles via OIDC (prod: main only; staging: main plus github_deploy_branches). Empty = don't create GitHub OIDC resources for it."
   type        = string
   default     = ""
 }
@@ -136,8 +136,15 @@ variable "staging_env" {
   default     = {}
 }
 
+variable "staging_secret_env" {
+  description = "Secrets for the staging server, stored under /papyr/staging/ and injected like secret_env. Nothing from secret_env reaches staging; list the entries you want there (with staging OAuth apps and keys of their own)."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
 variable "github_deploy_branches" {
-  description = "Branches of github_deploy_repo allowed to assume the image-deploy role (main is always included). Add a feature branch here to deploy it to staging from CI."
+  description = "Branches of github_deploy_repo allowed to assume the STAGING image-deploy role (main is always included). These branches can push staging images and roll the staging service, nothing in prod."
   type        = list(string)
   default     = []
 }

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -38,6 +38,11 @@ The nightly wipe destroys the data volumes — and with them the showcase projec
 and its id — so either re-seed each morning or disable the wipe timer for launch
 week (`systemctl disable --now aldine-demo-wipe.timer` on the box).
 
+The wipe also pulls `main` and rebuilds the images, so the demo tracks the
+repository without anyone logging in; a box provisioned before this ran a
+fixed commit until someone did. To update a box by hand (or right after a
+fix lands), run the wipe unit: `systemctl start aldine-demo-wipe.service`.
+
 The wipe deliberately keeps `aldine_caddy-data`. Let's Encrypt issues at most 5
 certificates per week for the same hostname, so a wipe that took the certificate
 store with it would put the demo behind an unreachable TLS handshake for hours

--- a/deploy/demo/cloud-init.yaml.tftpl
+++ b/deploy/demo/cloud-init.yaml.tftpl
@@ -15,10 +15,12 @@ write_files:
       ALDINE_COMPILE_PER_MIN=6
       ALDINE_PROTECTED_PROJECTS=${protected_projects}
 
-  # Nightly wipe: destroy the project data and recreate the stack. A demo box
-  # keeps nothing — except Caddy's certificate store: `down -v` would take that
-  # too, and re-issuing nightly burns Let's Encrypt's limit of 5 certificates
-  # per identifier per 168h, which takes the demo offline for hours.
+  # Nightly wipe: pull the current main, destroy the project data and rebuild
+  # the stack, so the demo never runs a fixed commit for months. A failed pull
+  # or build leaves the previous images in place. A demo box keeps nothing —
+  # except Caddy's certificate store: `down -v` would take that too, and
+  # re-issuing nightly burns Let's Encrypt's limit of 5 certificates per
+  # identifier per 168h, which takes the demo offline for hours.
   - path: /etc/systemd/system/aldine-demo-wipe.service
     content: |
       [Unit]
@@ -26,7 +28,7 @@ write_files:
       [Service]
       Type=oneshot
       WorkingDirectory=/opt/aldine/repo
-      ExecStart=/bin/bash -c 'docker compose --env-file /opt/aldine/.env.demo -f docker-compose.full.yml -f deploy/docker-compose.prod.yml --profile tls down && docker volume rm -f aldine_aldine-data aldine_aldine-secrets && docker compose --env-file /opt/aldine/.env.demo -f docker-compose.full.yml -f deploy/docker-compose.prod.yml --profile tls up -d'
+      ExecStart=/bin/bash -c 'git pull --ff-only; docker compose --env-file /opt/aldine/.env.demo -f docker-compose.full.yml -f deploy/docker-compose.prod.yml --profile tls down && docker volume rm -f aldine_aldine-data aldine_aldine-secrets && docker compose --env-file /opt/aldine/.env.demo -f docker-compose.full.yml -f deploy/docker-compose.prod.yml --profile tls up -d --build && docker image prune -f'
   - path: /etc/systemd/system/aldine-demo-wipe.timer
     content: |
       [Unit]


### PR DESCRIPTION
Fixes the six infra findings from the release review (R13 to R18).

**Terraform (`deploy/aws`)**
- Staging gets its own task and EFS security groups. Membership in `papyr-task` was the only thing the prod mount targets checked, so a staging task could reach prod `/data` and `/secrets`.
- Staging secrets move to `/papyr/staging/*`, provisioned from a new `staging_secret_env`. Prod secrets are no longer injected into the staging container. A separate `papyr-staging-ecs-execution` role can read only those.
- Staging images live in `papyr-staging-server` / `papyr-staging-compiler` (keep 10) so a feature-branch push never overwrites `:latest` in the prod repos or evicts prod rollback images.
- The deploy role splits: `papyr-github-deploy` (prod, trusted by `main` only) and `papyr-github-deploy-staging` (trusted by `main` + `github_deploy_branches`), each scoped to its own repos, service and execution role. `moved` blocks keep the prod role's state address.
- `ALDINE_SSO_ONLY` is stripped from the staging env, so password sign-in works there as the docs say.

**Workflows**
- `deploy-aws.yml` / `rollback-aws.yml` pick the role and ECR prefix by `target`. The prod deploy refuses a task-definition revision registered by the staging role (registration can't be scoped per family in IAM).

**Demo**
- The nightly wipe unit runs `git pull --ff-only` and `up --build`, so the box tracks `main`.

**Rollout**
1. Merge, then in `deploy/aws`: `tofu plan` and `apply` with your SSO session. Expect: 2 SGs, 2 ECR repos + lifecycle policies, 1 execution role (+ attachment), 1 IAM role + policy, updated trust/policy on the prod role, staging mount targets and service moved to the new SGs, a new staging task-definition revision. Prod resources should show no changes beyond the deploy role.
2. Add any staging secrets you want to `staging_secret_env` in `terraform.tfvars` before the apply (the staging task loses the prod ones).
3. Repository variable `AWS_STAGING_DEPLOY_ROLE_ARN` is already set to the deterministic ARN.
4. Dispatch **Deploy to AWS → target: staging** once, which fills the new repositories and moves the running task onto the new revision. Until then staging keeps running the old revision, and staging deploys fail at assume-role between merge and apply.

`tofu validate` passes; no plan was run (no AWS session in this environment).
