### PR TITLE
Serve Aldine under a URL prefix (ALDINE_BASE_PATH)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ dist/
 .data-e2e/
 .data-auth/
 .data-base-path/
+.data-remote/
 .data-shots/
 .secrets/
 .secrets-auth/
 .secrets-base-path/
+.secrets-remote/
 .secrets-pb/
 .secrets-shots/
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ dist/
 .data/
 .data-e2e/
 .data-auth/
+.data-base-path/
 .data-shots/
 .secrets/
 .secrets-auth/
+.secrets-base-path/
 .secrets-pb/
 .secrets-shots/
 .cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- Aldine can live under a URL prefix, for hosts that put several apps behind
+  one origin (`https://server/internal/aldine/`). Set `ALDINE_BASE_PATH`, or
+  give `ALDINE_PUBLIC_URL` a path: the app, the API, the collaboration
+  websocket, plugin assets, OAuth callbacks, reset links and share links all
+  follow it, the session cookie is scoped to it, and anything outside the
+  prefix is not served — except the two probes an orchestrator aims at the
+  container itself: `/api/health` and a bare `GET /`, which answers 200 with
+  a pointer to the prefix, so compose healthchecks and load balancers keep
+  working. (#27)
+
 ### Security
 - The hosted staging deployment is isolated from production. It had shared
   the task security group that alone authorises the production filesystem

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ is not `1`, so auth silently stays off.
 ```dotenv
 # app on loopback only; your reverse proxy fronts it
 ALDINE_APP_BIND=127.0.0.1
-# absolute origin used in OAuth callbacks and password-reset links
+# absolute URL of the app, used in OAuth callbacks and password-reset links.
+# Give it a path to serve Aldine under a prefix (https://server/internal/aldine)
 ALDINE_PUBLIC_URL=https://aldine.example.com
 
 # Everything below is optional and off unless set.

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -19,12 +19,16 @@ export function underBasePath(url: string): boolean {
 /**
  * Routes are declared once, at '/api/...', and the base path is peeled off the
  * incoming URL before routing. Requests outside the base path 404 — the rest of
- * the host belongs to whatever else is deployed there — except the health
- * check, which orchestrators poll at the container's own port and root.
+ * the host belongs to whatever else is deployed there — except the two probes
+ * orchestrators aim at the container's own port and root: /api/health, and a
+ * bare GET / (the default health check of most load balancers), which answers
+ * 200 with a one-line pointer to where the app lives.
  */
+export const ROOT_POINTER = '/__base-path-root__';
 export function rewriteUrl(url: string): string {
   if (!BASE) return url;
   if (url === '/api/health') return url;
+  if (url === '/') return ROOT_POINTER;
   if (!underBasePath(url)) return `/__outside-base-path__${url}`;
   const rest = url.slice(BASE.length);
   return rest === '' || rest.startsWith('?') ? `/${rest}` : rest;
@@ -64,6 +68,7 @@ export async function buildApp(): Promise<FastifyInstance> {
 
   await initObservability(app);
   await registerRoutes(app);
+  if (BASE) app.get(ROOT_POINTER, async (_req, reply) => reply.type('text/plain').send(`Aldine is served at ${BASE}/\n`));
 
   // Serve the built frontend (production). In dev, Vite serves it and proxies to us.
   const indexFile = path.join(config.webDist, 'index.html');

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,0 +1,94 @@
+import Fastify, { LogController, type FastifyInstance, type FastifyReply } from 'fastify';
+import fastifyStatic from '@fastify/static';
+import fs from 'node:fs';
+import path from 'node:path';
+import { config } from './config.js';
+import { registerRoutes } from './routes.js';
+import { initObservability } from './observability.js';
+
+const BASE = config.basePath;
+
+/** True when a raw request URL lies under the base path ('' matches everything). */
+export function underBasePath(url: string): boolean {
+  if (!BASE) return true;
+  if (!url.startsWith(BASE)) return false;
+  const next = url.charAt(BASE.length);
+  return next === '' || next === '/' || next === '?';
+}
+
+/**
+ * Routes are declared once, at '/api/...', and the base path is peeled off the
+ * incoming URL before routing. Requests outside the base path 404 — the rest of
+ * the host belongs to whatever else is deployed there — except the health
+ * check, which orchestrators poll at the container's own port and root.
+ */
+export function rewriteUrl(url: string): string {
+  if (!BASE) return url;
+  if (url === '/api/health') return url;
+  if (!underBasePath(url)) return `/__outside-base-path__${url}`;
+  const rest = url.slice(BASE.length);
+  return rest === '' || rest.startsWith('?') ? `/${rest}` : rest;
+}
+
+export function isCollabUpgrade(url: string | undefined): boolean {
+  return !!url && rewriteUrl(url).startsWith('/collab');
+}
+
+/**
+ * The built index.html is served at every app route (/, /p/<id>, …), so its
+ * asset references cannot stay relative to the document: Vite emits them as
+ * `./assets/…` (relative base, so chunks resolve from the loaded script's own
+ * URL) and the server pins them to the base path here. The meta tag is how
+ * the client learns the base path for API and websocket URLs.
+ */
+export function renderIndexHtml(raw: string): string {
+  return raw
+    .replace(/(\s(?:src|href)=")\.\//g, `$1${BASE}/`)
+    .replace('<head>', `<head>\n    <meta name="aldine-base-path" content="${BASE}/" />`);
+}
+
+export async function buildApp(): Promise<FastifyInstance> {
+  // trustProxy makes req.ip honor X-Forwarded-For — enable ONLY behind a trusted
+  // reverse proxy (Caddy/nginx). Off by default so clients can't spoof their IP
+  // to evade rate limits or lock others out.
+  // Info level so operational lines (a failed ZIP import and its reason) reach
+  // the hosted instance's log; per-request access lines stay off because the
+  // load balancer already keeps those. LOG_LEVEL=warn restores the old quiet.
+  const app = Fastify({
+    logger: { level: process.env.LOG_LEVEL || 'info' },
+    logController: new LogController({ disableRequestLogging: true }),
+    bodyLimit: 32 * 1024 * 1024,
+    trustProxy: process.env.TRUST_PROXY === '1',
+    rewriteUrl: (req) => rewriteUrl(req.url || '/'),
+  });
+
+  await initObservability(app);
+  await registerRoutes(app);
+
+  // Serve the built frontend (production). In dev, Vite serves it and proxies to us.
+  const indexFile = path.join(config.webDist, 'index.html');
+  if (fs.existsSync(indexFile)) {
+    const indexHtml = renderIndexHtml(fs.readFileSync(indexFile, 'utf8'));
+    const sendIndex = (_req: unknown, reply: FastifyReply) => reply.type('text/html').send(indexHtml);
+    // The raw index.html never goes on the wire: '/' has its own route, the
+    // static plugin is told not to serve directory indexes or the file itself,
+    // and every other app route lands in the not-found fallback below.
+    app.get('/', sendIndex);
+    await app.register(fastifyStatic, {
+      root: config.webDist,
+      prefix: '/',
+      index: false,
+      allowedPath: (pathname) => pathname !== '/index.html',
+    });
+    app.setNotFoundHandler((req, reply) => {
+      if (/^\/(api|plugins|collab|__outside-base-path__)(\/|$|\?)/.test(req.url)) {
+        return reply.code(404).send({ error: 'not found' });
+      }
+      return sendIndex(req, reply);
+    });
+  } else {
+    app.setNotFoundHandler((req, reply) => reply.code(404).send({ error: 'not found' }));
+  }
+
+  return app;
+}

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { db } from './db/index.js';
 import type { User } from './db/types.js';
+import { config } from './config.js';
 
 /**
  * Optional, env-gated auth (AUTH_ENABLED=1). When off, every request is
@@ -15,6 +16,8 @@ export const AUTH_ENABLED = process.env.AUTH_ENABLED === '1' || process.env.AUTH
 /** SSO-only mode: disable all password endpoints (register/login/reset/change) — sign-in is exclusively via a configured OAuth provider. */
 export const SSO_ONLY = process.env.ALDINE_SSO_ONLY === '1' || process.env.ALDINE_SSO_ONLY === 'true';
 export const COOKIE = 'aldine_session';
+// Scoped to the base path so a neighbouring app on the same host never sees it.
+export const COOKIE_PATH = config.basePath || '/';
 const SESSION_DAYS = 30;
 const RESET_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -159,10 +162,10 @@ function decodeCookieValue(raw: string): string {
   }
 }
 export function sessionCookie(sid: string): string {
-  return `${COOKIE}=${sid}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${SESSION_DAYS * 86400}${SECURE_COOKIES ? '; Secure' : ''}`;
+  return `${COOKIE}=${sid}; HttpOnly; SameSite=Lax; Path=${COOKIE_PATH}; Max-Age=${SESSION_DAYS * 86400}${SECURE_COOKIES ? '; Secure' : ''}`;
 }
 export function clearCookie(): string {
-  return `${COOKIE}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0${SECURE_COOKIES ? '; Secure' : ''}`;
+  return `${COOKIE}=; HttpOnly; SameSite=Lax; Path=${COOKIE_PATH}; Max-Age=0${SECURE_COOKIES ? '; Secure' : ''}`;
 }
 export function sidFromRequest(cookieHeader: string | undefined): string | undefined {
   return parseCookies(cookieHeader)[COOKIE];

--- a/apps/server/src/compile.ts
+++ b/apps/server/src/compile.ts
@@ -181,7 +181,7 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   const previous = remembered && remembered.pdf === expectedPdf ? remembered : null;
   if (!previous && remembered) lastGoodPdfUrl.delete(key);
   if (body.pdf && pdfFresh && (body.ok || !meta.stopOnFirstError)) {
-    const pdfUrl = `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${compileId}`;
+    const pdfUrl = `${config.basePath}/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${compileId}`;
     lastGoodPdfUrl.set(key, { url: pdfUrl, compileId, pdf: body.pdf });
     return { ...body, pdfUrl, compileId };
   }
@@ -191,7 +191,7 @@ async function runCompile(projectId: string, branch: string): Promise<CompileRes
   // calling it stale would flag every typeset of an unchanged document.
   if (body.ok && body.pdf) {
     const id = previous?.compileId ?? compileId;
-    const pdfUrl = previous?.url ?? `/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${id}`;
+    const pdfUrl = previous?.url ?? `${config.basePath}/api/projects/${projectId}/output?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(body.pdf)}&t=${id}`;
     if (!previous) lastGoodPdfUrl.set(key, { url: pdfUrl, compileId: id, pdf: body.pdf });
     if (!lastSynctexId.has(key) && body.synctex) lastSynctexId.set(key, id);
     return { ...body, pdfUrl, compileId: id };

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -5,6 +5,37 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
 
+/**
+ * The URL path Aldine is served under: '' for the root, '/internal/aldine' for
+ * https://host/internal/aldine/. Always without a trailing slash so it can be
+ * prefixed onto '/api/...' paths verbatim. ALDINE_BASE_PATH wins; without it
+ * the path part of ALDINE_PUBLIC_URL applies, so one setting is enough for the
+ * common case.
+ */
+export function normalizeBasePath(basePath: string | undefined, publicUrl: string | undefined): string {
+  let raw = basePath?.trim();
+  if (!raw && publicUrl) {
+    try { raw = new URL(publicUrl).pathname; } catch { raw = ''; }
+  }
+  if (!raw) return '';
+  const trimmed = raw.replace(/\/+$/, '').replace(/^\/*/, '/');
+  if (trimmed === '/') return '';
+  if (/[?#\s]/.test(trimmed)) throw new Error(`ALDINE_BASE_PATH must be a plain URL path, got ${JSON.stringify(raw)}`);
+  return trimmed;
+}
+
+/**
+ * Origin of ALDINE_PUBLIC_URL plus the base path, without a trailing slash —
+ * the trusted prefix for OAuth callbacks and reset links. '' when unset or not
+ * a URL, so callers fall back to request-derived origins or skip the link.
+ */
+export function publicAppUrl(publicUrl: string | undefined, basePath: string): string {
+  if (!publicUrl) return '';
+  try { return `${new URL(publicUrl).origin}${basePath}`; } catch { return ''; }
+}
+
+const basePath = normalizeBasePath(process.env.ALDINE_BASE_PATH, process.env.ALDINE_PUBLIC_URL);
+
 export const config = {
   port: Number(process.env.PORT || 3000),
   /** Root for project git repos: <dataDir>/projects/<id>. Shared with the compiler. */
@@ -27,6 +58,8 @@ export const config = {
    */
   venuesFile: process.env.VENUES_FILE || path.join(repoRoot, 'templates', 'venues.json'),
   webDist: process.env.WEB_DIST || path.join(repoRoot, 'apps/web/dist'),
+  basePath,
+  publicUrl: publicAppUrl(process.env.ALDINE_PUBLIC_URL, basePath),
 };
 
 export const projectsDir = path.join(config.dataDir, 'projects');

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,15 +1,11 @@
-import Fastify, { LogController } from 'fastify';
-import fastifyStatic from '@fastify/static';
 import { WebSocketServer } from 'ws';
-import fs from 'node:fs';
-import path from 'node:path';
 import { config } from './config.js';
-import { registerRoutes } from './routes.js';
+import { buildApp, isCollabUpgrade } from './app.js';
 import { hocuspocus, flushAllDocs, closeProjectConnections } from './collab.js';
 import { initProjectEvents } from './events.js';
 import { commitAll } from './gitops.js';
 import * as store from './store.js';
-import { initObservability, captureError } from './observability.js';
+import { captureError } from './observability.js';
 import { initDb, closeDb } from './db/index.js';
 import { initRateLimit } from './ratelimit.js';
 
@@ -24,39 +20,14 @@ await initRateLimit();
 // our local collab sockets for it so clients re-authenticate. No-op without Redis.
 initProjectEvents({ onAccessChanged: closeProjectConnections });
 
-// trustProxy makes req.ip honor X-Forwarded-For — enable ONLY behind a trusted
-// reverse proxy (Caddy/nginx). Off by default so clients can't spoof their IP
-// to evade rate limits or lock others out.
-// Info level so operational lines (a failed ZIP import and its reason) reach
-// the hosted instance's log; per-request access lines stay off because the
-// load balancer already keeps those. LOG_LEVEL=warn restores the old quiet.
-const app = Fastify({
-  logger: { level: process.env.LOG_LEVEL || 'info' },
-  logController: new LogController({ disableRequestLogging: true }),
-  bodyLimit: 32 * 1024 * 1024,
-  trustProxy: process.env.TRUST_PROXY === '1',
-});
-
-await initObservability(app);
-await registerRoutes(app);
-
-// Serve the built frontend (production). In dev, Vite serves it and proxies to us.
-if (fs.existsSync(path.join(config.webDist, 'index.html'))) {
-  await app.register(fastifyStatic, { root: config.webDist, prefix: '/' });
-  app.setNotFoundHandler((req, reply) => {
-    if (req.url.startsWith('/api') || req.url.startsWith('/plugins') || req.url.startsWith('/collab')) {
-      return reply.code(404).send({ error: 'not found' });
-    }
-    return reply.type('text/html').send(fs.readFileSync(path.join(config.webDist, 'index.html')));
-  });
-}
+const app = await buildApp();
 
 await app.listen({ port: config.port, host: '0.0.0.0' });
 
-// Yjs collaboration over WebSocket at /collab
+// Yjs collaboration over WebSocket at <basePath>/collab
 const wss = new WebSocketServer({ noServer: true });
 app.server.on('upgrade', (request, socket, head) => {
-  if (request.url && request.url.startsWith('/collab')) {
+  if (isCollabUpgrade(request.url)) {
     wss.handleUpgrade(request, socket, head, (ws) => {
       hocuspocus.handleConnection(ws, request);
     });
@@ -65,7 +36,7 @@ app.server.on('upgrade', (request, socket, head) => {
   }
 });
 
-console.log(`[aldine] server on :${config.port} — data=${config.dataDir} compiler=${config.compilerUrl}`);
+console.log(`[aldine] server on :${config.port}${config.basePath} — data=${config.dataDir} compiler=${config.compilerUrl}`);
 
 // Trash purge: hard-delete soft-deleted projects after ALDINE_TRASH_DAYS
 // (default 30). Swept on boot and daily; errors are logged, never fatal.

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -18,6 +18,7 @@ import { fetchBibEntry, searchWorks } from './references.js';
 import { latexWordCount, documentFiles } from './wordcount.js';
 import { unzip, zipEntryCount, ZipError } from './unzip.js';
 import { guessRoot, detectRoot } from './root.js';
+import { config } from './config.js';
 import { detectEngine, decodeText } from './detect.js';
 import { multipartBoundary, parseMultipart } from './multipart.js';
 import { aiConfigured, aiModel, diagnose } from './ai.js';
@@ -56,12 +57,13 @@ function badCredentials(body: { email?: unknown; password?: unknown } | undefine
 function oauthProviders(): Array<{ id: string; label: string }> {
   return oauth.configuredProviders().map((p) => ({ id: p.id, label: p.label }));
 }
-/** Public origin for OAuth redirects — ALDINE_PUBLIC_URL, else derived from the request. */
+/** Public URL of the app root (origin + base path, no trailing slash) for OAuth
+ *  redirects — ALDINE_PUBLIC_URL's origin, else derived from the request. */
 function publicBase(req: FastifyRequest): string {
-  if (process.env.ALDINE_PUBLIC_URL) return process.env.ALDINE_PUBLIC_URL.replace(/\/$/, '');
+  if (config.publicUrl) return config.publicUrl;
   const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'http';
   const host = (req.headers['x-forwarded-host'] as string) || req.headers.host;
-  return `${proto}://${host}`;
+  return `${proto}://${host}${config.basePath}`;
 }
 
 /** Last HEAD we successfully pushed per project — lets auto-sync skip a no-op
@@ -238,7 +240,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       // Build the reset link from the CONFIGURED public URL only — never the
       // request Host/X-Forwarded-Host, which an attacker controls and could use
       // to redirect the victim's valid token to their own domain (takeover).
-      const base = process.env.ALDINE_PUBLIC_URL?.replace(/\/$/, '');
+      const base = config.publicUrl;
       const link = `${base}/?reset_token=${encodeURIComponent(r.token)}`;
       if (email.emailConfigured() && base) {
         // send in the background so the response time doesn't leak whether the
@@ -273,7 +275,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     const provider = auth.AUTH_ENABLED ? oauth.getProvider(req.params.provider) : undefined;
     if (!provider) return reply.code(404).send({ error: 'This sign-in provider is not configured' });
     const state = crypto.randomBytes(12).toString('hex');
-    reply.header('set-cookie', `aldine_oauth_state=${state}; HttpOnly; SameSite=Lax; Path=/; Max-Age=600${auth.SECURE_COOKIES ? '; Secure' : ''}`);
+    reply.header('set-cookie', `aldine_oauth_state=${state}; HttpOnly; SameSite=Lax; Path=${auth.COOKIE_PATH}; Max-Age=600${auth.SECURE_COOKIES ? '; Secure' : ''}`);
     const redirect = `${publicBase(req)}/api/auth/oauth/${provider.id}/callback`;
     return reply.redirect(provider.authorizeUrl(state, redirect));
   });
@@ -289,8 +291,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       try {
         const profile = await provider.exchange(req.query.code, `${publicBase(req)}/api/auth/oauth/${provider.id}/callback`);
         const user = await auth.findOrCreateOAuth(profile.email, profile.name, provider.id);
-        reply.header('set-cookie', [auth.sessionCookie(await auth.createSession(user.id)), 'aldine_oauth_state=; Path=/; Max-Age=0']);
-        return reply.redirect('/');
+        reply.header('set-cookie', [auth.sessionCookie(await auth.createSession(user.id)), `aldine_oauth_state=; Path=${auth.COOKIE_PATH}; Max-Age=0`]);
+        return reply.redirect(`${config.basePath}/`);
       } catch (err: any) {
         return reply.code(400).send({ error: `${provider.label} sign-in failed: ${err.message}` });
       }
@@ -1203,7 +1205,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     if (!github.oauthEnabled()) return reply.code(404).send({ error: 'GitHub OAuth is not configured' });
     if (auth.AUTH_ENABLED && !reqUser(req)) return reply.code(401).send({ error: 'Sign in required' });
     const state = crypto.randomBytes(12).toString('hex');
-    reply.header('set-cookie', `aldine_gh_state=${state}; HttpOnly; SameSite=Lax; Path=/; Max-Age=600${auth.SECURE_COOKIES ? '; Secure' : ''}`);
+    reply.header('set-cookie', `aldine_gh_state=${state}; HttpOnly; SameSite=Lax; Path=${auth.COOKIE_PATH}; Max-Age=600${auth.SECURE_COOKIES ? '; Secure' : ''}`);
     return reply.redirect(github.connectUrl(state, `${publicBase(req)}/api/github/oauth/callback`));
   });
 
@@ -1217,8 +1219,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       const token = await github.exchangeCode(req.query.code, `${publicBase(req)}/api/github/oauth/callback`);
       const me = await github.whoami(token);
       await github.setConnection(ghUserId(req), { token, login: me.login, name: me.name });
-      reply.header('set-cookie', 'aldine_gh_state=; Path=/; Max-Age=0');
-      return reply.redirect('/?github=connected');
+      reply.header('set-cookie', `aldine_gh_state=; Path=${auth.COOKIE_PATH}; Max-Age=0`);
+      return reply.redirect(`${config.basePath}/?github=connected`);
     } catch (err: any) {
       return reply.code(400).send({ error: `GitHub connect failed: ${err.message}` });
     }

--- a/apps/server/test/base-path.test.mjs
+++ b/apps/server/test/base-path.test.mjs
@@ -66,6 +66,7 @@ eq(rewriteUrl('/internal/aldine'), '/', 'bare prefix → root');
 eq(rewriteUrl('/internal/aldine?x=1'), '/?x=1', 'bare prefix keeps its query');
 eq(rewriteUrl('/internal/aldine/api/projects?a=1'), '/api/projects?a=1', 'prefix peeled');
 eq(rewriteUrl('/api/health'), '/api/health', 'root health check passes through');
+eq(rewriteUrl('/'), '/__base-path-root__', 'bare root becomes the pointer');
 check(rewriteUrl('/internal/aldine-other/x').startsWith('/__outside-base-path__/'), 'sibling path is outside');
 check(rewriteUrl('/api/projects').startsWith('/__outside-base-path__/'), 'unprefixed api is outside');
 check(isCollabUpgrade('/internal/aldine/collab?token=x'), 'prefixed collab upgrade accepted');
@@ -97,6 +98,12 @@ res = await get('/internal/aldine/api/health');
 eq(res.statusCode, 200, 'health under the prefix');
 res = await get('/api/health');
 eq(res.statusCode, 200, 'health at the root for container healthchecks');
+res = await get('/');
+eq(res.statusCode, 200, 'bare root answers a load balancer probe');
+check(res.headers['content-type'].startsWith('text/plain'), 'root pointer is plain text');
+check(res.body.includes('/internal/aldine/'), 'root pointer names the base path');
+res = await app.inject({ method: 'HEAD', url: '/' });
+eq(res.statusCode, 200, 'HEAD probe at the root');
 res = await get('/internal/aldine/api/auth/me');
 eq(res.statusCode, 200, 'api under the prefix');
 eq(res.json().authEnabled, false, 'api answers');
@@ -104,7 +111,7 @@ res = await get('/internal/aldine/api/nope');
 eq(res.statusCode, 404, 'unknown api route under the prefix is 404, not the app');
 check(res.headers['content-type'].startsWith('application/json'), 'api 404 is json');
 
-for (const url of ['/', '/other', '/internal', '/internal/aldine-other', '/api/projects', '/assets/index-abc.js', '/index.html']) {
+for (const url of ['/?x=1', '/other', '/internal', '/internal/aldine-other', '/api/projects', '/assets/index-abc.js', '/index.html', '/__base-path-root__']) {
   res = await get(url);
   eq(res.statusCode, 404, `${url} is outside the base path`);
   check(!res.body.includes('aldine-base-path'), `${url} does not leak the app`);

--- a/apps/server/test/base-path.test.mjs
+++ b/apps/server/test/base-path.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Serving under a URL prefix (#27): routes stay declared at '/api/…', the
+ * prefix is peeled off before routing, everything outside it is not ours, and
+ * the served index.html carries the prefix for the client.
+ *
+ * Env must be set before any src import — the base path and the data/meta
+ * roots are read at module load.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { check, eq, throws } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-base-path-'));
+process.env.ALDINE_BASE_PATH = '/internal/aldine';
+delete process.env.ALDINE_PUBLIC_URL;
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'meta');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+process.env.WEB_DIST = path.join(tmp, 'dist');
+delete process.env.AUTH_ENABLED;
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+delete process.env.ALDINE_PROTECTED_PROJECTS;
+
+// A Vite build with base './': asset references relative to index.html.
+fs.mkdirSync(path.join(tmp, 'dist', 'assets'), { recursive: true });
+fs.writeFileSync(path.join(tmp, 'dist', 'index.html'), [
+  '<!doctype html>',
+  '<html lang="en">',
+  '  <head>',
+  '    <title>Aldine</title>',
+  '    <script type="module" crossorigin src="./assets/index-abc.js"></script>',
+  '    <link rel="stylesheet" crossorigin href="./assets/index-abc.css">',
+  '  </head>',
+  '  <body><div id="root"></div></body>',
+  '</html>',
+].join('\n'));
+fs.writeFileSync(path.join(tmp, 'dist', 'assets', 'index-abc.js'), 'console.log("app")');
+
+const { normalizeBasePath, publicAppUrl, config } = await import('../src/config.ts');
+
+eq(publicAppUrl(undefined, '/x'), '', 'no public url → no trusted prefix');
+eq(publicAppUrl('not a url', '/x'), '', 'malformed public url → no trusted prefix, no throw');
+eq(publicAppUrl('https://server/internal/Aldine/', '/internal/Aldine'), 'https://server/internal/Aldine', 'origin + base path');
+eq(publicAppUrl('https://server/ignored', '/b'), 'https://server/b', 'explicit base path wins over the url path');
+eq(config.publicUrl, '', 'no ALDINE_PUBLIC_URL in this test');
+
+eq(normalizeBasePath(undefined, undefined), '', 'unset → root');
+eq(normalizeBasePath('', 'https://aldine.example.com'), '', 'public url without a path → root');
+eq(normalizeBasePath('', 'https://aldine.example.com/'), '', 'public url with a bare slash → root');
+eq(normalizeBasePath(undefined, 'https://server/internal/Aldine/'), '/internal/Aldine', 'path of the public url applies');
+eq(normalizeBasePath('/x/', undefined), '/x', 'trailing slash dropped');
+eq(normalizeBasePath('x', undefined), '/x', 'leading slash added');
+eq(normalizeBasePath('/', 'https://server/y'), '', 'explicit root wins over the public url');
+eq(normalizeBasePath('/a', 'https://server/b'), '/a', 'explicit base path wins over the public url');
+await throws(() => normalizeBasePath('/a b', undefined), 'plain URL path', 'whitespace rejected');
+eq(config.basePath, '/internal/aldine', 'config reads ALDINE_BASE_PATH');
+
+const { initDb } = await import('../src/db/index.ts');
+await initDb();
+const { buildApp, rewriteUrl, isCollabUpgrade, renderIndexHtml } = await import('../src/app.ts');
+const auth = await import('../src/auth.ts');
+
+eq(rewriteUrl('/internal/aldine'), '/', 'bare prefix → root');
+eq(rewriteUrl('/internal/aldine?x=1'), '/?x=1', 'bare prefix keeps its query');
+eq(rewriteUrl('/internal/aldine/api/projects?a=1'), '/api/projects?a=1', 'prefix peeled');
+eq(rewriteUrl('/api/health'), '/api/health', 'root health check passes through');
+check(rewriteUrl('/internal/aldine-other/x').startsWith('/__outside-base-path__/'), 'sibling path is outside');
+check(rewriteUrl('/api/projects').startsWith('/__outside-base-path__/'), 'unprefixed api is outside');
+check(isCollabUpgrade('/internal/aldine/collab?token=x'), 'prefixed collab upgrade accepted');
+check(!isCollabUpgrade('/collab'), 'unprefixed collab upgrade refused');
+check(!isCollabUpgrade(undefined), 'missing url refused');
+
+check(auth.sessionCookie('sid').includes('Path=/internal/aldine;'), 'session cookie scoped to the base path');
+check(auth.clearCookie().includes('Path=/internal/aldine;'), 'cleared cookie uses the same path');
+
+const html = renderIndexHtml(fs.readFileSync(path.join(tmp, 'dist', 'index.html'), 'utf8'));
+check(html.includes('<meta name="aldine-base-path" content="/internal/aldine/" />'), 'base path meta injected');
+check(html.includes('src="/internal/aldine/assets/index-abc.js"'), 'script pinned to the base path');
+check(html.includes('href="/internal/aldine/assets/index-abc.css"'), 'stylesheet pinned to the base path');
+check(!html.includes('"./'), 'no document-relative reference survives');
+
+const app = await buildApp();
+const get = (url) => app.inject({ method: 'GET', url });
+
+for (const url of ['/internal/aldine', '/internal/aldine/', '/internal/aldine/p/abc123', '/internal/aldine/index.html']) {
+  const res = await get(url);
+  eq(res.statusCode, 200, `${url} serves the app`);
+  check(res.headers['content-type'].startsWith('text/html'), `${url} is html`);
+  check(res.body.includes('aldine-base-path'), `${url} is the rendered index`);
+}
+let res = await get('/internal/aldine/assets/index-abc.js');
+eq(res.statusCode, 200, 'asset under the prefix');
+eq(res.body, 'console.log("app")', 'asset body');
+res = await get('/internal/aldine/api/health');
+eq(res.statusCode, 200, 'health under the prefix');
+res = await get('/api/health');
+eq(res.statusCode, 200, 'health at the root for container healthchecks');
+res = await get('/internal/aldine/api/auth/me');
+eq(res.statusCode, 200, 'api under the prefix');
+eq(res.json().authEnabled, false, 'api answers');
+res = await get('/internal/aldine/api/nope');
+eq(res.statusCode, 404, 'unknown api route under the prefix is 404, not the app');
+check(res.headers['content-type'].startsWith('application/json'), 'api 404 is json');
+
+for (const url of ['/', '/other', '/internal', '/internal/aldine-other', '/api/projects', '/assets/index-abc.js', '/index.html']) {
+  res = await get(url);
+  eq(res.statusCode, 404, `${url} is outside the base path`);
+  check(!res.body.includes('aldine-base-path'), `${url} does not leak the app`);
+}
+
+await app.close();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('base-path: ok');

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,3 +1,5 @@
+import { withBase } from './basePath';
+
 export interface AuthUser { id: string; email: string; name: string; provider?: string }
 export interface OAuthProviderInfo { id: string; label: string }
 export interface ProjectSummary {
@@ -66,7 +68,7 @@ export class ApiError extends Error {
 }
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
+  const res = await fetch(withBase(url), {
     headers: init?.body && !(init.body instanceof FormData) ? { 'content-type': 'application/json' } : undefined,
     ...init,
   });
@@ -138,7 +140,7 @@ export const api = {
 
   listFiles: (id: string, branch: string) => req<TreeEntry[]>(`/api/projects/${id}/files?branch=${encodeURIComponent(branch)}`),
   readFile: async (id: string, branch: string, path: string) => {
-    const res = await fetch(`/api/projects/${id}/file?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(path)}`);
+    const res = await fetch(withBase(`/api/projects/${id}/file?branch=${encodeURIComponent(branch)}&path=${encodeURIComponent(path)}`));
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.text();
   },
@@ -183,7 +185,7 @@ export const api = {
   githubPush: (id: string, message?: string, auto?: boolean) => req<{ ok: boolean }>(`/api/projects/${id}/github/push`, { method: 'POST', body: JSON.stringify({ message, auto }) }),
   // conflict-aware: returns { conflict, conflicts } on a 409 instead of throwing
   githubPull: async (id: string): Promise<{ ok?: boolean; conflict?: boolean; conflicts?: string[] }> => {
-    const res = await fetch(`/api/projects/${id}/github/pull`, { method: 'POST' });
+    const res = await fetch(withBase(`/api/projects/${id}/github/pull`), { method: 'POST' });
     const body = await res.json().catch(() => ({}));
     if (res.status === 409) return { conflict: true, conflicts: body.conflicts || [] };
     if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);

--- a/apps/web/src/basePath.ts
+++ b/apps/web/src/basePath.ts
@@ -1,0 +1,26 @@
+/**
+ * The URL path this instance is served under ('' at the root,
+ * '/internal/aldine' for https://host/internal/aldine/). The server stamps it
+ * into index.html; the Vite dev server has no tag, so it is ''. Every
+ * root-relative URL the app builds — API, websocket, plugin assets, share
+ * links — goes through withBase() so the same build works at any depth.
+ */
+function readBasePath(): string {
+  if (typeof document === 'undefined') return '';
+  const meta = document.querySelector('meta[name="aldine-base-path"]') as HTMLMetaElement | null;
+  const raw = (meta?.content || '').trim().replace(/\/+$/, '');
+  return raw && raw !== '/' ? raw : '';
+}
+
+export const BASE_PATH: string = readBasePath();
+
+/** Prefix a root-relative path ('/api/…') with the base path. */
+export function withBase(path: string): string {
+  return `${BASE_PATH}${path}`;
+}
+
+/** Websocket URL for a root-relative path, on this page's host and scheme. */
+export function wsUrl(path: string): string {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${location.host}${withBase(path)}`;
+}

--- a/apps/web/src/components/Auth.tsx
+++ b/apps/web/src/components/Auth.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, type JSX } from 'react';
+import { withBase } from '../basePath';
 import { api, AuthUser, OAuthProviderInfo } from '../api';
 
 interface AuthState {
@@ -121,7 +122,7 @@ function LoginScreen({ providers, passwordAuth, onAuthed }: { providers: OAuthPr
         <p className="home__tag" style={{ marginBottom: 18 }}>{title}</p>
 
         {providers.map((p) => (
-          <a key={p.id} className="btn login__oauth" href={`/api/auth/oauth/${p.id}`} data-testid={`oauth-${p.id}`}>
+          <a key={p.id} className="btn login__oauth" href={withBase(`/api/auth/oauth/${p.id}`)} data-testid={`oauth-${p.id}`}>
             {PROVIDER_ICON[p.id]}
             Continue with {p.label}
           </a>

--- a/apps/web/src/components/CodePane.tsx
+++ b/apps/web/src/components/CodePane.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { wsUrl } from '../basePath';
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection, rectangularSelection, highlightSpecialChars, Decoration, DecorationSet } from '@codemirror/view';
 import { EditorState, StateField, StateEffect, Compartment } from '@codemirror/state';
 import { indentOnInput, bracketMatching, foldGutter, syntaxHighlighting, defaultHighlightStyle, HighlightStyle } from '@codemirror/language';
@@ -222,10 +223,9 @@ const CodePane = forwardRef<CodePaneHandle, Props>(function CodePane({ projectId
     let statsTimer: ReturnType<typeof setTimeout> | null = null;
     warmBib(projectId, branch); // so \cite hover tooltips have data immediately
     const docName = `${projectId}::${branch}::${filePath}`;
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const ydoc = new Y.Doc();
     const provider = new HocuspocusProvider({
-      url: `${proto}//${location.host}/collab`,
+      url: wsUrl('/collab'),
       name: docName,
       document: ydoc,
       // When auth is enabled the server defines onAuthenticate, which makes

--- a/apps/web/src/components/GithubImport.tsx
+++ b/apps/web/src/components/GithubImport.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { withBase } from '../basePath';
 import { api, GithubRepo, GithubStatus } from '../api';
 import { useToast } from './Toast';
 import { friendlyDate } from '../util/dates';
@@ -56,7 +57,7 @@ export default function GithubImport({ onClose, onImported }: { onClose(): void;
             <p className="modal__sub" style={{ marginBottom: 14 }}>Connect your GitHub account to browse and import repositories.</p>
             {status.oauth && (
               <>
-                <a className="btn login__oauth" href="/api/github/oauth" data-testid="github-connect-oauth">{GH_ICON} Connect with GitHub</a>
+                <a className="btn login__oauth" href={withBase('/api/github/oauth')} data-testid="github-connect-oauth">{GH_ICON} Connect with GitHub</a>
                 <div className="login__or">or use a token</div>
               </>
             )}

--- a/apps/web/src/components/GithubPublish.tsx
+++ b/apps/web/src/components/GithubPublish.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { withBase } from '../basePath';
 import { api, GithubStatus } from '../api';
 import { useToast } from './Toast';
 import Modal from './Modal';
@@ -57,7 +58,7 @@ export default function GithubPublish({ projectId, projectName, onClose, onLinke
           <div style={{ marginTop: 4 }}>
             {status.oauth && (
               <>
-                <a className="btn login__oauth" href="/api/github/oauth" data-testid="github-connect-oauth">{GH_ICON} Connect with GitHub</a>
+                <a className="btn login__oauth" href={withBase('/api/github/oauth')} data-testid="github-connect-oauth">{GH_ICON} Connect with GitHub</a>
                 <div className="login__or">or use a token</div>
               </>
             )}

--- a/apps/web/src/components/ShareModal.tsx
+++ b/apps/web/src/components/ShareModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { withBase } from '../basePath';
 import { api, ProjectSummary } from '../api';
 import { useToast } from './Toast';
 import Modal from './Modal';
@@ -18,7 +19,7 @@ export default function ShareModal({ project, onClose, onSaved }: {
   const [emails, setEmails] = useState((project.share?.collaborators || []).join(', '));
   const [busy, setBusy] = useState(false);
   const toast = useToast();
-  const shareUrl = `${location.origin}/p/${project.id}`;
+  const shareUrl = `${location.origin}${withBase(`/p/${project.id}`)}`;
 
   const copyLink = async () => {
     try {

--- a/apps/web/src/editor/commentSignal.ts
+++ b/apps/web/src/editor/commentSignal.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { wsUrl } from '../basePath';
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 
@@ -29,10 +30,9 @@ function useSignalDoc(projectId: string, branch: string, docPath: string, onRemo
   cbRef.current = onRemoteChange;
 
   useEffect(() => {
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const ydoc = new Y.Doc();
     const provider = new HocuspocusProvider({
-      url: `${proto}//${location.host}/collab`,
+      url: wsUrl('/collab'),
       name: `${projectId}::${branch}::${docPath}`,
       document: ydoc,
       // With auth enabled the server defines onAuthenticate, so a tokenless

--- a/apps/web/src/editor/visual/context.ts
+++ b/apps/web/src/editor/visual/context.ts
@@ -1,4 +1,5 @@
 import { api, BibEntry } from '../../api';
+import { withBase } from '../../basePath';
 import { pokeViews } from './refresh';
 
 /**
@@ -59,11 +60,11 @@ function joinPath(dir: string, p: string): string {
  */
 export function fileUrl(path: string): string | null {
   if (!ctx) return null;
-  return `/api/projects/${ctx.projectId}/file?branch=${encodeURIComponent(ctx.branch)}&path=${encodeURIComponent(joinPath(ctx.rootDir, path))}`;
+  return withBase(`/api/projects/${ctx.projectId}/file?branch=${encodeURIComponent(ctx.branch)}&path=${encodeURIComponent(joinPath(ctx.rootDir, path))}`);
 }
 
 /** Same file URL without root-dir resolution (fallback for fileUrl misses). */
 export function projectFileUrl(path: string): string | null {
   if (!ctx || !ctx.rootDir) return null; // identical to fileUrl when the root is top-level
-  return `/api/projects/${ctx.projectId}/file?branch=${encodeURIComponent(ctx.branch)}&path=${encodeURIComponent(joinPath('', path))}`;
+  return withBase(`/api/projects/${ctx.projectId}/file?branch=${encodeURIComponent(ctx.branch)}&path=${encodeURIComponent(joinPath('', path))}`);
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Home from './pages/Home';
 import Editor from './pages/Editor';
+import { BASE_PATH } from './basePath';
 
 function NotFound() {
   return (
@@ -22,7 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ToastProvider>
       <AuthProvider>
-        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <BrowserRouter basename={BASE_PATH} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/p/:id" element={<Editor />} />

--- a/apps/web/src/plugins/host.ts
+++ b/apps/web/src/plugins/host.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { withBase } from '../basePath';
 
 /**
  * Aldine plugin host.
@@ -68,7 +69,8 @@ export function PluginHost({ ctx, onPanels }: Props) {
       editor: { insertAtCursor: (t) => ctxRef.current.insertAtCursor(t) },
       compile: () => ctxRef.current.compile(),
       toast: (t, k) => ctxRef.current.toast(t, k),
-      fetch: (url, init) => fetch(url, init),
+      // plugins address the API root-relatively; the base path is the host's concern
+      fetch: (url, init) => fetch(url.startsWith('/') ? withBase(url) : url, init),
       ui: {
         registerSidebarPanel(panel) {
           panels.push({ id: `plugin:${panel.id}`, title: panel.title, mount: (el) => panel.render(el) });
@@ -78,12 +80,12 @@ export function PluginHost({ ctx, onPanels }: Props) {
 
     (async () => {
       try {
-        const res = await fetch('/api/plugins');
+        const res = await fetch(withBase('/api/plugins'));
         const manifests = (await res.json()) as Array<{ id: string; entry: string; enabled?: boolean }>;
         for (const m of manifests) {
           if (m.enabled === false) continue;
           try {
-            const mod = await import(/* @vite-ignore */ `/plugins/${m.id}/${m.entry}`);
+            const mod = await import(/* @vite-ignore */ withBase(`/plugins/${m.id}/${m.entry}`));
             mod.default?.activate?.(api);
           } catch (err) {
             console.error(`[plugins] failed to load ${m.id}`, err);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,10 @@ function gitRev(): string {
 }
 
 export default defineConfig({
+  // Relative base: chunk and asset URLs resolve from the loading script's own
+  // URL, so one build serves at the root or under ALDINE_BASE_PATH. The server
+  // pins index.html's own references to the base path when it serves it.
+  base: './',
   define: {
     __ALDINE_VERSION__: JSON.stringify(pkg.version),
     __ALDINE_REV__: JSON.stringify(gitRev()),

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -225,6 +225,7 @@ Everything is env-gated; blank/unset means "off" or the listed default.
 |---|---|
 | `ALDINE_DOMAIN` | Domain Caddy serves + provisions TLS for (`tls` profile) |
 | `ALDINE_PUBLIC_URL` | Absolute origin used in OAuth callbacks and reset links — required for SSO and email |
+| `ALDINE_BASE_PATH` | URL prefix to serve under (`/internal/aldine`) when Aldine shares a host with other apps. Defaults to the path of `ALDINE_PUBLIC_URL`, else the root. The proxy passes the prefix through unchanged; `/api/health` also answers at the root for healthchecks |
 | `ALDINE_APP_BIND` | Host interface for the app port (set `127.0.0.1` behind a proxy) |
 | `AUTH_ENABLED` | `1` = multi-user login, ownership, sharing. Unset = single-tenant, no login |
 | `ALDINE_SSO_ONLY` | `1` = disable password auth entirely (SSO only) |

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
     environment:
       # set these in a .env file next to docker-compose.yml (see deploy/README.md)
       ALDINE_PUBLIC_URL: ${ALDINE_PUBLIC_URL:-}
+      ALDINE_BASE_PATH: ${ALDINE_BASE_PATH:-}
       COOKIE_SECURE: "1"          # HTTPS-only session cookies in production
       TRUST_PROXY: "1"            # req.ip comes from Caddy's X-Forwarded-For
       ALDINE_COMPILE_QUOTA_MIN: ${ALDINE_COMPILE_QUOTA_MIN:-}  # monthly compile-minutes/user (blank = unmetered)

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -13,6 +13,12 @@
 #     limit here turns a valid import into a bare 413 before the app sees it.
 #   - WebSocket upgrade for /collab: without it, live collaboration silently
 #     degrades (editor loads, cursors never appear).
+#
+# Sharing the host with other apps? Set ALDINE_BASE_PATH=/internal/aldine (or
+# give ALDINE_PUBLIC_URL that path) and change the two location prefixes below
+# to `/internal/aldine/` and `/internal/aldine/collab`, keeping proxy_pass
+# without a URI so the prefix reaches the app unchanged. Do not rewrite the
+# path in the proxy: the app expects to see it.
 
 map $http_upgrade $connection_upgrade {
     default upgrade;

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -34,6 +34,7 @@ services:
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
       ALDINE_PUBLIC_URL: ${ALDINE_PUBLIC_URL:-}
+      ALDINE_BASE_PATH: ${ALDINE_BASE_PATH:-}
       # Optional outbound email for password resets: SMTP (any provider) or AWS
       # SES (SES_FROM + AWS_REGION). Without a transport, reset tokens are
       # logged server-side instead of emailed.

--- a/e2e/base-path-tests/base-path.spec.ts
+++ b/e2e/base-path-tests/base-path.spec.ts
@@ -72,4 +72,49 @@ test.describe('served under a base path (#27)', () => {
     await expect(page.getByTestId('project-name')).toContainText('Deep link');
     expect(failed).toEqual([]);
   });
+
+  test('plugins load from under the prefix', async ({ page, request }) => {
+    const { failed } = watch(page);
+    const entry = await request.get(`${BASE}/plugins/zotero/index.js`);
+    expect(entry.ok()).toBeTruthy();
+    expect(entry.headers()['content-type']).toContain('javascript');
+    expect((await request.get('/plugins/zotero/index.js')).status()).toBe(404);
+
+    const res = await request.post(`${BASE}/api/projects`, { data: { name: 'Plugin host' } });
+    const { id } = await res.json();
+    await page.goto(`${BASE}/p/${id}`);
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    // the host imports each plugin's entry module dynamically — a wrong base would 404 it
+    await expect(page.getByTestId('tab-plugin:zotero')).toBeVisible();
+    await page.getByTestId('tab-plugin:zotero').click();
+    await expect(page.getByTestId('zotero-panel')).toBeVisible();
+    expect(failed).toEqual([]);
+  });
+
+  test('typesetting serves the PDF and its download from under the prefix', async ({ page, request }) => {
+    const compiler = await (await request.get(`${BASE}/api/compiler`)).json();
+    test.skip(!compiler.ok, 'needs a compiler sharing this suite\'s DATA_DIR (COMPILER_URL)');
+
+    const { failed } = watch(page);
+    const res = await request.post(`${BASE}/api/projects`, { data: { name: 'Typeset under prefix' } });
+    const { id } = await res.json();
+    // plain LaTeX only, so a BasicTeX box can typeset it too
+    const put = await request.put(`${BASE}/api/projects/${id}/file`, {
+      data: { branch: 'main', path: 'main.tex', content: '\\documentclass{article}\n\\begin{document}\nUnder the prefix.\n\\end{document}\n' },
+    });
+    expect(put.ok()).toBeTruthy();
+
+    await page.goto(`${BASE}/p/${id}`);
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    await page.getByTestId('typeset-button').click();
+    await expect(page.getByTestId('pdf-status')).toContainText('Typeset in', { timeout: 120_000 });
+    await expect(page.locator('canvas.pdf-page').first()).toBeVisible({ timeout: 30_000 });
+
+    const href = await page.getByTestId('download-pdf').getAttribute('href');
+    expect(href).toMatch(new RegExp(`^${BASE}/api/projects/${id}/output\\?`));
+    const pdf = await request.get(href!);
+    expect(pdf.status()).toBe(200);
+    expect(pdf.headers()['content-type']).toContain('pdf');
+    expect(failed).toEqual([]);
+  });
 });

--- a/e2e/base-path-tests/base-path.spec.ts
+++ b/e2e/base-path-tests/base-path.spec.ts
@@ -1,0 +1,70 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+import { typeAtEnd } from '../tests/helpers';
+
+/** Mirrors ALDINE_BASE_PATH in playwright.base-path.config.ts. */
+const BASE = '/internal/aldine';
+
+/** Every response ≥ 400 and every websocket the page opens, for the assertions
+ *  below. Typeset results are skipped: this suite runs without a compiler, and
+ *  a 400 from <base>/api/…/compile is the compiler's absence, not a routing miss. */
+function watch(page: Page) {
+  const failed: string[] = [];
+  const sockets: string[] = [];
+  page.on('response', (r) => {
+    if (r.status() >= 400 && !new URL(r.url()).pathname.endsWith('/compile')) failed.push(`${r.status()} ${r.url()}`);
+  });
+  page.on('websocket', (ws) => sockets.push(ws.url()));
+  return { failed, sockets };
+}
+
+test.describe('served under a base path (#27)', () => {
+  test('only the base path is ours; the health check also answers at the root', async ({ request }) => {
+    expect((await request.get('/')).status()).toBe(404);
+    expect((await request.get('/api/projects')).status()).toBe(404);
+    expect((await request.get(`${BASE}-other`)).status()).toBe(404);
+    expect((await request.get(`${BASE}/api/projects`)).status()).toBe(200);
+    expect((await request.get(`${BASE}/api/health`)).status()).toBe(200);
+    // compose healthchecks poll the container's own root, whatever the prefix
+    expect((await request.get('/api/health')).status()).toBe(200);
+  });
+
+  test('home, project creation, editor, live sync and navigation all work under the prefix', async ({ page }) => {
+    const { failed, sockets } = watch(page);
+
+    await page.goto(BASE); // no trailing slash, as a portal link would be typed
+    await expect(page.locator('.home__brand').first()).toContainText('aldine');
+    await page.getByTestId('new-project').click();
+    await page.getByTestId('new-project-name').fill('Sub-path paper');
+    await page.getByTestId('create-project').click();
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    expect(new URL(page.url()).pathname).toMatch(new RegExp(`^${BASE}/p/[^/]+$`));
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+    await expect(page.locator('.cm-content')).toBeVisible();
+
+    // an edit round-trips through the collab websocket at <base>/collab
+    await typeAtEnd(page, '\nBASE-PATH-PERSISTED');
+    await expect.poll(() => sockets.some((u) => new URL(u).pathname === `${BASE}/collab`)).toBeTruthy();
+    await page.waitForTimeout(9_000); // hocuspocus debounce before it hits disk
+    await page.reload();
+    await expect(page.locator('.cm-content')).toContainText('BASE-PATH-PERSISTED', { timeout: 15_000 });
+
+    // in-app navigation keeps the prefix
+    await page.getByRole('button', { name: 'Back to projects' }).click();
+    await expect(page.getByTestId('project-grid')).toContainText('Sub-path paper');
+    expect(new URL(page.url()).pathname).toMatch(new RegExp(`^${BASE}/?$`));
+
+    expect(failed).toEqual([]);
+  });
+
+  test('a deep link reloads straight into the editor', async ({ page, request }) => {
+    const { failed } = watch(page);
+    const res = await request.post(`${BASE}/api/projects`, { data: { name: 'Deep link' } });
+    expect(res.ok()).toBeTruthy();
+    const { id } = await res.json();
+    await page.goto(`${BASE}/p/${id}`);
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    await expect(page.getByTestId('project-name')).toContainText('Deep link');
+    expect(failed).toEqual([]);
+  });
+});

--- a/e2e/base-path-tests/base-path.spec.ts
+++ b/e2e/base-path-tests/base-path.spec.ts
@@ -19,8 +19,13 @@ function watch(page: Page) {
 }
 
 test.describe('served under a base path (#27)', () => {
-  test('only the base path is ours; the health check also answers at the root', async ({ request }) => {
-    expect((await request.get('/')).status()).toBe(404);
+  test('only the base path is ours; the root probes still answer', async ({ request }) => {
+    const root = await request.get('/');
+    expect(root.status()).toBe(200); // a load balancer's default health check
+    expect(root.headers()['content-type']).toContain('text/plain');
+    expect(await root.text()).toContain(`${BASE}/`);
+    expect((await request.get('/other')).status()).toBe(404);
+    expect((await request.get('/index.html')).status()).toBe(404);
     expect((await request.get('/api/projects')).status()).toBe(404);
     expect((await request.get(`${BASE}-other`)).status()).toBe(404);
     expect((await request.get(`${BASE}/api/projects`)).status()).toBe(200);

--- a/e2e/playwright.base-path.config.ts
+++ b/e2e/playwright.base-path.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * The app served under a URL prefix (ALDINE_BASE_PATH=/internal/aldine) on
+ * :3300, isolated from the root-path suites. baseURL is the bare origin on
+ * purpose: Playwright resolves '/x' against the origin and would drop a path
+ * in baseURL, so the specs spell the prefix out.
+ */
+const PORT = Number(process.env.E2E_BASE_PATH_PORT || 3300);
+const BASE = process.env.ALDINE_BASE_PATH_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './base-path-tests',
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  retries: 1,
+  workers: 1,
+  reporter: [['list']],
+  use: { baseURL: BASE, trace: 'retain-on-failure', viewport: { width: 1440, height: 900 } },
+  webServer: process.env.ALDINE_BASE_PATH_URL ? undefined : {
+    command: `npm run build -w apps/web && PORT=${PORT} ALDINE_BASE_PATH=/internal/aldine ALDINE_TEST_HOOKS=1 DATA_DIR=$(pwd)/.data-base-path META_DIR=$(pwd)/.secrets-base-path CACHE_DIR=$(pwd)/.data-base-path/cache npx tsx apps/server/src/index.ts`,
+    cwd: '..',
+    port: PORT,
+    reuseExistingServer: true,
+    timeout: 600_000,
+  },
+});

--- a/e2e/playwright.base-path.config.ts
+++ b/e2e/playwright.base-path.config.ts
@@ -4,7 +4,10 @@ import { defineConfig } from '@playwright/test';
  * The app served under a URL prefix (ALDINE_BASE_PATH=/internal/aldine) on
  * :3300, isolated from the root-path suites. baseURL is the bare origin on
  * purpose: Playwright resolves '/x' against the origin and would drop a path
- * in baseURL, so the specs spell the prefix out.
+ * in baseURL, so the specs spell the prefix out. The typeset test runs only
+ * when a compiler shares this suite's data dir:
+ *   DATA_DIR=$(pwd)/.data-base-path PORT=4022 node apps/compiler/server.js
+ *   COMPILER_URL=http://localhost:4022 npm run test:e2e:base-path
  */
 const PORT = Number(process.env.E2E_BASE_PATH_PORT || 3300);
 const BASE = process.env.ALDINE_BASE_PATH_URL || `http://localhost:${PORT}`;

--- a/e2e/playwright.remote.config.ts
+++ b/e2e/playwright.remote.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Smoke test against a deployed instance (staging, a fresh compose stack):
+ *   ALDINE_REMOTE_URL=https://staging.example.com \
+ *   ALDINE_REMOTE_BASE_PATH=/internal/aldine   # only when served under a prefix
+ *   npm run test:e2e:remote
+ * Registers one throwaway account when the instance requires sign-in and
+ * deletes the project it created. Typesetting needs the instance's compiler
+ * (with biblatex); ALDINE_REMOTE_SKIP_TYPESET=1 leaves that step out.
+ */
+const URL = process.env.ALDINE_REMOTE_URL;
+if (!URL) throw new Error('ALDINE_REMOTE_URL is required (the instance to smoke test)');
+
+export default defineConfig({
+  testDir: './remote-tests',
+  timeout: 300_000,
+  expect: { timeout: 20_000 },
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: { baseURL: URL, trace: 'retain-on-failure', screenshot: 'only-on-failure', viewport: { width: 1440, height: 900 } },
+});

--- a/e2e/remote-tests/smoke.spec.ts
+++ b/e2e/remote-tests/smoke.spec.ts
@@ -12,7 +12,11 @@ const NAME = `Remote smoke ${STAMP}`;
 function watch(page: Page) {
   const failed: string[] = [];
   const sockets: string[] = [];
-  page.on('response', (r) => { if (r.status() >= 400) failed.push(`${r.status()} ${r.url()}`); });
+  page.on('response', (r) => {
+    // without a compiler the editor's automatic typeset answers 400; that is the skip case, not a routing miss
+    if (process.env.ALDINE_REMOTE_SKIP_TYPESET && new URL(r.url()).pathname.endsWith('/compile')) return;
+    if (r.status() >= 400) failed.push(`${r.status()} ${r.url()}`);
+  });
   page.on('websocket', (ws) => sockets.push(ws.url()));
   return { failed, sockets };
 }
@@ -77,10 +81,13 @@ test.describe(`deployed instance${BASE ? ` under ${BASE}` : ''}`, () => {
       await expect(page.getByTestId('download-pdf')).toHaveAttribute('href', new RegExp(`^${BASE}/api/projects/${projectId}/output`));
     }
 
-    // the share link is the public URL of this project
-    await page.getByTestId('share-project').click();
-    await expect(page.getByTestId('share-url')).toHaveValue(new RegExp(`^${page.url().split('/p/')[0]}/p/${projectId}$`));
-    await page.keyboard.press('Escape');
+    // the share link is the public URL of this project (sharing exists only with sign-in)
+    if (authed) {
+      await page.getByTestId('share-project').click();
+      await page.getByTestId('share-link').check();
+      await expect(page.getByTestId('share-url')).toHaveText(`${page.url().split('/p/')[0]}/p/${projectId}`);
+      await page.keyboard.press('Escape');
+    }
 
     await page.getByRole('button', { name: 'Back to projects' }).click();
     await expect(page.getByTestId('project-grid')).toContainText(NAME);

--- a/e2e/remote-tests/smoke.spec.ts
+++ b/e2e/remote-tests/smoke.spec.ts
@@ -1,0 +1,105 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+import { typeAtEnd } from '../tests/helpers';
+
+/** '' at the root; '/internal/aldine' when the instance is served under a prefix. */
+const BASE = (process.env.ALDINE_REMOTE_BASE_PATH || '').replace(/\/+$/, '');
+const STAMP = Date.now();
+const EMAIL = `e2e-smoke-${STAMP}@example.com`;
+const PASSWORD = `smoke-${STAMP}-pw`;
+const NAME = `Remote smoke ${STAMP}`;
+
+function watch(page: Page) {
+  const failed: string[] = [];
+  const sockets: string[] = [];
+  page.on('response', (r) => { if (r.status() >= 400) failed.push(`${r.status()} ${r.url()}`); });
+  page.on('websocket', (ws) => sockets.push(ws.url()));
+  return { failed, sockets };
+}
+
+/** Sign in if the instance asks for it: register a throwaway account. */
+async function signInIfNeeded(page: Page): Promise<boolean> {
+  await expect(page.getByTestId('auth-email').or(page.getByTestId('new-project')).first()).toBeVisible();
+  if (!(await page.getByTestId('auth-email').isVisible())) return false;
+  await page.getByTestId('auth-switch').click();
+  await page.getByTestId('auth-name').fill('E2E Smoke');
+  await page.getByTestId('auth-email').fill(EMAIL);
+  await page.getByTestId('auth-password').fill(PASSWORD);
+  await page.getByTestId('auth-submit').click();
+  await expect(page.getByTestId('new-project')).toBeVisible();
+  return true;
+}
+
+test.describe(`deployed instance${BASE ? ` under ${BASE}` : ''}`, () => {
+  test('probes answer where an orchestrator looks', async ({ request }) => {
+    expect((await request.get(`${BASE}/api/health`)).status()).toBe(200);
+    const me = await request.get(`${BASE}/api/auth/me`);
+    expect(me.status()).toBe(200);
+    expect(await me.json()).toHaveProperty('authEnabled');
+    if (BASE) {
+      const root = await request.get('/');
+      expect(root.status()).toBe(200);
+      expect(root.headers()['content-type']).toContain('text/plain');
+      expect((await request.get(`${BASE}-other`)).status()).toBe(404);
+      expect((await request.get('/api/projects')).status()).toBe(404);
+    }
+  });
+
+  test('sign in, write, sync, typeset, share, navigate, sign out', async ({ page }) => {
+    const { failed, sockets } = watch(page);
+    await page.goto(`${BASE}/`);
+    const authed = await signInIfNeeded(page);
+
+    await page.getByTestId('new-project').click();
+    await page.getByTestId('new-project-name').fill(NAME);
+    await page.getByTestId('create-project').click();
+    await expect(page.getByTestId('editor-shell')).toBeVisible();
+    const m = new URL(page.url()).pathname.match(new RegExp(`^${BASE}/p/([^/]+)$`));
+    expect(m, 'editor URL carries the base path').toBeTruthy();
+    const projectId = m![1];
+    await expect(page.getByTestId('file-main.tex')).toBeVisible();
+    await expect(page.locator('.cm-content')).toBeVisible();
+
+    // an edit round-trips through the collab websocket and survives a reload
+    await typeAtEnd(page, '\nREMOTE-SMOKE-PERSISTED');
+    await expect.poll(() => sockets.some((u) => new URL(u).pathname === `${BASE}/collab`)).toBeTruthy();
+    await page.waitForTimeout(9_000);
+    await page.reload();
+    await expect(page.locator('.cm-content')).toContainText('REMOTE-SMOKE-PERSISTED');
+
+    // typeset with the instance's own compiler; the PDF and its download link
+    // come from under the base path. The seed document needs biblatex, which
+    // a BasicTeX box lacks: ALDINE_REMOTE_SKIP_TYPESET=1 skips this block there.
+    if (!process.env.ALDINE_REMOTE_SKIP_TYPESET) {
+      await page.getByTestId('typeset-button').click();
+      await expect(page.getByTestId('pdf-status')).toContainText('Typeset in', { timeout: 240_000 });
+      await expect(page.locator('canvas.pdf-page').first()).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId('download-pdf')).toHaveAttribute('href', new RegExp(`^${BASE}/api/projects/${projectId}/output`));
+    }
+
+    // the share link is the public URL of this project
+    await page.getByTestId('share-project').click();
+    await expect(page.getByTestId('share-url')).toHaveValue(new RegExp(`^${page.url().split('/p/')[0]}/p/${projectId}$`));
+    await page.keyboard.press('Escape');
+
+    await page.getByRole('button', { name: 'Back to projects' }).click();
+    await expect(page.getByTestId('project-grid')).toContainText(NAME);
+    expect(new URL(page.url()).pathname).toMatch(new RegExp(`^${BASE}/?$`));
+
+    if (authed) {
+      await expect(page.getByTestId('user-name')).toBeVisible();
+      await page.getByTestId('logout').click();
+      await expect(page.getByTestId('auth-email')).toBeVisible();
+      await page.getByTestId('auth-email').fill(EMAIL);
+      await page.getByTestId('auth-password').fill(PASSWORD);
+      await page.getByTestId('auth-submit').click();
+      await expect(page.getByTestId('project-grid')).toContainText(NAME);
+    }
+
+    // leave the instance as we found it (best effort; the account stays)
+    const del = await page.request.delete(`${BASE}/api/projects/${projectId}?permanent=1`);
+    expect(del.ok()).toBeTruthy();
+
+    expect(failed).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "notices:check": "node scripts/gen-notices.mjs --check",
     "templates:check": "node scripts/check-templates.mjs",
     "test:e2e": "npx playwright test -c e2e",
-    "test:e2e:auth": "npx playwright test -c e2e/playwright.auth.config.ts"
+    "test:e2e:auth": "npx playwright test -c e2e/playwright.auth.config.ts",
+    "test:e2e:base-path": "npx playwright test -c e2e/playwright.base-path.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "templates:check": "node scripts/check-templates.mjs",
     "test:e2e": "npx playwright test -c e2e",
     "test:e2e:auth": "npx playwright test -c e2e/playwright.auth.config.ts",
-    "test:e2e:base-path": "npx playwright test -c e2e/playwright.base-path.config.ts"
+    "test:e2e:base-path": "npx playwright test -c e2e/playwright.base-path.config.ts",
+    "test:e2e:remote": "npx playwright test -c e2e/playwright.remote.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0"


### PR DESCRIPTION
Closes #27.

## What

Aldine can now live under a sub-path such as `https://server/internal/aldine/`, for hosts that front several apps with one origin.

- `ALDINE_BASE_PATH=/internal/aldine`, or simply a path in `ALDINE_PUBLIC_URL` (`https://server/internal/aldine`). Explicit wins; unset means the root, as before.
- The proxy passes the path through unchanged (no rewriting), so the fragile workaround the issue mentions is not needed.

## How

**Server** (`apps/server/src/app.ts`, new, split out of `index.ts` so it can be unit tested)
- Routes stay declared at `/api/...`. Fastify's `rewriteUrl` peels the prefix off before routing; anything outside the prefix is a JSON 404, never the app. `/api/health` also answers at the root so the compose healthchecks keep working.
- `index.html` is rendered once at startup: Vite's `./assets/...` references are pinned to `<base>/assets/...` (the SPA fallback serves it at every depth) and a `<meta name="aldine-base-path">` tells the client where it lives. The raw file never goes on the wire.
- Session and OAuth state cookies get `Path=<base>`, so a neighbouring app on the same host never sees them (the scenario behind #26).
- OAuth callbacks, password-reset links, post-login redirects and `pdfUrl` carry the prefix. `ALDINE_PUBLIC_URL` is parsed once in config; a malformed value no longer throws inside a handler.
- The collab websocket upgrade accepts `<base>/collab`.

**Web**
- `src/basePath.ts` reads the meta tag; `withBase()` / `wsUrl()` wrap every root-relative URL (API client, plugin registry and plugin asset imports, plugin `aldine.fetch`, visual-editor file URLs, both Hocuspocus providers, OAuth links, share link).
- `BrowserRouter` gets `basename`.
- Vite builds with `base: './'`, so chunks resolve from the loading script's own URL and one image serves at any depth. Dev server is unaffected (Vite uses `/` in dev).

## Tests

- `apps/server/test/base-path.test.mjs`: base-path normalisation, URL rewriting, cookie path, rendered index.html, and Fastify `inject` across prefixed, root and sibling paths (20/20 unit files pass).
- New Playwright suite `npm run test:e2e:base-path` (server on :3300 with `ALDINE_BASE_PATH=/internal/aldine`): root and sibling paths 404 while `/api/health` stays up; home → create project → editor → edit → reload persists (through `<base>/collab`) → back to the project grid, with no failed request; a deep link reloads into the editor. 3 passed.
- Regression at the root path: auth suite 21 passed; main suite 01-home, 02-compile (PDF URL), 03-collab, 06-plugins 10 passed with a local compiler; web vitest 26 passed; both typechecks clean.

## Docs

CHANGELOG (Unreleased/Added), README `.env` sample, `deploy/README.md` config table, `deploy/nginx.conf` sub-path note, `ALDINE_BASE_PATH` passthrough in `docker-compose.full.yml` and `deploy/docker-compose.prod.yml`.

https://claude.ai/code/session_01TRn9mstWXJTcbNeH5Mabj9
