### PR TITLE
Server admin: ALDINE_ADMIN_EMAILS, /admin, active-user counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to Aldine are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- Server admin: `ALDINE_ADMIN_EMAILS` (comma-separated) names the accounts
+  that may open `/admin` and `GET /api/admin/{stats,users}`. The page shows
+  how many accounts exist, how many were active in the last 7 and 30 days,
+  who is editing right now, project and open-document counts, this month's
+  compile time, and an accounts table (sign-in method, joined, last seen,
+  owned projects, compile minutes). Metadata only: an admin never sees a
+  project's files and the project ACL is unchanged. To support "active", the
+  server now records `lastSeenAt` per account, written at most every five
+  minutes (Postgres gains a `users.last_seen_at` column automatically).
 - AWS stack: `enable_ecs_exec` (off by default) lets an operator open a shell
   in the running server container with `aws ecs execute-command`, for one-off
   inspection of the datastore on EFS. It grants the task role the SSM

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Live collaboration, a recompile, and a SyncTeX jump, in one real recording (comp
   email/password (scrypt-hashed, revocable HTTP-only-cookie sessions);
   `ALDINE_SSO_ONLY=1` disables passwords entirely. Off by default
   (single-tenant); the collab socket is access-checked.
+  `ALDINE_ADMIN_EMAILS=you@example.org` opens `/admin`: accounts, active
+  users (7 / 30 days, editing now), projects, compile time. Metadata only.
 - **Scales when you need it**: flat-file storage by default; set
   `DATABASE_URL` for Postgres and `REDIS_URL` for shared rate limits and
   cross-node collab events. One app node is still the supported topology;

--- a/apps/server/src/admin.ts
+++ b/apps/server/src/admin.ts
@@ -1,0 +1,109 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { db } from './db/index.js';
+import * as auth from './auth.js';
+import { isAdmin } from './authz.js';
+import { meteringEnabled, usageFor } from './usage.js';
+import { hocuspocus, onlineUserIds } from './collab.js';
+
+/**
+ * Instance administration: server-wide metadata for the operator. Metadata
+ * only — no route here returns project content, and none bypasses the
+ * project ACL. Guarded by isAdmin at the plugin level so a route added later
+ * cannot forget the check.
+ */
+
+/** Activity older than this no longer counts as "active". */
+const ACTIVE_WINDOWS_DAYS = [7, 30] as const;
+
+/** Heartbeat write cadence: at most one datastore write per user per window.
+ *  Per process; a multi-node deployment writes once per node per window,
+ *  which is still cheap and still correct to the minute. */
+const TOUCH_INTERVAL_MS = 5 * 60 * 1000;
+const lastTouch = new Map<string, number>();
+
+/** Record that a signed-in user made a request. Fire-and-forget: the caller
+ *  never waits on it and a datastore error must not fail the request. */
+export function noteActivity(userId: string, now = Date.now()): void {
+  const prev = lastTouch.get(userId) || 0;
+  if (now - prev < TOUCH_INTERVAL_MS) return;
+  lastTouch.set(userId, now);
+  db().touchUser(userId, new Date(now).toISOString()).catch(() => { lastTouch.delete(userId); });
+}
+
+/** Test hook: forget the throttle so a follow-up request touches again. */
+export function resetActivityThrottle(): void { lastTouch.clear(); }
+
+export interface AdminStats {
+  users: { total: number; active7d: number; active30d: number; onlineNow: number };
+  projects: { total: number; trashed: number };
+  collab: { documents: number; connections: number };
+  compile: { month: string; seconds: number; quotaSeconds: number; metering: boolean };
+  /** The configured allow-list, so the page can show who else can see it. */
+  admins: string[];
+}
+
+export interface AdminUserRow {
+  id: string;
+  email: string | null;
+  name: string;
+  provider?: string;
+  createdAt: string;
+  lastSeenAt?: string;
+  admin: boolean;
+  projects: number;
+  compileSecondsThisMonth: number;
+}
+
+function activeSince(users: { lastSeenAt?: string }[], days: number, now: number): number {
+  const cutoff = now - days * 864e5;
+  return users.filter((u) => u.lastSeenAt && Date.parse(u.lastSeenAt) >= cutoff).length;
+}
+
+export async function adminStats(now = Date.now()): Promise<AdminStats> {
+  const [users, metas] = await Promise.all([db().listUsers(), db().listMeta()]);
+  const month = `${new Date(now).getUTCFullYear()}-${String(new Date(now).getUTCMonth() + 1).padStart(2, '0')}`;
+  const seconds = await db().totalUsageSeconds(month);
+  const quotaSeconds = users[0] ? (await usageFor(users[0].id, new Date(now))).quotaSeconds : 0;
+  return {
+    users: {
+      total: users.length,
+      active7d: activeSince(users, ACTIVE_WINDOWS_DAYS[0], now),
+      active30d: activeSince(users, ACTIVE_WINDOWS_DAYS[1], now),
+      onlineNow: onlineUserIds().size,
+    },
+    projects: { total: metas.filter((m) => !m.deletedAt).length, trashed: metas.filter((m) => !!m.deletedAt).length },
+    collab: { documents: hocuspocus.getDocumentsCount(), connections: hocuspocus.getConnectionsCount() },
+    compile: { month, seconds: Math.round(seconds), quotaSeconds, metering: meteringEnabled() },
+    admins: [...auth.ADMIN_EMAILS],
+  };
+}
+
+export async function adminUsers(now = Date.now()): Promise<AdminUserRow[]> {
+  const [users, metas] = await Promise.all([db().listUsers(), db().listMeta()]);
+  const owned = new Map<string, number>();
+  for (const m of metas) if (m.ownerId && !m.deletedAt) owned.set(m.ownerId, (owned.get(m.ownerId) || 0) + 1);
+  return Promise.all(users.map(async (u) => ({
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    provider: u.provider,
+    createdAt: u.createdAt,
+    lastSeenAt: u.lastSeenAt,
+    admin: isAdmin(auth.pub(u)),
+    projects: owned.get(u.id) || 0,
+    compileSecondsThisMonth: Math.round((await usageFor(u.id, new Date(now))).seconds),
+  })));
+}
+
+export async function registerAdminRoutes(app: FastifyInstance, reqUser: (req: FastifyRequest) => auth.PublicUser | null): Promise<void> {
+  await app.register(async (admin) => {
+    admin.addHook('preHandler', async (req, reply) => {
+      if (!auth.AUTH_ENABLED) return;
+      const user = reqUser(req);
+      if (!user) return reply.code(401).send({ error: 'Sign in required' });
+      if (!isAdmin(user)) return reply.code(403).send({ error: 'Administrator access required' });
+    });
+    admin.get('/api/admin/stats', async () => adminStats());
+    admin.get('/api/admin/users', async () => adminUsers());
+  });
+}

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -16,6 +16,15 @@ import type { OAuthProfile } from './oauth.js';
 export const AUTH_ENABLED = process.env.AUTH_ENABLED === '1' || process.env.AUTH_ENABLED === 'true';
 /** SSO-only mode: disable all password endpoints (register/login/reset/change) — sign-in is exclusively via a configured OAuth provider. */
 export const SSO_ONLY = process.env.ALDINE_SSO_ONLY === '1' || process.env.ALDINE_SSO_ONLY === 'true';
+/**
+ * Instance administrators, by email (ALDINE_ADMIN_EMAILS, comma-separated).
+ * Env rather than a role column: the operator who controls the process
+ * controls admin, there is no bootstrap problem on a fresh install, and it
+ * needs no migration on either datastore. Compared case-insensitively.
+ */
+export const ADMIN_EMAILS = new Set(
+  (process.env.ALDINE_ADMIN_EMAILS || '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+);
 export const COOKIE = 'aldine_session';
 // Scoped to the base path so a neighbouring app on the same host never sees it.
 export const COOKIE_PATH = config.basePath || '/';

--- a/apps/server/src/authz.ts
+++ b/apps/server/src/authz.ts
@@ -1,4 +1,4 @@
-import { AUTH_ENABLED, PublicUser, getUser } from './auth.js';
+import { ADMIN_EMAILS, AUTH_ENABLED, PublicUser, getUser } from './auth.js';
 import { ProjectMeta } from './store.js';
 
 /**
@@ -40,6 +40,17 @@ export function isOwner(meta: ProjectMeta, user: PublicUser | null): boolean {
   if (!AUTH_ENABLED) return true;
   if (!meta.ownerId) return false;
   return !!user && meta.ownerId === user.id;
+}
+
+/**
+ * Instance administrator: may read server-wide metadata (accounts, counts,
+ * usage). Deliberately NOT a superset of canAccess — an admin sees that a
+ * project exists and who owns it, never its content. With auth off there is
+ * nobody to distinguish, so the admin surface is open like everything else.
+ */
+export function isAdmin(user: PublicUser | null): boolean {
+  if (!AUTH_ENABLED) return true;
+  return !!user?.email && ADMIN_EMAILS.has(user.email.toLowerCase());
 }
 
 /** Resolve the owner's display name for listings (best-effort). A lookup

--- a/apps/server/src/collab.ts
+++ b/apps/server/src/collab.ts
@@ -143,8 +143,21 @@ const authHook = AUTH_ENABLED ? {
     let meta;
     try { meta = await readMeta(parsed.projectId); } catch { throw new Error('project not found'); }
     if (!canAccess(meta, user)) throw new Error('Access denied');
+    // Becomes connection.context: the only per-socket identity we keep, so
+    // onlineUserIds can count people rather than sockets.
+    return { userId: user.id };
   },
 } : {};
+
+/** Distinct signed-in users with an open collab socket on this node. Empty
+ *  with auth off (sockets carry no identity then). */
+export function onlineUserIds(): Set<string> {
+  const ids = new Set<string>();
+  hocuspocus.documents.forEach((doc: { getConnections?: () => { context?: { userId?: string } }[] }) => {
+    for (const c of doc.getConnections?.() ?? []) if (c.context?.userId) ids.add(c.context.userId);
+  });
+  return ids;
+}
 
 // Multi-node collaboration (scaling wall #2): with REDIS_URL, the Redis extension
 // syncs awareness across nodes and hands a document off cleanly on failover.

--- a/apps/server/src/db/json.ts
+++ b/apps/server/src/db/json.ts
@@ -99,6 +99,13 @@ export class JsonStore implements DataStore {
     this.write(this.usersPath, m);
   }
   async updateUser(u: User) { const m = this.users(); m[u.id] = this.clone(u); this.write(this.usersPath, m); }
+  async listUsers() { return Object.values(this.users()).sort((a, b) => a.createdAt.localeCompare(b.createdAt)).map((u) => this.clone(u)); }
+  async touchUser(id: string, lastSeenAt: string) {
+    const m = this.users();
+    if (!m[id]) return;
+    m[id].lastSeenAt = lastSeenAt;
+    this.write(this.usersPath, m);
+  }
   async getUser(id: string) { return this.clone(this.users()[id] || null); }
   async findUserByEmail(email: string) { return this.clone(Object.values(this.users()).find((u) => u.email === email) || null); }
   async findUserBySubject(subject: string) { return this.clone(Object.values(this.users()).find((u) => u.subject === subject) || null); }
@@ -186,5 +193,10 @@ export class JsonStore implements DataStore {
     u[userId] = this.userMonths(u[userId]);
     u[userId][month] = (u[userId][month] || 0) + seconds;
     this.write(this.usagePath, u);
+  }
+  async totalUsageSeconds(month: string) {
+    let total = 0;
+    for (const rec of Object.values(this.usage())) total += this.userMonths(rec)[month] ?? 0;
+    return total;
   }
 }

--- a/apps/server/src/db/pg.ts
+++ b/apps/server/src/db/pg.ts
@@ -84,19 +84,20 @@ export class PgStore implements DataStore {
       ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
       ALTER TABLE users ADD COLUMN IF NOT EXISTS subject text;
       CREATE UNIQUE INDEX IF NOT EXISTS users_subject_idx ON users(subject);
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS last_seen_at text;
     `);
   }
   async close(): Promise<void> { await this.pool?.end(); }
 
   // ---- users ----
   private rowToUser(r: any): User {
-    return { id: r.id, email: r.email, name: r.name, salt: r.salt, hash: r.hash, createdAt: r.created_at, provider: r.provider ?? undefined, subject: r.subject ?? undefined };
+    return { id: r.id, email: r.email, name: r.name, salt: r.salt, hash: r.hash, createdAt: r.created_at, provider: r.provider ?? undefined, subject: r.subject ?? undefined, lastSeenAt: r.last_seen_at ?? undefined };
   }
   async createUser(u: User) {
     try {
       await this.pool.query(
-        `INSERT INTO users(id,email,name,salt,hash,created_at,provider,subject) VALUES($1,$2,$3,$4,$5,$6,$7,$8)`,
-        [u.id, u.email, u.name, u.salt, u.hash, u.createdAt, u.provider ?? null, u.subject ?? null],
+        `INSERT INTO users(id,email,name,salt,hash,created_at,provider,subject,last_seen_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+        [u.id, u.email, u.name, u.salt, u.hash, u.createdAt, u.provider ?? null, u.subject ?? null, u.lastSeenAt ?? null],
       );
     } catch (err: any) {
       // Same messages as the JSON backend, so register() surfaces one
@@ -110,9 +111,16 @@ export class PgStore implements DataStore {
   }
   async updateUser(u: User) {
     await this.pool.query(
-      `UPDATE users SET email=$2,name=$3,salt=$4,hash=$5,created_at=$6,provider=$7,subject=$8 WHERE id=$1`,
-      [u.id, u.email, u.name, u.salt, u.hash, u.createdAt, u.provider ?? null, u.subject ?? null],
+      `UPDATE users SET email=$2,name=$3,salt=$4,hash=$5,created_at=$6,provider=$7,subject=$8,last_seen_at=$9 WHERE id=$1`,
+      [u.id, u.email, u.name, u.salt, u.hash, u.createdAt, u.provider ?? null, u.subject ?? null, u.lastSeenAt ?? null],
     );
+  }
+  async listUsers() {
+    const { rows } = await this.pool.query(`SELECT * FROM users ORDER BY created_at, id`);
+    return rows.map((r: any) => this.rowToUser(r));
+  }
+  async touchUser(id: string, lastSeenAt: string) {
+    await this.pool.query(`UPDATE users SET last_seen_at=$2 WHERE id=$1`, [id, lastSeenAt]);
   }
   async getUser(id: string) {
     const { rows } = await this.pool.query(`SELECT * FROM users WHERE id=$1`, [id]);
@@ -201,6 +209,10 @@ export class PgStore implements DataStore {
        ON CONFLICT(user_id,month) DO UPDATE SET seconds = usage.seconds + EXCLUDED.seconds`,
       [userId, month, seconds],
     );
+  }
+  async totalUsageSeconds(month: string) {
+    const { rows } = await this.pool.query(`SELECT COALESCE(SUM(seconds),0) AS total FROM usage WHERE month=$1`, [month]);
+    return Number(rows[0]?.total ?? 0);
   }
 
   // ---- connections ----

--- a/apps/server/src/db/types.ts
+++ b/apps/server/src/db/types.ts
@@ -17,6 +17,10 @@ export interface User {
   salt: string;
   hash: string;
   createdAt: string;
+  /** Last authenticated request, coarse (touched at most every few minutes).
+   *  The basis for "active users"; absent for accounts that never signed in
+   *  since the field was introduced. */
+  lastSeenAt?: string;
   provider?: string;
   /** Stable provider-scoped identity, `orcid:0000-0002-1825-0097`. Unique. */
   subject?: string;
@@ -89,6 +93,11 @@ export interface DataStore {
   findUserByEmail(emailLower: string): Promise<User | null>;
   findUserBySubject(subject: string): Promise<User | null>;
   updateUser(u: User): Promise<void>;
+  /** Every account, oldest first. Instance administration only. */
+  listUsers(): Promise<User[]>;
+  /** Record activity without a read-modify-write of the whole row, so a
+   *  heartbeat racing a password change can never resurrect the old hash. */
+  touchUser(id: string, lastSeenAt: string): Promise<void>;
 
   // sessions (revocable)
   createSession(sid: string, userId: string, exp: number): Promise<void>;
@@ -114,6 +123,8 @@ export interface DataStore {
   // compile-time usage metering: seconds consumed per (user, month YYYY-MM)
   getUsageSeconds(userId: string, month: string): Promise<number>;
   addUsageSeconds(userId: string, month: string, seconds: number): Promise<void>;
+  /** Instance-wide compile seconds for a month, across every user. */
+  totalUsageSeconds(month: string): Promise<number>;
 
   // per-user external connections (e.g. a GitHub access token). Secrets — kept
   // in the secrets store, never in the compiler-visible projects dir.

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -26,7 +26,8 @@ import * as comments from './comments.js';
 import * as auth from './auth.js';
 import * as oauth from './oauth.js';
 import * as email from './email.js';
-import { canAccess, isListed, isMember, isOwner, ownerName } from './authz.js';
+import { canAccess, isAdmin, isListed, isMember, isOwner, ownerName } from './authz.js';
+import { noteActivity, registerAdminRoutes } from './admin.js';
 import { loginLimiter, registerLimiter, aiLimiter, refLimiter, compileGate, compileLimiter, clientKey } from './ratelimit.js';
 import { safeJoin, isTextFile, importPath, isHiddenPath, overlongPath, pathConflict, seedError, newId, BRANCH_RE, invalidRootFile } from './util.js';
 
@@ -170,7 +171,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   }
 
   // ---------- auth (env-gated) ----------
-  app.get('/api/auth/me', async (req) => ({ authEnabled: auth.AUTH_ENABLED, passwordAuth: !auth.SSO_ONLY, user: reqUser(req), providers: oauthProviders() }));
+  app.get('/api/auth/me', async (req) => {
+    const user = reqUser(req);
+    return { authEnabled: auth.AUTH_ENABLED, passwordAuth: !auth.SSO_ONLY, user, providers: oauthProviders(), admin: !!user && isAdmin(user) };
+  });
 
   /** 403 when password sign-in is disabled (SSO-only mode). */
   const passwordDisabled = (reply: any) => reply.code(403).send({ error: 'Password sign-in is disabled — use single sign-on.' });
@@ -303,8 +307,11 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // Resolve the request's user once (awaiting the async datastore) and cache it,
   // so reqUser() is a synchronous read everywhere downstream.
   app.addHook('onRequest', async (req) => {
-    (req as any)._user = auth.AUTH_ENABLED ? await auth.userFromRequest(req.headers.cookie) : null;
+    const user = auth.AUTH_ENABLED ? await auth.userFromRequest(req.headers.cookie) : null;
+    (req as any)._user = user;
+    if (user) noteActivity(user.id);
   });
+  await registerAdminRoutes(app, reqUser);
 
   // Global guard: enforce project access when auth is on. Runs after routing,
   // so it uses the DECODED :id param — never a regex over the raw (still

--- a/apps/server/test/admin.test.mjs
+++ b/apps/server/test/admin.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Instance admin: the allow-list guard, the stats and users routes, and the
+ * activity heartbeat.
+ *  - signed-out → 401, signed-in non-admin → 403, admin → 200
+ *  - the email comparison is case-insensitive
+ *  - stats count accounts, active users by lastSeenAt, projects by owner
+ *  - the heartbeat is throttled and never blocks the request
+ *  - /api/auth/me reports `admin` so the client can show the page
+ *
+ * Env must be set before any src import — AUTH_ENABLED and the admin list
+ * are read at module load.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { check, eq } from './assert.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aldine-admin-'));
+process.env.AUTH_ENABLED = '1';
+process.env.ALDINE_ADMIN_EMAILS = ' Root@Example.org ,second@example.org';
+process.env.RL_REGISTER_BURST = '200';
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.META_DIR = path.join(tmp, 'meta');
+process.env.CACHE_DIR = path.join(tmp, 'cache');
+delete process.env.DATABASE_URL;
+delete process.env.REDIS_URL;
+
+const { default: Fastify } = await import('fastify');
+const { initDb, closeDb, db } = await import('../src/db/index.ts');
+const { registerRoutes } = await import('../src/routes.ts');
+const { resetActivityThrottle } = await import('../src/admin.ts');
+
+await initDb();
+const app = Fastify({ logger: false });
+await registerRoutes(app);
+await app.ready();
+
+const cookieOf = (res) => String(res.headers['set-cookie']).split(';')[0];
+async function signUp(email, name) {
+  const res = await app.inject({ method: 'POST', url: '/api/auth/register', payload: { email, password: 'password123', name } });
+  eq(res.statusCode, 200, `register ${email}`);
+  return { cookie: cookieOf(res), id: res.json().user.id };
+}
+const get = (url, cookie) => app.inject({ method: 'GET', url, headers: cookie ? { cookie } : {} });
+
+// ---- guard ----
+eq((await get('/api/admin/stats')).statusCode, 401, 'signed out → 401');
+const bob = await signUp('bob@example.org', 'Bob');
+const denied = await get('/api/admin/stats', bob.cookie);
+eq(denied.statusCode, 403, 'non-admin → 403');
+eq(denied.json().error, 'Administrator access required', 'non-admin error names the requirement');
+eq((await get('/api/admin/users', bob.cookie)).statusCode, 403, 'users route shares the guard');
+eq((await get('/api/auth/me', bob.cookie)).json().admin, false, 'me: admin false for Bob');
+
+const root = await signUp('root@example.org', 'Root'); // allow-list has "Root@Example.org"
+eq((await get('/api/auth/me', root.cookie)).json().admin, true, 'me: admin true, case-insensitive');
+
+// ---- stats ----
+await app.inject({ method: 'POST', url: '/api/projects', headers: { cookie: root.cookie }, payload: { name: 'Live' } });
+const trashed = (await app.inject({ method: 'POST', url: '/api/projects', headers: { cookie: root.cookie }, payload: { name: 'Gone' } })).json();
+eq((await app.inject({ method: 'DELETE', url: `/api/projects/${trashed.id}`, headers: { cookie: root.cookie } })).statusCode, 200, 'trash a project');
+
+const stats = (await get('/api/admin/stats', root.cookie)).json();
+eq(stats.users.total, 2, 'stats: two accounts');
+eq(stats.users.active7d, 2, 'stats: both made a request since signing up');
+eq(stats.users.active30d, 2, 'stats: active30d');
+eq(stats.users.onlineNow, 0, 'stats: no collab sockets');
+eq(stats.projects, { total: 1, trashed: 1 }, 'stats: live and trashed projects');
+eq(stats.admins, ['root@example.org', 'second@example.org'], 'stats: allow-list, normalised');
+check(/^\d{4}-\d{2}$/.test(stats.compile.month), 'stats: month key');
+eq(stats.compile.metering, false, 'stats: metering off by default');
+
+// ---- users ----
+const users = (await get('/api/admin/users', root.cookie)).json();
+eq(users.map((u) => u.email), ['bob@example.org', 'root@example.org'], 'users: oldest first');
+const rootRow = users.find((u) => u.id === root.id);
+eq(rootRow.admin, true, 'users: admin flag');
+eq(rootRow.projects, 1, 'users: owned projects exclude trash');
+check(typeof rootRow.lastSeenAt === 'string', 'users: lastSeenAt present');
+check(!('hash' in rootRow) && !('salt' in rootRow), 'users: no credential material');
+
+// ---- heartbeat ----
+// A user who never signed in again keeps the old timestamp within the window...
+const stale = '2026-01-01T00:00:00.000Z';
+await db().touchUser(bob.id, stale);
+await get('/api/projects', bob.cookie);
+eq((await db().getUser(bob.id)).lastSeenAt, stale, 'heartbeat: throttled within the window');
+// ...and is counted inactive; once the throttle lapses, the next request touches.
+eq((await get('/api/admin/stats', root.cookie)).json().users.active30d, 1, 'stats: stale user is inactive');
+resetActivityThrottle();
+await get('/api/projects', bob.cookie);
+await new Promise((r) => setTimeout(r, 20)); // the touch is fire-and-forget
+check((await db().getUser(bob.id)).lastSeenAt > stale, 'heartbeat: touches after the window');
+eq((await get('/api/admin/stats', root.cookie)).json().users.active30d, 2, 'stats: active again');
+
+await app.close();
+await closeDb();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('✓ admin: guard, stats, users, heartbeat');

--- a/apps/server/test/datastore.conformance.mjs
+++ b/apps/server/test/datastore.conformance.mjs
@@ -48,6 +48,18 @@ async function runSuite(store, label) {
   await store.updateUser({ ...user, name: 'Ada L.' });
   eq((await store.getUser(user.id)).name, 'Ada L.', `${label}: updateUser`);
 
+  // touchUser writes only lastSeenAt: a concurrent password change must survive.
+  check((await store.getUser(user.id)).lastSeenAt === undefined, `${label}: lastSeenAt absent by default`);
+  await store.updateUser({ ...user, name: 'Ada L.', hash: 'h2' });
+  await store.touchUser(user.id, '2026-09-10T10:00:00.000Z');
+  const touched = await store.getUser(user.id);
+  eq(touched.lastSeenAt, '2026-09-10T10:00:00.000Z', `${label}: touchUser sets lastSeenAt`);
+  eq(touched.hash, 'h2', `${label}: touchUser leaves the rest of the row alone`);
+  await store.touchUser(`missing-${t}`, '2026-09-10T10:00:00.000Z'); // no throw, no row
+  check((await store.getUser(`missing-${t}`)) === null, `${label}: touchUser of a missing user creates nothing`);
+  const listed = (await store.listUsers()).filter((u) => u.id === user.id);
+  eq(listed, [touched], `${label}: listUsers includes lastSeenAt`);
+
   // ---- accounts keyed by provider subject, with no email (ORCID) ----
   const orcidUser = { id: `u3-${t}`, email: null, name: 'Josiah', salt: 's', hash: '', createdAt: new Date().toISOString(), provider: 'orcid', subject: `orcid:${t}` };
   await store.createUser(orcidUser);
@@ -123,6 +135,9 @@ async function runSuite(store, label) {
   await store.addUsageSeconds(user.id, month, 7.5);
   eq(await store.getUsageSeconds(user.id, month), 20, `${label}: usage accumulates`);
   eq(await store.getUsageSeconds(user.id, '2026-09'), 0, `${label}: usage months isolated`);
+  const before = await store.totalUsageSeconds(month);
+  await store.addUsageSeconds(orcidUser.id, month, 5);
+  eq((await store.totalUsageSeconds(month)) - before, 5, `${label}: totalUsageSeconds sums across users`);
 
   // ---- connections ----
   check((await store.getConnection(user.id, 'github')) === null, `${label}: connection default null`);

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -23,6 +23,26 @@ export interface ProjectSummary {
   github?: { fullName: string; owner: string; repo: string; remoteBranch: string; cloneUrl: string } | null;
 }
 
+/** Server-wide counts for the admin page. Metadata only: no project content. */
+export interface AdminStats {
+  users: { total: number; active7d: number; active30d: number; onlineNow: number };
+  projects: { total: number; trashed: number };
+  collab: { documents: number; connections: number };
+  compile: { month: string; seconds: number; quotaSeconds: number; metering: boolean };
+  admins: string[];
+}
+export interface AdminUserRow {
+  id: string;
+  email: string | null;
+  name: string;
+  provider?: string;
+  createdAt: string;
+  lastSeenAt?: string;
+  admin: boolean;
+  projects: number;
+  compileSecondsThisMonth: number;
+}
+
 export interface GithubRepo { fullName: string; name: string; owner: string; private: boolean; defaultBranch: string; cloneUrl: string; updatedAt: string }
 export interface GithubStatus { connected: boolean; login?: string; oauth: boolean }
 
@@ -224,7 +244,9 @@ export const api = {
   deleteComment: (id: string, cid: string) =>
     req<{ ok: boolean }>(`/api/projects/${id}/comments/${cid}`, { method: 'DELETE' }),
 
-  me: () => req<{ authEnabled: boolean; passwordAuth: boolean; user: AuthUser | null; providers: OAuthProviderInfo[] }>('/api/auth/me'),
+  me: () => req<{ authEnabled: boolean; passwordAuth: boolean; user: AuthUser | null; providers: OAuthProviderInfo[]; admin: boolean }>('/api/auth/me'),
+  adminStats: () => req<AdminStats>('/api/admin/stats'),
+  adminUsers: () => req<AdminUserRow[]>('/api/admin/users'),
   changePassword: (currentPassword: string, newPassword: string) =>
     req<{ ok: boolean }>('/api/auth/password', { method: 'POST', body: JSON.stringify({ currentPassword, newPassword }) }),
   resetRequest: (email: string) =>

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -913,3 +913,21 @@
   border-radius: 3px;
   padding: 0 2px;
 }
+
+/* ---------- server admin ---------- */
+a.btn { text-decoration: none; }
+.admin__stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+.admin__stat { padding: 14px 16px; border: 1px solid var(--hairline); border-radius: 10px; background: var(--bg-panel); }
+.admin__stat-value { font-size: 26px; font-weight: 600; letter-spacing: -0.02em; }
+.admin__stat-label { color: var(--text-2); font-size: 13px; margin-top: 2px; }
+.admin__stat-hint { color: var(--text-3); font-size: 12px; margin-top: 2px; }
+.admin__table-wrap { overflow-x: auto; border: 1px solid var(--hairline); border-radius: 10px; }
+.admin__table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.admin__table th, .admin__table td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--hairline); white-space: nowrap; }
+.admin__table th { color: var(--text-2); font-weight: 600; font-size: 12px; }
+.admin__table tbody tr:last-child td { border-bottom: 0; }
+.admin__num { text-align: right !important; font-variant-numeric: tabular-nums; }
+.admin__badge { display: inline-block; margin-left: 6px; padding: 1px 6px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 11px; font-weight: 600; }
+.admin__muted { color: var(--text-3); }
+.admin__error { color: var(--error); }
+.admin__foot { color: var(--text-3); font-size: 12px; margin-top: 14px; }

--- a/apps/web/src/components/Auth.tsx
+++ b/apps/web/src/components/Auth.tsx
@@ -6,12 +6,15 @@ interface AuthState {
   loading: boolean;
   authEnabled: boolean;
   user: AuthUser | null;
+  /** Instance administrator (server allow-list); gates the /admin link only,
+   *  the server enforces the routes. */
+  admin: boolean;
   providers: OAuthProviderInfo[];
   setUser(u: AuthUser | null): void;
   refresh(): Promise<void>;
 }
 
-const Ctx = createContext<AuthState>({ loading: true, authEnabled: false, user: null, providers: [], setUser: () => {}, refresh: async () => {} });
+const Ctx = createContext<AuthState>({ loading: true, authEnabled: false, user: null, admin: false, providers: [], setUser: () => {}, refresh: async () => {} });
 
 export function useAuth() { return useContext(Ctx); }
 
@@ -19,6 +22,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [authEnabled, setAuthEnabled] = useState(false);
   const [user, setUser] = useState<AuthUser | null>(null);
+  const [admin, setAdmin] = useState(false);
   const [providers, setProviders] = useState<OAuthProviderInfo[]>([]);
   const [passwordAuth, setPasswordAuth] = useState(true);
 
@@ -27,11 +31,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const me = await api.me();
       setAuthEnabled(me.authEnabled);
       setUser(me.user);
+      setAdmin(!!me.admin);
       setProviders(me.providers || []);
       setPasswordAuth(me.passwordAuth !== false);
     } catch {
       setAuthEnabled(false);
       setUser(null);
+      setAdmin(false);
     }
     setLoading(false);
   };
@@ -45,7 +51,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const hasResetToken = typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('reset_token');
   if (authEnabled && (!user || hasResetToken)) return <LoginScreen providers={providers} passwordAuth={passwordAuth} onAuthed={(u) => setUser(u)} />;
 
-  return <Ctx.Provider value={{ loading, authEnabled, user, providers, setUser, refresh }}>{children}</Ctx.Provider>;
+  return <Ctx.Provider value={{ loading, authEnabled, user, admin, providers, setUser, refresh }}>{children}</Ctx.Provider>;
 }
 
 type Mode = 'login' | 'register' | 'forgot' | 'reset';

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Home from './pages/Home';
 import Editor from './pages/Editor';
+import Admin from './pages/Admin';
 import { BASE_PATH } from './basePath';
 
 function NotFound() {
@@ -27,6 +28,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/p/:id" element={<Editor />} />
+            <Route path="/admin" element={<Admin />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api, ApiError, AdminStats, AdminUserRow } from '../api';
+import { useAuth } from '../components/Auth';
+
+/**
+ * Instance administration: who is on this server and how busy it is.
+ * Everything shown is metadata the server already holds about accounts and
+ * projects — never a project's files. The server guards the routes; this
+ * page only decides what to render.
+ */
+
+function ago(iso: string | undefined, now: number): string {
+  if (!iso) return 'never';
+  const mins = Math.max(0, Math.round((now - Date.parse(iso)) / 60000));
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours} h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 60) return `${days} d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function minutes(seconds: number): string {
+  return seconds < 60 ? `${Math.round(seconds)} s` : `${Math.round(seconds / 60)} min`;
+}
+
+function Stat({ label, value, hint, testId }: { label: string; value: string | number; hint?: string; testId: string }) {
+  return (
+    <div className="admin__stat" data-testid={testId}>
+      <div className="admin__stat-value">{value}</div>
+      <div className="admin__stat-label">{label}</div>
+      {hint && <div className="admin__stat-hint">{hint}</div>}
+    </div>
+  );
+}
+
+export default function Admin() {
+  const { authEnabled, admin } = useAuth();
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [users, setUsers] = useState<AdminUserRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  const load = async () => {
+    try {
+      const [s, u] = await Promise.all([api.adminStats(), api.adminUsers()]);
+      setStats(s);
+      setUsers(u);
+      setNow(Date.now());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Could not load server statistics');
+    }
+  };
+
+  useEffect(() => {
+    if (authEnabled && !admin) return;
+    load();
+    // The online count changes with every socket; keep the numbers live while the page is open.
+    const t = setInterval(load, 30_000);
+    return () => clearInterval(t);
+  }, [authEnabled, admin]);
+
+  if (authEnabled && !admin) {
+    return (
+      <div className="notfound" data-testid="admin-denied">
+        <h1>Administrator access required</h1>
+        <p>Your account is not on this server’s admin list (ALDINE_ADMIN_EMAILS).</p>
+        <Link className="btn btn--primary" to="/">Back to your projects</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="home admin" data-testid="admin-page">
+      <div className="home__inner">
+        <div className="home__bar">
+          <div>
+            <h1 className="home__brand">aldine<em>.</em></h1>
+            <p className="home__tag">Server admin</p>
+          </div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button className="btn" onClick={load} data-testid="admin-refresh">Refresh</button>
+            <Link className="btn" to="/">Back to projects</Link>
+          </div>
+        </div>
+
+        {error && <p className="admin__error" data-testid="admin-error">{error}</p>}
+
+        {stats && (
+          <>
+            <h2 className="home__section">People</h2>
+            <div className="admin__stats">
+              <Stat label="Accounts" value={stats.users.total} testId="stat-users-total" />
+              <Stat label="Active, last 7 days" value={stats.users.active7d} testId="stat-users-active7d" />
+              <Stat label="Active, last 30 days" value={stats.users.active30d} testId="stat-users-active30d" />
+              <Stat label="Editing right now" value={stats.users.onlineNow} hint={`${stats.collab.connections} open sockets`} testId="stat-users-online" />
+            </div>
+
+            <h2 className="home__section">Work</h2>
+            <div className="admin__stats">
+              <Stat label="Projects" value={stats.projects.total} hint={stats.projects.trashed ? `${stats.projects.trashed} in trash` : undefined} testId="stat-projects" />
+              <Stat label="Open documents" value={stats.collab.documents} testId="stat-docs" />
+              <Stat
+                label={`Compile time, ${stats.compile.month}`}
+                value={minutes(stats.compile.seconds)}
+                hint={stats.compile.metering ? `${minutes(stats.compile.quotaSeconds)} quota per user` : 'no quota set'}
+                testId="stat-compile"
+              />
+            </div>
+
+            <h2 className="home__section">Accounts</h2>
+            <div className="admin__table-wrap">
+              <table className="admin__table" data-testid="admin-users">
+                <thead>
+                  <tr><th>Name</th><th>Email</th><th>Sign-in</th><th>Joined</th><th>Last seen</th><th className="admin__num">Projects</th><th className="admin__num">Compile, this month</th></tr>
+                </thead>
+                <tbody>
+                  {(users || []).map((u) => (
+                    <tr key={u.id} data-testid="admin-user-row">
+                      <td>{u.name}{u.admin && <span className="admin__badge" title="On the admin list">admin</span>}</td>
+                      <td>{u.email || <span className="admin__muted">no email</span>}</td>
+                      <td>{u.provider || 'password'}</td>
+                      <td title={u.createdAt}>{new Date(u.createdAt).toLocaleDateString()}</td>
+                      <td title={u.lastSeenAt}>{ago(u.lastSeenAt, now)}</td>
+                      <td className="admin__num">{u.projects}</td>
+                      <td className="admin__num">{minutes(u.compileSecondsThisMonth)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="admin__foot">
+              Admins: {stats.admins.length ? stats.admins.join(', ') : 'none configured (auth is off, so everyone can see this page)'}.
+              Activity is recorded to the nearest few minutes. Project files are never shown here.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { api, ApiError, ProjectSummary, TemplateCategory, TemplateInfo } from '../api';
 import { useToast } from '../components/Toast';
 import { useAuth } from '../components/Auth';
@@ -48,7 +48,7 @@ export default function Home() {
   const dismissOnboarding = () => { localStorage.setItem('aldine.onboarded', '1'); setShowOnboarding(false); };
   const navigate = useNavigate();
   const toast = useToast();
-  const { authEnabled, user, setUser } = useAuth();
+  const { authEnabled, user, admin, setUser } = useAuth();
 
   const load = () => {
     api.listTrash().then(setTrash).catch(() => setTrash([]));
@@ -186,6 +186,9 @@ export default function Home() {
             >
               {themeChoice === 'dark' ? '☀︎' : '☾'}
             </button>
+            {admin && authEnabled && (
+              <Link className="btn" to="/admin" data-testid="admin-link" title="Server-wide accounts and usage">Server admin</Link>
+            )}
             {authEnabled && user && (
               <span className="user-chip">
                 <button className="user-chip__name" data-testid="user-name" onClick={() => setShowAccount(true)} title="Account settings">{user.name}</button>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -235,6 +235,7 @@ Everything is env-gated; blank/unset means "off" or the listed default.
 | `ALDINE_BASE_PATH` | URL prefix to serve under (`/internal/aldine`) when Aldine shares a host with other apps. Defaults to the path of `ALDINE_PUBLIC_URL`, else the root. The proxy passes the prefix through unchanged; `/api/health` also answers at the root for healthchecks |
 | `ALDINE_APP_BIND` | Host interface for the app port (set `127.0.0.1` behind a proxy) |
 | `AUTH_ENABLED` | `1` = multi-user login, ownership, sharing. Unset = single-tenant, no login |
+| `ALDINE_ADMIN_EMAILS` | Comma-separated emails that may open `/admin` (accounts, active users, projects, compile time). Metadata only; needs `AUTH_ENABLED=1` to mean anything |
 | `ALDINE_SSO_ONLY` | `1` = disable password auth entirely (SSO only) |
 | `GOOGLE_OAUTH_CLIENT_ID/SECRET` | Google SSO |
 | `GITHUB_LOGIN_CLIENT_ID/SECRET` | GitHub SSO (login) |

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -31,6 +31,7 @@ locals {
     },
     var.auth_enabled ? { AUTH_ENABLED = "1" } : {},
     var.sso_only ? { ALDINE_SSO_ONLY = "1" } : {},
+    var.admin_emails != "" ? { ALDINE_ADMIN_EMAILS = var.admin_emails } : {},
     var.enable_ses ? { SES_FROM = local.ses_from, AWS_REGION = var.region } : {},
   )
 

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -61,6 +61,12 @@ variable "sso_only" {
   default     = true
 }
 
+variable "admin_emails" {
+  description = "Comma-separated account emails that may open /admin (ALDINE_ADMIN_EMAILS). Empty = nobody."
+  type        = string
+  default     = ""
+}
+
 variable "ai_model" {
   description = "ALDINE_AI_MODEL (optional; used when an AI key secret is set)."
   type        = string

--- a/e2e/auth-tests/admin.spec.ts
+++ b/e2e/auth-tests/admin.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../fixtures';
+
+/** Unique email per run so re-runs don't collide with the persisted user store. */
+const uniq = (tag: string) => `${tag}${Date.now()}${Math.floor(Math.random() * 1000)}@test.com`;
+
+/** The auth stack is started with ALDINE_ADMIN_EMAILS=admin@test.com (see
+ *  playwright.auth.config.ts); a re-run finds that account already registered. */
+const ADMIN_EMAIL = 'admin@test.com';
+
+/** Register (first run) or sign in (re-run against the persisted store); the
+ *  page shares the request context's cookie jar, so the UI is signed in after. */
+async function signIn(page: import('@playwright/test').Page, email: string, name: string) {
+  const reg = await page.request.post('/api/auth/register', { data: { email, password: 'password123', name } });
+  if (!reg.ok()) {
+    const login = await page.request.post('/api/auth/login', { data: { email, password: 'password123' } });
+    expect(login.ok()).toBeTruthy();
+  }
+  await page.goto('/');
+  await expect(page.getByTestId('new-project')).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('server admin', () => {
+  test('a regular account gets no link, no page, and 403 from the API', async ({ page }) => {
+    await signIn(page, uniq('plain'), 'Plain');
+    await expect(page.getByTestId('user-name')).toBeVisible();
+    await expect(page.getByTestId('admin-link')).toHaveCount(0);
+
+    const denied = await page.request.get('/api/admin/stats');
+    expect(denied.status()).toBe(403);
+
+    await page.goto('/admin');
+    await expect(page.getByTestId('admin-denied')).toBeVisible();
+    await expect(page.getByTestId('admin-page')).toHaveCount(0);
+  });
+
+  test('the allow-listed account sees counts and the accounts table', async ({ page, browser }) => {
+    // One more account guarantees the table has somebody besides the admin.
+    const other = await browser.newContext();
+    const otherEmail = uniq('other');
+    await other.request.post('/api/auth/register', { data: { email: otherEmail, password: 'password123', name: 'Other' } });
+    await other.request.post('/api/projects', { data: { name: 'Counted' } });
+    await other.close();
+
+    await signIn(page, ADMIN_EMAIL, 'Admin');
+    await page.getByTestId('admin-link').click();
+    await expect(page.getByTestId('admin-page')).toBeVisible();
+
+    const total = Number(await page.getByTestId('stat-users-total').locator('.admin__stat-value').textContent());
+    expect(total).toBeGreaterThanOrEqual(2);
+    const active = Number(await page.getByTestId('stat-users-active7d').locator('.admin__stat-value').textContent());
+    expect(active).toBeGreaterThanOrEqual(2);
+    expect(active).toBeLessThanOrEqual(total);
+
+    const rows = page.getByTestId('admin-user-row');
+    await expect(rows.filter({ hasText: otherEmail })).toHaveCount(1);
+    await expect(rows.filter({ hasText: otherEmail })).toContainText('1'); // owns one project
+    await expect(rows.filter({ hasText: ADMIN_EMAIL })).toContainText('admin');
+
+    const stats = await (await page.request.get('/api/admin/stats')).json();
+    expect(stats.admins).toEqual([ADMIN_EMAIL]);
+    expect(stats.users.total).toBe(total);
+  });
+});

--- a/e2e/playwright.auth.config.ts
+++ b/e2e/playwright.auth.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       timeout: 10_000,
     },
     {
-      command: `npm run build -w apps/web && PORT=${PORT} AUTH_ENABLED=1 ALDINE_RESET_ECHO=1 ALDINE_TEST_HOOKS=1 TRUST_PROXY=1 RL_REGISTER_BURST=200 DATA_DIR=$(pwd)/.data-auth META_DIR=$(pwd)/.secrets-auth ORCID_CLIENT_ID=test-orcid ORCID_CLIENT_SECRET=test-orcid-secret ORCID_API_BASE=http://localhost:${MOCK} ORCID_PUB_API_BASE=http://localhost:${MOCK} npx tsx apps/server/src/index.ts`,
+      command: `npm run build -w apps/web && PORT=${PORT} AUTH_ENABLED=1 ALDINE_ADMIN_EMAILS=admin@test.com ALDINE_RESET_ECHO=1 ALDINE_TEST_HOOKS=1 TRUST_PROXY=1 RL_REGISTER_BURST=200 DATA_DIR=$(pwd)/.data-auth META_DIR=$(pwd)/.secrets-auth ORCID_CLIENT_ID=test-orcid ORCID_CLIENT_SECRET=test-orcid-secret ORCID_API_BASE=http://localhost:${MOCK} ORCID_PUB_API_BASE=http://localhost:${MOCK} npx tsx apps/server/src/index.ts`,
       cwd: '..',
       port: PORT,
       reuseExistingServer: true,


### PR DESCRIPTION
## What

An instance admin concept, kept to one flag: accounts listed in `ALDINE_ADMIN_EMAILS` may open `/admin` and `GET /api/admin/{stats,users}`.

- **Stats**: accounts, active in the last 7 / 30 days, editing right now, projects (live / trashed), open documents, compile time this month.
- **Accounts table**: sign-in method, joined, last seen, owned projects, compile minutes. No credential material.
- **Metadata only**: an admin never sees a project's files and never bypasses `canAccess`. With auth off, the routes are open like everything else.
- **Heartbeat**: `lastSeenAt` per account, written via a dedicated `touchUser` at most every five minutes, so a heartbeat racing a password change cannot resurrect the old hash. Postgres adds `users.last_seen_at` on boot.

## Why

"How many users are active on this server?" had no answer. The flag also gives later features (disable user, invite-only signup, early trash purge) a place to hang.

## Tests

- `apps/server/test/admin.test.mjs`: 401 / 403 / 200, case-insensitive allow-list, counts, throttled heartbeat.
- Datastore conformance: `listUsers`, `touchUser`, `totalUsageSeconds` on JSON and Postgres.
- `e2e/auth-tests/admin.spec.ts`: no link and denied page for a regular account, counts and table for the admin.

https://claude.ai/code/session_01GTT2nLYnJEVJH3CtMYajGA