### PR TITLE
changelog: cut 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-09-05
+
 ### Added
 - Aldine can live under a URL prefix, for hosts that put several apps behind
   one origin (`https://server/internal/aldine/`). Set `ALDINE_BASE_PATH`, or
@@ -757,7 +759,8 @@ First public release. Everything below is new.
   timer, Terraform for a full serverless-ish AWS deployment (deploy/aws).
 - Templates: article, IAC conference paper, beamer, report/thesis.
 
-[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/trahloff/Aldine/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/trahloff/Aldine/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/trahloff/Aldine/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/trahloff/Aldine/compare/v0.2.0...v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ found".
 DATA_DIR=$(pwd)/.data-e2e PORT=4020 node apps/compiler/server.js   # in its own terminal
 npx playwright test -c e2e                                   # main (no-auth)
 npx playwright test -c e2e/playwright.auth.config.ts         # auth
+npx playwright test -c e2e/playwright.base-path.config.ts    # served under /internal/aldine (:3300)
+ALDINE_REMOTE_URL=https://staging.example.com npx playwright test -c e2e/playwright.remote.config.ts  # a deployed instance
 ```
 
 Kill the dev compiler container from the previous section first, or it holds

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.1}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.5.0}
     ports:
       - "8080:3000"
     volumes:
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.1}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.5.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -154,7 +154,7 @@ fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
 - **You are pinned to a version.** The block above says
-  `${ALDINE_VERSION:-0.4.1}`, so a fresh copy installs the current release and
+  `${ALDINE_VERSION:-0.5.0}`, so a fresh copy installs the current release and
   nothing under a running install changes on its own. To upgrade, read the
   [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/server",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/web",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.4.1}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.5.0}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.4.1}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.5.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aldine",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aldine",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
@@ -18,7 +18,7 @@
     },
     "apps/server": {
       "name": "@aldine/server",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -46,7 +46,7 @@
     },
     "apps/web": {
       "name": "@aldine/web",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aldine",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Slim, fast, open-source LaTeX collaboration platform",
   "workspaces": [
     "apps/server",


### PR DESCRIPTION
Cuts 0.5.0: URL-prefix support (#27, #40) and the isolated hosted staging (#39).

- Version pins to 0.5.0 (root and workspace `package.json`, lockfile, `docker-compose.yml` default, README block); `node scripts/check-release-pins.mjs --tag v0.5.0` passes.
- CHANGELOG: `[Unreleased]` entries moved under `[0.5.0] — 2026-09-05`, compare links added.
- CONTRIBUTING: the two new Playwright suites (`playwright.base-path.config.ts`, `playwright.remote.config.ts`).

After merge: tag `v0.5.0` on the squash commit, approve `promote` in the `latest` environment once the smoke job is green.

https://claude.ai/code/session_01TRn9mstWXJTcbNeH5Mabj9
