### PR TITLE
changelog: cut 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aldine are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-09-10
+
 ### Added
 - GitLab as a second remote provider, next to GitHub. Import a project from
   gitlab.com or a self-hosted instance (nested group paths included),

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.8.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.9.0}
     ports:
       - "8080:3000"
     volumes:
@@ -128,7 +128,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.8.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.9.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # The compiler runs untrusted LaTeX. Keep this block.
@@ -161,7 +161,7 @@ fixes the volume names, which is what lets you switch compose files later and
 what `deploy/backup.sh` looks for.
 
 - **You are pinned to a version.** The block above says
-  `${ALDINE_VERSION:-0.8.0}`, so a fresh copy installs the current release and
+  `${ALDINE_VERSION:-0.9.0}`, so a fresh copy installs the current release and
   nothing under a running install changes on its own. To upgrade, read the
   [CHANGELOG](CHANGELOG.md), back up (`deploy/backup.sh`), then:
 
@@ -201,7 +201,7 @@ what `deploy/backup.sh` looks for.
         image: aldine-compiler-local
         build:
           dockerfile_inline: |
-            FROM ghcr.io/trahloff/aldine-compiler:0.8.0
+            FROM ghcr.io/trahloff/aldine-compiler:0.9.0
             RUN tlmgr install pgfplots tikz-cd
     ```
     Bump the `FROM` tag when you bump `ALDINE_VERSION`. Compose builds the

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/server",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aldine/web",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aldine/web",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aldine/web",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ name: aldine
 
 services:
   app:
-    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.8.0}
+    image: ghcr.io/trahloff/aldine-app:${ALDINE_VERSION:-0.9.0}
     ports:
       - "8080:3000"
     volumes:
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   compiler:
-    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.8.0}${ALDINE_TEXLIVE:-}
+    image: ghcr.io/trahloff/aldine-compiler:${ALDINE_VERSION:-0.9.0}${ALDINE_TEXLIVE:-}
     volumes:
       - aldine-data:/data
     # Hardening: no external egress (internal network), drop all Linux caps, no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aldine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aldine",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/server",
@@ -18,7 +18,7 @@
     },
     "apps/server": {
       "name": "@aldine/server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -46,7 +46,7 @@
     },
     "apps/web": {
       "name": "@aldine/web",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aldine",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Slim, fast, open-source LaTeX collaboration platform",
   "workspaces": [
     "apps/server",


### PR DESCRIPTION
Release 0.9.0: GitLab as a remote provider (#52), templates from a git repository (#53), auto-provisioning into a GitLab group with server-side autopush (#56). Version pins bumped (check-release-pins: all 7 say 0.9.0).

https://claude.ai/code/session_01Suj3jpvWS3gTe5uhR6eB7u