### PR TITLE
Error tracking names the instance and the build, and stops carrying the document

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -115,9 +115,13 @@ jobs:
               echo "Register a clean revision with terraform apply, then rerun."; exit 1;;
             esac
           fi
-          jq --arg s "$REG/$IMAGE_PREFIX-server:$SHA" --arg c "$REG/$IMAGE_PREFIX-compiler:$SHA" '
+          # SENTRY_RELEASE rides along with the image tags: terraform owns the rest
+          # of the container env and has no commit to name, so the deploy sets it
+          # here and re-sets it on every deploy, exactly like the image swap.
+          jq --arg s "$REG/$IMAGE_PREFIX-server:$SHA" --arg c "$REG/$IMAGE_PREFIX-compiler:$SHA" --arg rel "$SHA" '
             .containerDefinitions |= map(
               if .name == "server" then .image = $s
+                | .environment = (((.environment // []) | map(select(.name != "SENTRY_RELEASE"))) + [{name: "SENTRY_RELEASE", value: $rel}])
               elif .name == "compiler" then .image = $c
               else . end)
             | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Changed
+- Error tracking says which instance and which build an error came from, and
+  keeps the document out of it. `SENTRY_ENVIRONMENT` names the instance
+  (`staging`, `production`) instead of the environment being read from
+  `NODE_ENV`, which every deployed build sets to `production`; the release is
+  `SENTRY_RELEASE`, else the running `ALDINE_VERSION`, else the package
+  version. Events are stripped of the request body, cookies and headers, and a
+  URL is sent without its query string, which is where the file path, the
+  branch and a PDF link's signature live. A run with the test hooks on never
+  reports at all, so a developer machine that exports `SENTRY_DSN` for another
+  project does not file this app's test errors into it.
 - Contributors sign the CLA with one click on
   [cla-assistant.io](https://cla-assistant.io/trahloff/Aldine) instead of
   posting a sentence as a pull-request comment. The `contributor-assistant`

--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=
-# error tracking
+# error tracking, and which instance the errors came from
 SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
 ```
 
 ```bash

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import type { FastifyInstance } from 'fastify';
 
 /**
@@ -7,14 +8,68 @@ import type { FastifyInstance } from 'fastify';
  */
 let sentry: { captureException(e: unknown): void } | null = null;
 
+const pkg = createRequire(import.meta.url)('../package.json') as { version: string };
+
+interface ScrubbableEvent {
+  request?: { url?: string; query_string?: unknown; data?: unknown; cookies?: unknown; headers?: unknown };
+}
+
+/**
+ * What leaves the instance with an error. A URL's query carries the things a
+ * document platform must not hand to a third party: the path of the file being
+ * read, the branch, and the signature on a PDF link (a valid credential for
+ * that artifact until it expires). Headers can carry the session cookie or an
+ * access token. The stack frames and the message are the diagnosis; none of
+ * this is.
+ */
+export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
+  const req = event.request;
+  if (req) {
+    if (typeof req.url === 'string') req.url = req.url.split('?')[0];
+    delete req.query_string;
+    delete req.data;
+    delete req.cookies;
+    delete req.headers;
+  }
+  return event;
+}
+
+export interface SentrySettings { dsn: string; environment: string; release: string }
+
+/**
+ * Settings for this process, or null when error tracking is off. The
+ * environment is its own variable rather than NODE_ENV: a staging deployment
+ * runs NODE_ENV=production like every other production build, and errors filed
+ * under the wrong environment are worse than none. A test run never reports —
+ * a developer machine often exports SENTRY_DSN for another project, and the
+ * suites would file this app's errors into it.
+ */
+export function sentrySettings(env: NodeJS.ProcessEnv = process.env): SentrySettings | null {
+  const dsn = env.SENTRY_DSN;
+  if (!dsn || env.ALDINE_TEST_HOOKS === '1') return null;
+  return {
+    dsn,
+    environment: env.SENTRY_ENVIRONMENT || env.NODE_ENV || 'production',
+    // The build a trace belongs to: prod and staging run different commits.
+    release: env.SENTRY_RELEASE || env.ALDINE_VERSION || pkg.version,
+  };
+}
+
 export async function initObservability(app: FastifyInstance): Promise<void> {
-  const dsn = process.env.SENTRY_DSN;
-  if (dsn) {
+  const settings = sentrySettings();
+  if (settings) {
     try {
       const Sentry = await import('@sentry/node');
-      Sentry.init({ dsn, tracesSampleRate: 0, environment: process.env.NODE_ENV || 'production' });
+      Sentry.init({
+        dsn: settings.dsn,
+        environment: settings.environment,
+        release: settings.release,
+        tracesSampleRate: 0,
+        sendDefaultPii: false,
+        beforeSend: (event) => scrubEvent(event),
+      });
       sentry = Sentry;
-      console.log('[aldine] Sentry error tracking enabled');
+      console.log(`[aldine] Sentry error tracking enabled — environment ${settings.environment}, release ${settings.release}`);
     } catch {
       console.warn('[aldine] SENTRY_DSN is set but @sentry/node is not installed — run `npm i @sentry/node` to enable it');
     }

--- a/apps/server/test/observability.test.mjs
+++ b/apps/server/test/observability.test.mjs
@@ -1,0 +1,60 @@
+/**
+ * What reaches the error tracker, and under which environment and release.
+ * Both are pure functions on purpose: a test must be able to pin them without
+ * a DSN, a network, or the SDK installed.
+ */
+import { check, eq } from './assert.mjs';
+
+const { sentrySettings, scrubEvent } = await import('../src/observability.ts');
+
+// ---- off unless configured ----------------------------------------------
+eq(sentrySettings({}), null, 'no DSN: error tracking is off');
+eq(sentrySettings({ SENTRY_DSN: '' }), null, 'an empty DSN is off, not a crash');
+
+// A developer machine often exports SENTRY_DSN for an unrelated project; a
+// test run must never file this app's errors into it.
+eq(sentrySettings({ SENTRY_DSN: 'https://k@o1.ingest.de.sentry.io/2', ALDINE_TEST_HOOKS: '1' }), null,
+  'the test hooks refuse a DSN outright');
+
+// ---- environment ---------------------------------------------------------
+const dsn = 'https://key@o1.ingest.de.sentry.io/2';
+eq(sentrySettings({ SENTRY_DSN: dsn }).environment, 'production',
+  'no hint: production, the safe assumption for a deployed instance');
+eq(sentrySettings({ SENTRY_DSN: dsn, NODE_ENV: 'production', SENTRY_ENVIRONMENT: 'staging' }).environment, 'staging',
+  'SENTRY_ENVIRONMENT wins: a staging box runs NODE_ENV=production like any build');
+eq(sentrySettings({ SENTRY_DSN: dsn, NODE_ENV: 'development' }).environment, 'development',
+  'NODE_ENV is the fallback');
+
+// ---- release -------------------------------------------------------------
+eq(sentrySettings({ SENTRY_DSN: dsn, ALDINE_VERSION: '0.7.0' }).release, '0.7.0', 'the deployed image tag');
+eq(sentrySettings({ SENTRY_DSN: dsn, ALDINE_VERSION: '0.7.0', SENTRY_RELEASE: 'sha-abc1234' }).release, 'sha-abc1234',
+  'SENTRY_RELEASE wins, for a build that is not a version tag');
+check(/^\d+\.\d+\.\d+/.test(sentrySettings({ SENTRY_DSN: dsn }).release),
+  'without either, the package version identifies the build');
+
+// ---- what leaves the instance -------------------------------------------
+const event = {
+  request: {
+    url: 'https://aldine.example.com/api/projects/abc123/output?branch=main&path=.aldine-out%2Fmain.pdf&exp=1&sig=deadbeef',
+    query_string: 'branch=main&sig=deadbeef',
+    data: { content: '\\section{Unpublished results}' },
+    cookies: { aldine_session: 's3cret' },
+    headers: { authorization: 'Bearer aldn_secret', 'x-aldine-token': 'aldn_secret' },
+  },
+  exception: { values: [{ type: 'Error', value: 'ENOENT' }] },
+};
+const scrubbed = scrubEvent(event);
+eq(scrubbed.request.url, 'https://aldine.example.com/api/projects/abc123/output', 'the query is cut from the URL');
+eq(scrubbed.request.query_string, undefined, 'no query string');
+eq(scrubbed.request.data, undefined, 'no request body — it is the document');
+eq(scrubbed.request.cookies, undefined, 'no cookies — the session lives there');
+eq(scrubbed.request.headers, undefined, 'no headers — the access token lives there');
+check(JSON.stringify(scrubbed).indexOf('sig=') === -1, 'no PDF-link signature anywhere in the event');
+check(JSON.stringify(scrubbed).indexOf('aldn_') === -1, 'no access token anywhere in the event');
+eq(scrubbed.exception.values[0].value, 'ENOENT', 'the diagnosis itself is untouched');
+
+// An event without request data (a captureException outside a request) passes through.
+const bare = scrubEvent({ exception: { values: [{ type: 'Error', value: 'boom' }] } });
+eq(bare.exception.values[0].value, 'boom', 'an event with no request survives');
+
+console.log('observability: ALL PASSED');

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,8 +76,10 @@ SMTP_FROM="Aldine <no-reply@aldine.example.com>"
 # Useful when hosting for a group; over-quota compiles return HTTP 402.
 ALDINE_COMPILE_QUOTA_MIN=
 
-# error tracking (optional)
+# error tracking (optional). SENTRY_ENVIRONMENT separates this instance from
+# your others in the issue list; without it every instance files as production.
 SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
 
 # Shared rate limits and cross-node access-revocation events (the `redis`
 # profile). This does NOT make multiple app nodes a supported topology: routing
@@ -247,7 +249,9 @@ Everything is env-gated; blank/unset means "off" or the listed default.
 | `DATABASE_URL` | Postgres datastore (blank = flat JSON files) |
 | `PG_POOL_MAX` | Postgres pool size (default 10) |
 | `REDIS_URL` | Shared rate limits + collab sync across app nodes |
-| `SENTRY_DSN` | Error tracking |
+| `SENTRY_DSN` | Error tracking. Server errors only (5xx and unhandled rejections); URLs are sent without their query string, and request bodies, cookies and headers are dropped |
+| `SENTRY_ENVIRONMENT` | Which instance an error came from (`production`, `staging`, …). Defaults to `NODE_ENV`, then `production` |
+| `SENTRY_RELEASE` | Build an error belongs to. Defaults to `ALDINE_VERSION`, then the package version |
 | `TRUST_PROXY` | `1` = trust `X-Forwarded-For` (set by the prod overlay; needed behind any proxy) |
 | `COOKIE_SECURE` | `1` = Secure session cookies (prod overlay sets it) |
 | `RL_LOGIN_BURST`, `RL_REGISTER_BURST`, `RL_AI_BURST`, `RL_AI_REFILL_PER_MIN`, `RL_REF_BURST` | Rate-limit tuning (sane defaults) |

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -18,15 +18,16 @@ locals {
   # Plain (non-secret) env for the server. Secrets come from SSM below.
   server_env = merge(
     {
-      NODE_ENV          = "production"
-      PORT              = "3000"
-      DATA_DIR          = "/data"
-      META_DIR          = "/secrets"
-      COMPILER_URL      = "http://localhost:4020"
-      ALDINE_PUBLIC_URL = "https://${var.domain_name}"
-      COOKIE_SECURE     = "1"
-      TRUST_PROXY       = "1" # behind the ALB, so X-Forwarded-For is trusted for rate-limit keys
-      ALDINE_AI_MODEL   = var.ai_model
+      NODE_ENV           = "production"
+      SENTRY_ENVIRONMENT = "production"
+      PORT               = "3000"
+      DATA_DIR           = "/data"
+      META_DIR           = "/secrets"
+      COMPILER_URL       = "http://localhost:4020"
+      ALDINE_PUBLIC_URL  = "https://${var.domain_name}"
+      COOKIE_SECURE      = "1"
+      TRUST_PROXY        = "1" # behind the ALB, so X-Forwarded-For is trusted for rate-limit keys
+      ALDINE_AI_MODEL    = var.ai_model
     },
     var.auth_enabled ? { AUTH_ENABLED = "1" } : {},
     var.sso_only ? { ALDINE_SSO_ONLY = "1" } : {},

--- a/deploy/aws/staging.tf
+++ b/deploy/aws/staging.tf
@@ -22,7 +22,7 @@ locals {
 
   staging_server_env = merge(
     { for k, v in local.server_env : k => v if k != "ALDINE_SSO_ONLY" },
-    { ALDINE_PUBLIC_URL = "https://${var.staging_domain_name}" },
+    { ALDINE_PUBLIC_URL = "https://${var.staging_domain_name}", SENTRY_ENVIRONMENT = "staging" },
     var.staging_env,
   )
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -52,6 +52,8 @@ services:
       AWS_REGION: ${AWS_REGION:-}
       # Optional error tracking.
       SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
       # Public-demo hardening: comma-separated project ids everyone may read
       # and typeset but nobody may edit; per-client typeset budget per minute.
       ALDINE_PROTECTED_PROJECTS: ${ALDINE_PROTECTED_PROJECTS:-}


### PR DESCRIPTION
`SENTRY_DSN` on this machine belongs to an unrelated project and is exported globally, so today's local end-to-end runs filed their errors into it, tagged `production`. That is what surfaced both of the real problems here.

- **The environment was `NODE_ENV`**, which every deployed build sets to `production`. The hosted staging service inherits the production environment map, so its errors would have been indistinguishable from production ones. `SENTRY_ENVIRONMENT` now names the instance; the terraform sets `production` and `staging` respectively.
- **The release was unset.** The deploy workflow now writes the deployed commit into `SENTRY_RELEASE` alongside the image tags it already swaps, so a stack trace maps to the build that produced it. Without it the SDK falls back to `ALDINE_VERSION`, then the package version.
- **The payload carried more than the diagnosis.** A URL is now sent without its query string, and the request body, cookies and headers are dropped. On Aldine those hold the file being edited, the branch, the signature on a PDF link, and the session cookie or an `aldn_` access token.
- **A test run never reports.** With `ALDINE_TEST_HOOKS=1` the DSN is refused outright, so a developer machine that exports one for another project cannot file this app's test errors into it.

Only server errors of 500 and above and unhandled rejections were ever captured; that is unchanged.

Tests: `apps/server/test/observability.test.mjs` pins the environment and release precedence, the test-hooks refusal, and that no signature, token, cookie or request body survives an event. Server unit suite 22/22, both typechecks clean.