### PR TITLE
changelog: cut 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-09-06
+
 ### Added
 - Sign in with ORCID. Set `ORCID_CLIENT_ID` and `ORCID_CLIENT_SECRET` from a
   Public API client (`ORCID_SANDBOX=1` for the sandbox) and the sign-in page
@@ -770,7 +772,8 @@ First public release. Everything below is new.
   timer, Terraform for a full serverless-ish AWS deployment (deploy/aws).
 - Templates: article, IAC conference paper, beamer, report/thesis.
 
-[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/trahloff/Aldine/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/trahloff/Aldine/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/trahloff/Aldine/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/trahloff/Aldine/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/trahloff/Aldine/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.5.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.6.0}
     ports:
       - "8080:3000"
     volumes:
@@ -121,7 +121,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.5.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.6.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -154,7 +154,7 @@ fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
 - **You are pinned to a version.** The block above says
-  `${ALDINE_VERSION:-0.5.0}`, so a fresh copy installs the current release and
+  `${ALDINE_VERSION:-0.6.0}`, so a fresh copy installs the current release and
   nothing under a running install changes on its own. To upgrade, read the
   [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/server",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aldine/web",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aldine/web",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/web",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.5.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.6.0}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.5.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.6.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aldine",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aldine",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
@@ -18,7 +18,7 @@
     },
     "apps/server": {
       "name": "@aldine/server",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -46,7 +46,7 @@
     },
     "apps/web": {
       "name": "@aldine/web",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aldine",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Slim, fast, open-source LaTeX collaboration platform",
   "workspaces": [
     "apps/server",


### PR DESCRIPTION
Release cut for 0.6.0: ORCID sign-in (#10, #42) on top of 0.5.0. All seven version pins bumped (check-release-pins passes with --tag v0.6.0); the stray apps/web lockfile, at 0.1.0 since forever, now agrees too. Tag v0.6.0 on the squash commit starts the release pipeline.