### PR TITLE
aws: a shell into the running task, off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- AWS stack: `enable_ecs_exec` (off by default) lets an operator open a shell
+  in the running server container with `aws ecs execute-command`, for one-off
+  inspection of the datastore on EFS. It grants the task role the SSM
+  messaging permissions ECS Exec needs; who may open a session stays with IAM.
+  Documented in `deploy/aws/README.md`.
+
 ### Changed
 - The default compiler image installs whole TeX Live collections instead of
   a hand-picked list: `collection-pictures` (pgfplots, tikz-cd),

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -89,6 +89,18 @@ Set the corresponding client id/secret in `secret_env`.
   the previous task-definition revision; pass a revision number to go further
   back. Nothing is rebuilt, so it takes about as long as one deploy cycle.
 - **Infra change:** edit the `.tf` files → `terraform apply`.
+- **A shell in the running container** (`enable_ecs_exec = true`, then one
+  deploy so the task starts with it): needs the
+  [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+  on your machine and `ecs:ExecuteCommand` on your IAM principal.
+  ```bash
+  TASK=$(aws ecs list-tasks --cluster papyr --service-name papyr --query 'taskArns[0]' --output text)
+  aws ecs execute-command --cluster papyr --task "$TASK" --container server \
+    --interactive --command "/bin/sh"
+  ```
+  The JSON datastore lives under `META_DIR` (`/secrets` in the task), so
+  `users.json` there is the account list. Leave it off when nobody needs it:
+  it is a door into the container that IAM alone guards.
 
 The ECS deployment circuit breaker also rolls back on its own if the new tasks
 never reach a healthy state.

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -166,6 +166,10 @@ resource "aws_ecs_service" "app" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.desired_count
 
+  # Takes effect for tasks started after the change: a running task keeps
+  # the setting it was launched with until the next deploy.
+  enable_execute_command = var.enable_ecs_exec
+
   capacity_provider_strategy {
     capacity_provider = var.use_fargate_spot ? "FARGATE_SPOT" : "FARGATE"
     weight            = 1

--- a/deploy/aws/iam.tf
+++ b/deploy/aws/iam.tf
@@ -42,6 +42,28 @@ resource "aws_iam_role" "task" {
   assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
 }
 
+# ECS Exec: the SSM agent inside the task opens these channels; the
+# resources are not scopeable (AWS documents them as "*").
+data "aws_iam_policy_document" "ecs_exec" {
+  count = var.enable_ecs_exec ? 1 : 0
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_exec" {
+  count  = var.enable_ecs_exec ? 1 : 0
+  name   = "papyr-ecs-exec"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.ecs_exec[0].json
+}
+
 data "aws_iam_policy_document" "send_email" {
   count = var.enable_ses ? 1 : 0
   statement {

--- a/deploy/aws/staging.tf
+++ b/deploy/aws/staging.tf
@@ -320,6 +320,8 @@ resource "aws_ecs_service" "staging" {
   task_definition = aws_ecs_task_definition.staging[0].arn
   desired_count   = 1
 
+  enable_execute_command = var.enable_ecs_exec
+
   capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"
     weight            = 1

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -68,6 +68,12 @@ variable "ai_model" {
 }
 
 # ---- transactional email (SES) ----
+variable "enable_ecs_exec" {
+  description = "Allow `aws ecs execute-command` into the running tasks (a shell in the server container, for one-off inspection of the datastore). Grants the task role the SSM messaging permissions this needs; who may open a session is still governed by IAM (ecs:ExecuteCommand)."
+  type        = bool
+  default     = false
+}
+
 variable "enable_ses" {
   description = "Provision SES (domain identity, DKIM, MAIL FROM) and let the app send reset emails via the task role."
   type        = bool


### PR DESCRIPTION
`enable_ecs_exec` (default false) enables ECS Exec on the production and staging services and grants the task role the four `ssmmessages` permissions it needs. Purpose: one-off inspection of the JSON datastore on EFS (`/secrets/users.json`), which has no other read path. Who may open a session stays with IAM (`ecs:ExecuteCommand`). Documented in `deploy/aws/README.md`.

Takes effect for tasks started after the change, so the flag needs one deploy to become usable.
